### PR TITLE
header contains action AuthFail handler+snackbar+callApi is deleted

### DIFF
--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -2,10 +2,11 @@ import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 
 import { RegistrationComponent } from '../shared/modals/registration/registration.component';
-import { Select, Store } from '@ngxs/store';
+import { Actions, ofAction, Select, Store } from '@ngxs/store';
 import { UserRegistrationState } from '../shared/store/user-registration.state';
 import { Observable } from 'rxjs';
-import { CallApi, Logout, CheckAuth } from '../shared/store/user-registration.actions';
+import { Logout, CheckAuth, AuthFail } from '../shared/store/user-registration.actions';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 
 @Component({
@@ -23,7 +24,18 @@ export class HeaderComponent implements OnInit {
   isAuthorized$: Observable<boolean>;
 
   constructor(private modalDialog: MatDialog,
-    public store: Store) { }
+    public store: Store,
+    private actions$: Actions,
+    public snackBar: MatSnackBar) { 
+      actions$.pipe(
+        ofAction(AuthFail)
+      ).subscribe(action => {
+          this.snackBar.open('Check your connection', "Try again!", {
+          duration: 5000,
+          panelClass: ['red-snackbar'],
+          });
+      })
+    }
 
   ngOnInit(): void {
     this.store.dispatch(new CheckAuth())
@@ -34,9 +46,4 @@ export class HeaderComponent implements OnInit {
   logout(): void {
     this.store.dispatch(new Logout())  
   }
-  callApi(): void {
-  this.store.dispatch(new CallApi())  
-  }
-  
-
 }

--- a/src/app/shared/error-interceptors/http-error.interceptor.ts
+++ b/src/app/shared/error-interceptors/http-error.interceptor.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngxs/store';
 import { Observable, throwError } from 'rxjs';
 import { retry, catchError } from 'rxjs/operators';
-import { CheckAuthFail } from '../store/user-registration.actions';
+import { AuthFail } from '../store/user-registration.actions';
 
 @Injectable({
 
@@ -30,7 +30,7 @@ export class HttpErrorInterceptor implements HttpInterceptor {
             errorMessage = `Error Code: ${error.status}\nMessage: ${error.message}`;
           } 
         }
-        this.store.dispatch(new CheckAuthFail(errorMessage))
+        this.store.dispatch(new AuthFail())
         console.log(errorMessage);
         return throwError(errorMessage);
       })

--- a/src/app/shared/modals/registration/registration.module.ts
+++ b/src/app/shared/modals/registration/registration.module.ts
@@ -17,10 +17,7 @@ export function configureAuth(oidcConfigService: OidcConfigService): any {
         postLogoutRedirectUri: window.location.origin,
         scope: 'openid outofschoolapi.read',
         logLevel: LogLevel.Debug,})  
-    
-    
-  }
-    
+  }  
 }
 
 @NgModule({

--- a/src/app/shared/store/user-registration.actions.ts
+++ b/src/app/shared/store/user-registration.actions.ts
@@ -6,15 +6,11 @@ export class Logout {
   static readonly type = '[user] logouts';
   constructor() {}
 }
-export class CallApi {
-  static readonly type = '[user] calls API';
-  constructor() {}
-}
 export class CheckAuth {
   static readonly type = '[user] checks auth';
   constructor() {}
 }
-export class CheckAuthFail {
+export class AuthFail {
   static readonly type = '[user] has auth failed';
-  constructor(public payload: string) {}
+  constructor() {}
 }

--- a/src/app/shared/store/user-registration.state.ts
+++ b/src/app/shared/store/user-registration.state.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@angular/core';
 import { State, Action, StateContext, Selector } from '@ngxs/store';
-import { CallApi, Login, Logout, CheckAuth, CheckAuthFail } from './user-registration.actions';
+import { Login, Logout, CheckAuth, AuthFail } from './user-registration.actions';
 
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { OidcSecurityService } from 'angular-auth-oidc-client';
-import { MatSnackBar } from '@angular/material/snack-bar';
 
 export interface UserRegistrationStateModel {
   isAuthorized: boolean;
@@ -20,9 +19,7 @@ export interface UserRegistrationStateModel {
 export class UserRegistrationState {
   constructor(
     public oidcSecurityService: OidcSecurityService,
-    public http: HttpClient,
-    public snackBar: MatSnackBar
-    ) {}
+    public http: HttpClient) {}
 
   @Selector()
     static isAuthorized(state: UserRegistrationStateModel) {
@@ -30,36 +27,15 @@ export class UserRegistrationState {
   }
 
   @Action(Login)
-    Login({  dispatch }: StateContext<UserRegistrationStateModel>): void {
-      this.oidcSecurityService.authorize();
-      dispatch(new CheckAuth()); 
+  Login({  dispatch }: StateContext<UserRegistrationStateModel>): void {
+    this.oidcSecurityService.authorize();
+    dispatch(new CheckAuth()); 
   }
   @Action(Logout)
-    Logout({  dispatch  }: StateContext<UserRegistrationStateModel>): void {
-      let isAuth: boolean;
-      this.oidcSecurityService.checkAuth().subscribe(value => {
-        isAuth = value;
-      });
-      if (isAuth) {
-        this.oidcSecurityService.logoff();
-        dispatch(new CheckAuth());
-      }
+  Logout({  dispatch  }: StateContext<UserRegistrationStateModel>): void {
+    this.oidcSecurityService.logoff();
+    dispatch(new CheckAuth());
   }
-  @Action(CallApi)
-    CallApi(): void {
-      const token = this.oidcSecurityService.getToken();
-
-      this.http.get('http://localhost:5000/Organization/TestOk', {
-        headers: new HttpHeaders({
-          Authorization: 'Bearer ' + token,
-        }),
-        responseType: 'text'
-      })
-        .subscribe((data: any) => {
-          console.log('api result:', data);
-        });
-  }
-  
   @Action(CheckAuth)
   CheckAuth({ patchState }: StateContext<UserRegistrationStateModel>): void {
     this.oidcSecurityService
@@ -69,11 +45,8 @@ export class UserRegistrationState {
         patchState({ isAuthorized: auth});
       });
   }
-  @Action(CheckAuthFail)
-  CheckAuthFail({ payload }: CheckAuthFail): void {
-    this.snackBar.open('Check your connection', "Try again!", {
-      duration: 5000,
-      panelClass: ['red-snackbar'],
-      });
+  @Action(AuthFail)
+  AuthFail(): void {
+      console.log("Authorization failed");
+    }
   }
-}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  stsServer: 'http://localhost:5443'
 };


### PR DESCRIPTION
1) CallAPi action was deleted
2) AuthFail action was created
3) Header contains the "handler" of AuthFail.
4)When there is no connection, the header displays snackbar with an error.