### PR TITLE
Create guard triggers only if the create-form is dirty

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,7 +17,7 @@ import { FormsModule } from '@angular/forms';
 import { ShellComponent } from './shell/shell.component';
 import { MetaDataState } from './shared/store/meta-data.state';
 import { FooterComponent } from './footer/footer.component';
-import { RegistrationModule } from './shared/modals/registration/registration.module';
+import { RegistrationModule } from './shared/registration/registration.module';
 import { RegistrationState } from './shared/store/registration.state';
 import { SharedModule } from './shared/shared.module';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';

--- a/src/app/shared/registration/registration.module.ts
+++ b/src/app/shared/registration/registration.module.ts
@@ -5,7 +5,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AuthModule, LogLevel, OidcConfigService } from 'angular-auth-oidc-client';
 import { HttpClientModule } from '@angular/common/http';
 import { environment } from 'src/environments/environment';
-import { LocalSessionManagerService } from '../../services/local-session-manager/local-session-manager.service';
+import { LocalSessionManagerService } from '../services/local-session-manager/local-session-manager.service';
 
 export function configureAuth(oidcConfigService: OidcConfigService): any {
 

--- a/src/app/shared/store/app.actions.ts
+++ b/src/app/shared/store/app.actions.ts
@@ -19,10 +19,6 @@ export class GetTeachersById {
   static readonly type = '[app] Get Teachers by Id';
   constructor(public payload: number) { }
 }
-export class ToggleEditMode {
-  static readonly type = '[app] toggle edit mode';
-  constructor(public payload: boolean) { }
-}
 export class MarkFormDirty {
   static readonly type = '[app] mark the form dirty';
   constructor(public payload: boolean) { }

--- a/src/app/shared/store/app.actions.ts
+++ b/src/app/shared/store/app.actions.ts
@@ -19,3 +19,11 @@ export class GetTeachersById {
   static readonly type = '[app] Get Teachers by Id';
   constructor(public payload: number) { }
 }
+export class ToggleEditMode {
+  static readonly type = '[app] toggle edit mode';
+  constructor(public payload: boolean) { }
+}
+export class MarkFormDirty {
+  static readonly type = '[app] mark the form dirty';
+  constructor(public payload: boolean) { }
+}

--- a/src/app/shared/store/app.state.ts
+++ b/src/app/shared/store/app.state.ts
@@ -5,8 +5,7 @@ import { Teacher } from '../models/teacher.model';
 import { Workshop } from '../models/workshop.model';
 import { TeacherService } from '../services/teachers/teacher.service';
 import { AppWorkshopsService } from '../services/workshops/app-workshop/app-workshops.service';
-import { ChangePage, GetTeachersById, GetWorkshops, MarkFormDirty, SetLocation, ToggleEditMode, ToggleLoading } from './app.actions';
-import { FilterStateModel } from './filter.state';
+import { ChangePage, GetTeachersById, GetWorkshops, MarkFormDirty, SetLocation, ToggleLoading } from './app.actions';
 
 export interface AppStateModel {
   isLoading: boolean;
@@ -16,7 +15,6 @@ export interface AppStateModel {
   lat: Number | null;
   allWorkshops: Workshop[];
   teachers: Teacher[],
-  isEditMode: boolean,
   isDirtyForm: boolean
 }
 
@@ -30,7 +28,6 @@ export interface AppStateModel {
     lat: null,
     allWorkshops: [],
     teachers: [],
-    isEditMode: false,
     isDirtyForm: false
   }
 })
@@ -47,9 +44,6 @@ export class AppState {
 
   @Selector()
   static teachers(state: AppStateModel): Teacher[] { return state.teachers }
-
-  @Selector()
-  static isEditMode(state: AppStateModel): boolean { return state.isEditMode }
 
   @Selector()
   static isDirtyForm(state: AppStateModel): boolean { return state.isDirtyForm }
@@ -88,11 +82,6 @@ export class AppState {
       .pipe(
         tap((workshopTeachers: Teacher[]) => patchState({ teachers: workshopTeachers })
         ))
-  }
-
-  @Action(ToggleEditMode)
-  toggleEditMode({ patchState }: StateContext<AppStateModel>, { payload }: ToggleEditMode): void {
-    patchState({ isEditMode: payload });
   }
 
   @Action(MarkFormDirty)

--- a/src/app/shared/store/app.state.ts
+++ b/src/app/shared/store/app.state.ts
@@ -5,7 +5,7 @@ import { Teacher } from '../models/teacher.model';
 import { Workshop } from '../models/workshop.model';
 import { TeacherService } from '../services/teachers/teacher.service';
 import { AppWorkshopsService } from '../services/workshops/app-workshop/app-workshops.service';
-import { ChangePage, GetTeachersById, GetWorkshops, SetLocation, ToggleLoading } from './app.actions';
+import { ChangePage, GetTeachersById, GetWorkshops, MarkFormDirty, SetLocation, ToggleEditMode, ToggleLoading } from './app.actions';
 import { FilterStateModel } from './filter.state';
 
 export interface AppStateModel {
@@ -15,7 +15,9 @@ export interface AppStateModel {
   lng: Number | null;
   lat: Number | null;
   allWorkshops: Workshop[];
-  teachers: Teacher[]
+  teachers: Teacher[],
+  isEditMode: boolean,
+  isDirtyForm: boolean
 }
 
 @State<AppStateModel>({
@@ -28,6 +30,8 @@ export interface AppStateModel {
     lat: null,
     allWorkshops: [],
     teachers: [],
+    isEditMode: false,
+    isDirtyForm: false
   }
 })
 @Injectable()
@@ -43,6 +47,12 @@ export class AppState {
 
   @Selector()
   static teachers(state: AppStateModel): Teacher[] { return state.teachers }
+
+  @Selector()
+  static isEditMode(state: AppStateModel): boolean { return state.isEditMode }
+
+  @Selector()
+  static isDirtyForm(state: AppStateModel): boolean { return state.isDirtyForm }
 
   constructor(
     private appWorkshopsService: AppWorkshopsService,
@@ -78,5 +88,15 @@ export class AppState {
       .pipe(
         tap((workshopTeachers: Teacher[]) => patchState({ teachers: workshopTeachers })
         ))
+  }
+
+  @Action(ToggleEditMode)
+  toggleEditMode({ patchState }: StateContext<AppStateModel>, { payload }: ToggleEditMode): void {
+    patchState({ isEditMode: payload });
+  }
+
+  @Action(MarkFormDirty)
+  markFormDirty({ patchState }: StateContext<AppStateModel>, { payload }: MarkFormDirty): void {
+    patchState({ isDirtyForm: payload });
   }
 }

--- a/src/app/shared/store/user.state.ts
+++ b/src/app/shared/store/user.state.ts
@@ -12,7 +12,7 @@ import { ChildrenService } from '../services/children/children.service';
 import { ParentService } from '../services/parent/parent.service';
 import { ProviderService } from '../services/provider/provider.service';
 import { UserWorkshopService } from '../services/workshops/user-workshop/user-workshop.service';
-import { GetWorkshops } from './app.actions';
+import { GetWorkshops, MarkFormDirty } from './app.actions';
 import { ClearCategories } from './meta-data.actions';
 import { GetProfile, RegisterUser } from './registration.actions';
 import {
@@ -140,19 +140,16 @@ export class UserState {
   @Action(OnCreateWorkshopFail)
   onCreateWorkshopFail({ dispatch }: StateContext<UserStateModel>, { payload }: OnCreateWorkshopFail): void {
     console.log('Workshop creation is failed', payload);
-    setTimeout(() => {
-      throwError(payload);
-      this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
-    }, 1000);
+    throwError(payload);
+    this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
   }
 
   @Action(OnCreateWorkshopSuccess)
   onCreateWorkshopSuccess({ dispatch }: StateContext<UserStateModel>, { payload }: OnCreateWorkshopSuccess): void {
+    dispatch(new MarkFormDirty(false));
     console.log('Workshop is created', payload);
-    setTimeout(() => {
-      this.showSnackBar('Гурток створено!', 'primary', 'top');
-      this.router.navigate(['/personal-cabinet/workshops']);
-    }, 1000);
+    this.showSnackBar('Гурток створено!', 'primary');
+    this.router.navigate(['/personal-cabinet/workshops']);
     dispatch(new ClearCategories());
   }
 
@@ -169,18 +166,14 @@ export class UserState {
   @Action(OnDeleteWorkshopFail)
   onDeleteWorkshopFail({ dispatch }: StateContext<UserStateModel>, { payload }: OnDeleteWorkshopFail): void {
     console.log('Workshop is not deleted', payload);
-    setTimeout(() => {
-      throwError(payload);
-      this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
-    }, 1000);
+    throwError(payload);
+    this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
   }
 
   @Action(OnDeleteWorkshopSuccess)
   onDeleteWorkshopSuccess({ dispatch }: StateContext<UserStateModel>, { payload }: OnDeleteWorkshopSuccess): void {
     console.log('Workshop is deleted', payload);
-    setTimeout(() => {
-      this.showSnackBar('Гурток видалено!', 'primary', 'top');
-    }, 1000);
+    this.showSnackBar('Гурток видалено!', 'primary');
     dispatch(new GetWorkshops());
   }
 
@@ -197,19 +190,16 @@ export class UserState {
   @Action(OnCreateChildrenFail)
   onCreateChildrenFail({ dispatch }: StateContext<UserStateModel>, { payload }: OnCreateChildrenFail): void {
     console.log('Child creation is failed', payload);
-    setTimeout(() => {
-      throwError(payload);
-      this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
-    }, 1000);
+    throwError(payload);
+    this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
   }
 
   @Action(OnCreateChildrenSuccess)
   onCreateChildrenSuccess({ dispatch }: StateContext<UserStateModel>, { payload }: OnCreateChildrenSuccess): void {
+    dispatch(new MarkFormDirty(false));
     console.log('Child is created', payload);
-    setTimeout(() => {
-      this.showSnackBar('Дитина усіпшно зареєстрована', 'primary', 'top');
-      this.router.navigate(['/personal-cabinet/parent/info']);
-    }, 1000);
+    this.showSnackBar('Дитина успішно зареєстрована', 'primary');
+    this.router.navigate(['/personal-cabinet/parent/info']);
   }
 
   @Action(CreateProvider)
@@ -225,20 +215,17 @@ export class UserState {
   @Action(OnCreateProviderFail)
   onCreateProviderFail({ dispatch }: StateContext<UserStateModel>, { payload }: OnCreateProviderFail): void {
     console.log('Provider creation is failed', payload);
-    setTimeout(() => {
-      throwError(payload);
-      this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
-    }, 1000);
+    throwError(payload);
+    this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
   }
 
   @Action(OnCreateProviderSuccess)
   onCreateProviderSuccess({ dispatch }: StateContext<UserStateModel>, { payload }: OnCreateProviderSuccess): void {
+    dispatch(new MarkFormDirty(false));
     console.log('Provider is created', payload);
     dispatch(new GetProfile());
-    setTimeout(() => {
-      this.showSnackBar('Організацію успішно створено', 'primary');
-      this.router.navigate(['']);
-    }, 1000);
+    this.showSnackBar('Організацію успішно створено', 'primary');
+    this.router.navigate(['']);
   }
 
   @Action(CreateApplication)
@@ -254,19 +241,16 @@ export class UserState {
   @Action(OnCreateApplicationFail)
   onCreateApplicationFail({ dispatch }: StateContext<UserStateModel>, { payload }: OnCreateApplicationFail): void {
     console.log('Application creation is failed', payload);
-    setTimeout(() => {
-      throwError(payload);
-      this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
-    }, 1000);
+    throwError(payload);
+    this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
   }
 
   @Action(OnCreateApplicationSuccess)
   onCreateApplicationSuccess({ dispatch }: StateContext<UserStateModel>, { payload }: OnCreateApplicationSuccess): void {
+    dispatch(new MarkFormDirty(false));
     console.log('Application is created', payload);
-    setTimeout(() => {
-      this.showSnackBar('Заявку створено!', 'primary', 'top');
-      this.router.navigate(['']);
-    }, 1000);
+    this.showSnackBar('Заявку створено!', 'primary');
+    this.router.navigate(['']);
   }
 
   @Action(CreateParent)
@@ -282,10 +266,8 @@ export class UserState {
   @Action(OnCreateParentFail)
   onCreateParentFail({ dispatch }: StateContext<UserStateModel>, { payload }: OnCreateParentFail): void {
     console.log('Parent creation is failed', payload);
-    setTimeout(() => {
-      throwError(payload);
-      this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
-    }, 1000);
+    throwError(payload);
+    this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
   }
 
   @Action(OnCreateParentSuccess)
@@ -307,18 +289,14 @@ export class UserState {
   @Action(OnDeleteChildFail)
   onDeleteChildFail({ dispatch }: StateContext<UserStateModel>, { payload }: OnDeleteChildFail): void {
     console.log('Child is not deleted', payload);
-    setTimeout(() => {
-      throwError(payload);
-      this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
-    }, 1000);
+    throwError(payload);
+    this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
   }
 
   @Action(OnDeleteChildSuccess)
   onDeleteChildSuccess({ dispatch }: StateContext<UserStateModel>, { payload }: OnDeleteChildSuccess): void {
     console.log('Child is deleted', payload);
-    setTimeout(() => {
-      this.showSnackBar('Дитину видалено!', 'primary', 'top');
-    }, 1000);
+    this.showSnackBar('Дитину видалено!', 'primary');
     dispatch(new GetChildren());
   }
 
@@ -335,31 +313,21 @@ export class UserState {
   @Action(OnUpdateChildFail)
   onUpdateChildfail({ dispatch }: StateContext<UserStateModel>, { payload }: OnUpdateChildFail): void {
     console.log('Child updating is failed', payload);
-    setTimeout(() => {
-      throwError(payload);
-      this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
-    }, 1000);
+    throwError(payload);
+    this.showSnackBar('На жаль виникла помилка', 'red-snackbar');
   }
 
   @Action(OnUpdateChildSuccess)
   onUpdateChildSuccess({ dispatch }: StateContext<UserStateModel>, { payload }: OnUpdateChildSuccess): void {
+    dispatch(new MarkFormDirty(false));
     console.log('Child is updated', payload);
-    setTimeout(() => {
-      this.showSnackBar('Дитина успішно відредагована', 'primary', 'top');
-      this.router.navigate(['/personal-cabinet/parent/info']);
-    }, 1000);
+    this.showSnackBar('Дитина успішно відредагована', 'primary');
+    this.router.navigate(['/personal-cabinet/parent/info']);
   }
 
-  showSnackBar(
-    message: string,
-    color: string,
-    vertical: MatSnackBarVerticalPosition = 'bottom',
-    horizontal: MatSnackBarHorizontalPosition = 'center'): void {
-
+  showSnackBar(message: string, color: string): void {
     this.snackBar.open(message, '', {
       duration: 2000,
-      horizontalPosition: horizontal,
-      verticalPosition: vertical,
       panelClass: [color],
     });
   }

--- a/src/app/shell/personal-cabinet/create.guard.spec.ts
+++ b/src/app/shell/personal-cabinet/create.guard.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
+import { NgxsModule } from '@ngxs/store';
 
 import { CreateGuard } from './create.guard';
 
@@ -8,7 +9,10 @@ describe('CreateGuard', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [MatDialogModule]
+      imports: [
+        NgxsModule.forRoot([]),
+        MatDialogModule
+      ]
     });
     guard = TestBed.inject(CreateGuard);
   });

--- a/src/app/shell/personal-cabinet/create.guard.ts
+++ b/src/app/shell/personal-cabinet/create.guard.ts
@@ -1,8 +1,11 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { CanDeactivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Select, Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { ConfirmationModalWindowComponent } from 'src/app/shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { AppState } from 'src/app/shared/store/app.state';
 
 @Injectable({
   providedIn: 'root'
@@ -10,7 +13,7 @@ import { ConfirmationModalWindowComponent } from 'src/app/shared/components/conf
 export class CreateGuard implements CanDeactivate<unknown> {
 
   result: boolean
-  constructor(private matDialog: MatDialog) { }
+  constructor(private matDialog: MatDialog, private store: Store) { }
 
   canDeactivate(
     component: unknown,
@@ -18,11 +21,17 @@ export class CreateGuard implements CanDeactivate<unknown> {
     currentState: RouterStateSnapshot,
     nextState?: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
 
-    const dialogRef = this.matDialog.open(ConfirmationModalWindowComponent, {
-      width: '330px',
-      data: 'Залишити сторінку?'
-    });
+    const isDirty = this.store.selectSnapshot<boolean>(AppState.isDirtyForm);
 
-    return dialogRef.afterClosed().pipe(result => result);
+    if (isDirty) {
+      const dialogRef = this.matDialog.open(ConfirmationModalWindowComponent, {
+        width: '330px',
+        data: 'Залишити сторінку?'
+      });
+
+      return dialogRef.afterClosed().pipe(result => result);
+    } else {
+      return true;
+    }
   }
 }

--- a/src/app/shell/personal-cabinet/parent/create-child/create-child.component.ts
+++ b/src/app/shell/personal-cabinet/parent/create-child/create-child.component.ts
@@ -7,7 +7,7 @@ import { Child } from 'src/app/shared/models/child.model';
 import { Parent } from 'src/app/shared/models/parent.model';
 import { SocialGroup } from 'src/app/shared/models/socialGroup.model';
 import { ChildrenService } from 'src/app/shared/services/children/children.service';
-import { ChangePage } from 'src/app/shared/store/app.actions';
+import { ChangePage, MarkFormDirty } from 'src/app/shared/store/app.actions';
 import { GetSocialGroup } from 'src/app/shared/store/meta-data.actions';
 import { MetaDataState } from 'src/app/shared/store/meta-data.state';
 import { RegistrationState } from 'src/app/shared/store/registration.state';
@@ -55,7 +55,7 @@ export class CreateChildComponent implements OnInit {
       this.ChildrenFormArray.push(this.newForm());
     }
 
-
+    this.ChildrenFormArray.valueChanges.subscribe(() => this.store.dispatch(new MarkFormDirty(true)));
   }
 
   /**

--- a/src/app/shell/personal-cabinet/parent/create-child/create-child.component.ts
+++ b/src/app/shell/personal-cabinet/parent/create-child/create-child.component.ts
@@ -2,12 +2,14 @@ import { Component, OnInit } from '@angular/core';
 import { FormArray, FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { Select, Store } from '@ngxs/store';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { map, takeUntil, takeWhile } from 'rxjs/operators';
 import { Child } from 'src/app/shared/models/child.model';
 import { Parent } from 'src/app/shared/models/parent.model';
 import { SocialGroup } from 'src/app/shared/models/socialGroup.model';
 import { ChildrenService } from 'src/app/shared/services/children/children.service';
 import { ChangePage, MarkFormDirty } from 'src/app/shared/store/app.actions';
+import { AppState } from 'src/app/shared/store/app.state';
 import { GetSocialGroup } from 'src/app/shared/store/meta-data.actions';
 import { MetaDataState } from 'src/app/shared/store/meta-data.state';
 import { RegistrationState } from 'src/app/shared/store/registration.state';
@@ -26,9 +28,12 @@ export class CreateChildComponent implements OnInit {
 
   @Select(MetaDataState.socialGroups)
   socialGroups$: Observable<SocialGroup[]>;
-
   @Select(RegistrationState.parent)
   parent$: Observable<Parent>;
+
+  @Select(AppState.isDirtyForm)
+  isDirtyForm$: Observable<Boolean>;
+  isPristine = true;
 
   constructor(
     private store: Store,
@@ -55,7 +60,13 @@ export class CreateChildComponent implements OnInit {
       this.ChildrenFormArray.push(this.newForm());
     }
 
-    this.ChildrenFormArray.valueChanges.subscribe(() => this.store.dispatch(new MarkFormDirty(true)));
+    this.ChildrenFormArray.valueChanges
+      .pipe(
+        takeWhile(() => this.isPristine))
+      .subscribe(() => {
+        this.isPristine = false;
+        this.store.dispatch(new MarkFormDirty(true))
+      });
   }
 
   /**

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
@@ -19,8 +19,7 @@ export class CreateWorkshopComponent implements OnInit {
 
   constructor(private store: Store) { }
 
-  ngOnInit() {
-  }
+  ngOnInit() { }
 
   /**
    * This method dispatch store action to create a Workshop with Form Groups values

--- a/src/app/shell/shell-routing.module.ts
+++ b/src/app/shell/shell-routing.module.ts
@@ -35,7 +35,6 @@ const routes: Routes = [
     path: 'create-workshop', component: CreateWorkshopComponent,
     loadChildren: () => import('./personal-cabinet/provider/provider.module').then(m => m.ProviderModule),
     canLoad: [ProviderGuard],
-    canDeactivate: [CreateGuard]
   },
   {
     path: 'create-provider', component: CreateProviderComponent,

--- a/src/app/shell/shell-routing.module.ts
+++ b/src/app/shell/shell-routing.module.ts
@@ -13,6 +13,7 @@ import { CreateChildComponent } from './personal-cabinet/parent/create-child/cre
 import { CreateApplicationComponent } from './personal-cabinet/parent/create-application/create-application.component';
 import { CreateProviderGuard } from './personal-cabinet/provider/create-provider/create-provider.guard';
 import { UserConfigEditComponent } from './personal-cabinet/user-config/user-config-edit/user-config-edit.component';
+import { CreateGuard } from './personal-cabinet/create.guard';
 
 const routes: Routes = [
   { path: '', component: MainComponent },
@@ -34,6 +35,7 @@ const routes: Routes = [
     path: 'create-workshop', component: CreateWorkshopComponent,
     loadChildren: () => import('./personal-cabinet/provider/provider.module').then(m => m.ProviderModule),
     canLoad: [ProviderGuard],
+    canDeactivate: [CreateGuard]
   },
   {
     path: 'create-provider', component: CreateProviderComponent,
@@ -45,11 +47,13 @@ const routes: Routes = [
     path: 'create-child/:id', component: CreateChildComponent,
     loadChildren: () => import('./personal-cabinet/parent/parent.module').then(m => m.ParentModule),
     canLoad: [ParentGuard],
+    canDeactivate: [CreateGuard]
   },
   {
     path: 'create-application/:id', component: CreateApplicationComponent,
     loadChildren: () => import('./personal-cabinet/parent/parent.module').then(m => m.ParentModule),
-    canLoad: [ParentGuard]
+    canLoad: [ParentGuard],
+    canDeactivate: [CreateGuard]
   },
 ];
 


### PR DESCRIPTION
Create guard is modified so it tracks is the create-child forms dirty. 
If so, it opens a modal window, otherwise, you can just leave the page. If you click "submit" the modal window does not appear. 

Also, I took off the setTimeout because the time of response is enough before the redirection. 