### PR TITLE
Create all categories page + search bar refactoring

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -40,19 +40,19 @@
   <div class="authorization">
     <span class="header_menu-button">
 
-      <button mat-icon-button [matMenuTriggerFor]="menu" class="pointer"> 
-        <mat-icon>notifications_none</mat-icon> 
+      <button mat-icon-button [matMenuTriggerFor]="menu" class="pointer">
+        <mat-icon>notifications_none</mat-icon>
       </button>
       <span class="header_menu-button_account-circle">
-        <mat-icon matBadge="1" matBadgePosition="before" ></mat-icon>
+        <mat-icon matBadge="1" matBadgePosition="before"></mat-icon>
       </span>
-     
-    <mat-menu #menu="matMenu" class="notification">
-      <span>1 нова заявка очікує підтвердження <mat-icon class="circle-notification">brightness_1</mat-icon></span>
-      <button mat-menu-item [routerLink]="'url'" class="btn-notification">
-        <span>Переглянути </span>
-      </button>
-    </mat-menu>
+
+      <mat-menu #menu="matMenu" class="notification">
+        <span>1 нова заявка очікує підтвердження <mat-icon class="circle-notification">brightness_1</mat-icon></span>
+        <button mat-menu-item [routerLink]="'url'" class="btn-notification">
+          <span>Переглянути </span>
+        </button>
+      </mat-menu>
 
       <button mat-icon-button class="header_menu-button_account-circle">
         <mat-icon>account_circle</mat-icon>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -22,11 +22,7 @@
     <h2 class="header_descr">
       Понад 500 найрізноманітніших гуртків
     </h2>
-    <div class="header_search">
-      <mat-icon> place</mat-icon>
-      <app-city-filter class="header_city"></app-city-filter>
-      <app-searchbar class="header_bar"></app-searchbar>
-    </div>
+    <app-full-search-bar></app-full-search-bar>
   </div>
 </ng-template>
 

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -89,29 +89,6 @@
     margin-top: 1rem;
   }
 
-  &_search {
-    background: white;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-top: 30px;
-    margin-bottom: 1rem;
-    width: 55%;
-    height: 52px;
-    gap: 15px;
-    border-radius: 60px;
-    padding: 0 20px;
-  }
-
-  &_bar {
-    flex-grow: 1;
-  }
-
-  &_city {
-    border-right: 1px solid #E3E3E3;
-    width: 143px;
-  }
-
   &_username {
     font-size: medium;
     font-weight: bold;

--- a/src/app/header/header.component.spec.ts
+++ b/src/app/header/header.component.spec.ts
@@ -30,7 +30,6 @@ describe('HeaderComponent', () => {
       ],
       declarations: [
         HeaderComponent,
-        MockCityFilterComponent,
         MockSearchBarComponent
       ],
       providers: [
@@ -52,13 +51,7 @@ describe('HeaderComponent', () => {
 });
 
 @Component({
-  selector: 'app-city-filter',
-  template: ''
-})
-class MockCityFilterComponent {
-}
-@Component({
-  selector: 'app-searchbar',
+  selector: 'app-full-search-bar',
   template: ''
 })
 class MockSearchBarComponent {

--- a/src/app/shared/components/city-autocomplete/city-autocomplete.component.html
+++ b/src/app/shared/components/city-autocomplete/city-autocomplete.component.html
@@ -1,13 +1,9 @@
-<form class="search-city">
+<form class="city-search">
   <mat-form-field appearance="none">
-    <input matInput type="text"
-      matInput
-      [formControl]="cityControl"
-      [matAutocomplete]="auto"
-      >
+    <input matInput type="text" matInput [formControl]="cityControl" [matAutocomplete]="auto">
     <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete" (optionSelected)="onSelect($event)">
-      <mat-option [disabled]= "noCity" *ngFor="let city of filteredCities$ | async" [value]="city.city">
-          {{city.city}}
+      <mat-option [disabled]="noCity" *ngFor="let city of filteredCities$ | async" [value]="city.city">
+        {{city.city}}
       </mat-option>
     </mat-autocomplete>
   </mat-form-field>

--- a/src/app/shared/components/city-autocomplete/city-autocomplete.component.scss
+++ b/src/app/shared/components/city-autocomplete/city-autocomplete.component.scss
@@ -14,4 +14,5 @@ input {
   color: #161414;
   opacity: 0.4;
   max-width: 100px;
+  min-width: 80px;
 }

--- a/src/app/shared/components/city-autocomplete/city-autocomplete.component.scss
+++ b/src/app/shared/components/city-autocomplete/city-autocomplete.component.scss
@@ -1,13 +1,17 @@
 :host ::ng-deep .mat-form-field-wrapper{
-    padding: 0;
-   }
-  :host ::ng-deep .mat-form-field-infix{
-    border: none;
-   }
-  .search-city{
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    height: 100%;
-  }
-  
+  padding: 0;
+}
+:host ::ng-deep .mat-form-field-infix{
+  border: none;
+}
+.city-search{
+  min-width: min-content;
+}
+input {
+  font-weight: normal;
+  font-size: 16px;
+  line-height: 22px;
+  color: #161414;
+  opacity: 0.4;
+  max-width: 100px;
+}

--- a/src/app/shared/components/filters-list/category-check-box/category-check-box.component.ts
+++ b/src/app/shared/components/filters-list/category-check-box/category-check-box.component.ts
@@ -15,7 +15,6 @@ import { MetaDataState } from 'src/app/shared/store/meta-data.state';
   styleUrls: ['./category-check-box.component.scss']
 })
 export class CategoryCheckBoxComponent implements OnInit {
-
   @Select(MetaDataState.directions)
   directions$: Observable<Direction[]>;
   destroy$: Subject<boolean> = new Subject<boolean>();

--- a/src/app/shared/components/filters-list/category-check-box/category-check-box.component.ts
+++ b/src/app/shared/components/filters-list/category-check-box/category-check-box.component.ts
@@ -15,6 +15,7 @@ import { MetaDataState } from 'src/app/shared/store/meta-data.state';
   styleUrls: ['./category-check-box.component.scss']
 })
 export class CategoryCheckBoxComponent implements OnInit {
+
   @Select(MetaDataState.directions)
   directions$: Observable<Direction[]>;
   destroy$: Subject<boolean> = new Subject<boolean>();

--- a/src/app/shared/components/filters-list/searchbar/searchbar.component.html
+++ b/src/app/shared/components/filters-list/searchbar/searchbar.component.html
@@ -1,8 +1,4 @@
-<div fxLayout="row" fxLayoutAlign="space-between center">
-  <mat-form-field floatLabel=never appearance="none">
-    <input type="text" maxlength="200" [formControl]="searchValue" class="search" matInput
-      placeholder="Введіть назву гуртка, школи">
-    <mat-error *ngIf="searchValue && searchValue.errors">Пошук не може містити спеціальні символи.</mat-error>
-  </mat-form-field>
-  <mat-icon class="search-icon" style="transform: rotate(90deg)">search</mat-icon>
-</div>
+<mat-form-field floatLabel=never appearance="none">
+  <input type="text" maxlength="200" [formControl]="searchValue" matInput placeholder="Введіть назву гуртка, школи">
+  <mat-error *ngIf="searchValue && searchValue.errors">Пошук не може містити спеціальні символи.</mat-error>
+</mat-form-field>

--- a/src/app/shared/components/filters-list/searchbar/searchbar.component.html
+++ b/src/app/shared/components/filters-list/searchbar/searchbar.component.html
@@ -1,9 +1,8 @@
-<div class="search-field">
+<div fxLayout="row" fxLayoutAlign="space-between center">
   <mat-form-field floatLabel=never appearance="none">
-    <input type="text"  maxlength="200" [formControl]="searchValue" class="search" matInput placeholder="Введіть назву гуртка, школи"> 
-    <mat-error  *ngIf="searchValue && searchValue.errors">Пошук не може містити спеціальні символи.</mat-error>
-  </mat-form-field> 
-  <button mat-stroked-button>
-    <mat-icon class="search-icon" style="transform: rotate(90deg)">search</mat-icon>
-  </button>
+    <input type="text" maxlength="200" [formControl]="searchValue" class="search" matInput
+      placeholder="Введіть назву гуртка, школи">
+    <mat-error *ngIf="searchValue && searchValue.errors">Пошук не може містити спеціальні символи.</mat-error>
+  </mat-form-field>
+  <mat-icon class="search-icon" style="transform: rotate(90deg)">search</mat-icon>
 </div>

--- a/src/app/shared/components/filters-list/searchbar/searchbar.component.scss
+++ b/src/app/shared/components/filters-list/searchbar/searchbar.component.scss
@@ -1,12 +1,6 @@
-.search-field {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  height: 100%;
-}
 .mat-form-field {
-  width: 100%;
   font-size: 14px;
+  width: max-content;
   input {
     font-weight: normal;
     font-size: 16px;
@@ -21,15 +15,13 @@
 :host ::ng-deep .mat-form-field-infix {
   border: none;
 }
-:host ::ng-deep .mat-stroked-button {
-  min-width: inherit;
-  padding: 0;
-}
 button {
   border: none;
   height: 100%;
 }
-
+.search-icon{
+  margin: 1rem;
+}
 @media(max-width: 415px) {
   .search {
     font-size: inherit !important;

--- a/src/app/shared/components/filters-list/searchbar/searchbar.component.scss
+++ b/src/app/shared/components/filters-list/searchbar/searchbar.component.scss
@@ -1,13 +1,5 @@
 .mat-form-field {
   font-size: 14px;
-  width: max-content;
-  input {
-    font-weight: normal;
-    font-size: 16px;
-    line-height: 22px;
-    color: #AAAAAA;
-    opacity: 0.4;
-  }
 }
 :host ::ng-deep .mat-form-field-wrapper {
   padding: 0;
@@ -19,11 +11,11 @@ button {
   border: none;
   height: 100%;
 }
-.search-icon{
-  margin: 1rem;
-}
-@media(max-width: 415px) {
-  .search {
-    font-size: inherit !important;
-  }
+input {
+  font-weight: normal;
+  font-size: 16px;
+  line-height: 22px;
+  color: #161414;
+  opacity: 0.4;
+  min-width: 230px;
 }

--- a/src/app/shared/components/full-search-bar/full-search-bar.component.html
+++ b/src/app/shared/components/full-search-bar/full-search-bar.component.html
@@ -1,0 +1,6 @@
+<div class="search" fxLayout='row' fxLayoutAlign='space-between center'>
+  <mat-icon class="icon"> place</mat-icon>
+  <app-city-filter class="city"></app-city-filter>
+  <app-searchbar></app-searchbar>
+  <mat-icon class="icon" style="transform: rotate(90deg)">search</mat-icon>
+</div>

--- a/src/app/shared/components/full-search-bar/full-search-bar.component.scss
+++ b/src/app/shared/components/full-search-bar/full-search-bar.component.scss
@@ -1,0 +1,14 @@
+
+.search {
+  background: white;
+  margin: 1rem;
+  width: 100%;
+  height: 52px;
+  border-radius: 60px;
+}
+.city {
+  border-right: 1px solid #E3E3E3;
+}
+.icon{
+  margin: 0 1rem ;
+}

--- a/src/app/shared/components/full-search-bar/full-search-bar.component.scss
+++ b/src/app/shared/components/full-search-bar/full-search-bar.component.scss
@@ -1,7 +1,7 @@
 
 .search {
   background: white;
-  margin: 1rem;
+  margin: 1rem 0;
   width: 100%;
   height: 52px;
   border-radius: 60px;

--- a/src/app/shared/components/full-search-bar/full-search-bar.component.spec.ts
+++ b/src/app/shared/components/full-search-bar/full-search-bar.component.spec.ts
@@ -1,3 +1,4 @@
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 
@@ -10,7 +11,10 @@ describe('FullSearchBarComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MatIconModule],
-      declarations: [FullSearchBarComponent]
+      declarations: [
+        FullSearchBarComponent,
+        MockCityFilterComponent,
+        MockSearchBarComponent]
     })
       .compileComponents();
   });
@@ -25,3 +29,15 @@ describe('FullSearchBarComponent', () => {
     expect(component).toBeTruthy();
   });
 });
+@Component({
+  selector: 'app-searchbar',
+  template: ''
+})
+class MockSearchBarComponent {
+}
+@Component({
+  selector: 'app-city-filter',
+  template: ''
+})
+class MockCityFilterComponent {
+}

--- a/src/app/shared/components/full-search-bar/full-search-bar.component.spec.ts
+++ b/src/app/shared/components/full-search-bar/full-search-bar.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FullSearchBarComponent } from './full-search-bar.component';
+
+describe('FullSearchBarComponent', () => {
+  let component: FullSearchBarComponent;
+  let fixture: ComponentFixture<FullSearchBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ FullSearchBarComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FullSearchBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/full-search-bar/full-search-bar.component.spec.ts
+++ b/src/app/shared/components/full-search-bar/full-search-bar.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconModule } from '@angular/material/icon';
 
 import { FullSearchBarComponent } from './full-search-bar.component';
 
@@ -8,9 +9,10 @@ describe('FullSearchBarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ FullSearchBarComponent ]
+      imports: [MatIconModule],
+      declarations: [FullSearchBarComponent]
     })
-    .compileComponents();
+      .compileComponents();
   });
 
   beforeEach(() => {

--- a/src/app/shared/components/full-search-bar/full-search-bar.component.ts
+++ b/src/app/shared/components/full-search-bar/full-search-bar.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-full-search-bar',
+  templateUrl: './full-search-bar.component.html',
+  styleUrls: ['./full-search-bar.component.scss']
+})
+export class FullSearchBarComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/shared/components/navigation-bar/navigation-bar.component.ts
+++ b/src/app/shared/components/navigation-bar/navigation-bar.component.ts
@@ -1,7 +1,7 @@
 import { NavigationState } from './../../store/navigation.state';
 import { Navigation } from './../../models/navigation.model';
 import { Observable } from 'rxjs';
-import { Component} from '@angular/core';
+import { Component } from '@angular/core';
 import { Select, Store } from '@ngxs/store';
 
 
@@ -15,7 +15,5 @@ export class NavigationBarComponent {
   @Select(NavigationState.navigationPaths)
   navigationPaths$: Observable<Navigation[]>
 
-  constructor(private store: Store) { }
+  constructor() { }
 }
-
-

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -34,6 +34,7 @@ import { ConfirmationModalWindowComponent } from './components/confirmation-moda
 import { NavigationBarComponent } from './components/navigation-bar/navigation-bar.component';
 import { WorkshopCheckboxDropdownComponent } from './components/workshop-checkbox-dropdown/workshop-checkbox-dropdown.component';
 import { WorkshopFilterPipe } from './pipes/workshop-filter.pipe';
+import { FullSearchBarComponent } from './components/full-search-bar/full-search-bar.component';
 
 @NgModule({
   declarations: [
@@ -65,6 +66,7 @@ import { WorkshopFilterPipe } from './pipes/workshop-filter.pipe';
     NavigationBarComponent,
     WorkshopCheckboxDropdownComponent,
     WorkshopFilterPipe,
+    FullSearchBarComponent,
   ],
   imports: [
     MaterialModule,
@@ -104,6 +106,7 @@ import { WorkshopFilterPipe } from './pipes/workshop-filter.pipe';
     NavigationBarComponent,
     WorkshopCheckboxDropdownComponent,
     WorkshopFilterPipe,
+    FullSearchBarComponent
   ]
 })
 export class SharedModule { }

--- a/src/app/shell/all-categories/all-categories.component.html
+++ b/src/app/shell/all-categories/all-categories.component.html
@@ -1,12 +1,6 @@
 <div class="header-wrapper" fxLayout="row wrap" fxLayoutAlign="start center">
   <h3 class="title">Усі напрямки</h3>
-  <div fxLayout="row" fxLayoutAlign="start center">
-    <div class="header_search">
-      <mat-icon> place</mat-icon>
-      <app-city-filter class="header_city"></app-city-filter>
-      <app-searchbar class="header_bar"></app-searchbar>
-    </div>
-  </div>
+  <app-full-search-bar></app-full-search-bar>
 </div>
 <div class="categories-wrapper" fxLayout="row" fxLayoutAlign="space-evenly" fxLayoutGap="grid">
   <app-category-card *ngFor="let direction of directions$ | async " [direction]="direction">

--- a/src/app/shell/all-categories/all-categories.component.html
+++ b/src/app/shell/all-categories/all-categories.component.html
@@ -1,0 +1,13 @@
+<div fxLayout="row" fxLayoutAlign="center center">
+  <h3 class="title">Усі напрямки</h3>
+  <div fxFlex fxLayout="row" fxLayoutAlign="start center">
+    <div class="shell-search">
+      <app-city-filter class="shell-city"></app-city-filter>
+      <app-searchbar class="shell-searchbar"></app-searchbar>
+    </div>
+  </div>
+</div>
+<div class="categories-wrapper" fxLayout="row" fxLayoutAlign="space-evenly" fxLayoutGap="grid">
+  <app-category-card *ngFor="let direction of directions$ | async " [direction]="direction">
+  </app-category-card>
+</div>

--- a/src/app/shell/all-categories/all-categories.component.html
+++ b/src/app/shell/all-categories/all-categories.component.html
@@ -1,9 +1,10 @@
-<div fxLayout="row" fxLayoutAlign="center center">
+<div class="header-wrapper" fxLayout="row wrap" fxLayoutAlign="start center">
   <h3 class="title">Усі напрямки</h3>
-  <div fxFlex fxLayout="row" fxLayoutAlign="start center">
-    <div class="shell-search">
-      <app-city-filter class="shell-city"></app-city-filter>
-      <app-searchbar class="shell-searchbar"></app-searchbar>
+  <div fxLayout="row" fxLayoutAlign="start center">
+    <div class="header_search">
+      <mat-icon> place</mat-icon>
+      <app-city-filter class="header_city"></app-city-filter>
+      <app-searchbar class="header_bar"></app-searchbar>
     </div>
   </div>
 </div>

--- a/src/app/shell/all-categories/all-categories.component.scss
+++ b/src/app/shell/all-categories/all-categories.component.scss
@@ -1,27 +1,37 @@
-.shell-search {
-  background: white;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 40%;
-  height: 34px;
-  gap: 15px;
-  border-radius: 60px;
-  padding: 0 20px;
-  .shell-searchbar {
-    flex-grow: 1;
-    width: 70%;
+.header{
+  &_search {
+    background: white;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 30px;
+    margin-bottom: 1rem;
+    min-width: max-content;
+    height: 52px;
+    gap: 15px;
+    border-radius: 60px;
+    padding: 0 20px;
   }
-  .shell-city {
+  &_city {
     border-right: 1px solid #E3E3E3;
-    width: 30%;
+    min-width: 143px;
+  }
+  &_bar {
+    flex-grow: 1;
   }
 }
 .title{
-  margin-right: 2rem;
+  margin: 1rem;
+  margin-left: 0;
 }
 .categories-wrapper{
   flex-wrap: wrap;
   gap: 2rem;
-  margin: 2rem 0;
+  margin: 1rem 0;
+}
+
+@media(min-width: 750px) {
+  .shell-search{
+    width:  50%;
+  }
 }

--- a/src/app/shell/all-categories/all-categories.component.scss
+++ b/src/app/shell/all-categories/all-categories.component.scss
@@ -1,28 +1,5 @@
-.header{
-  &_search {
-    background: white;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-top: 30px;
-    margin-bottom: 1rem;
-    min-width: max-content;
-    height: 52px;
-    gap: 15px;
-    border-radius: 60px;
-    padding: 0 20px;
-  }
-  &_city {
-    border-right: 1px solid #E3E3E3;
-    min-width: 143px;
-  }
-  &_bar {
-    flex-grow: 1;
-  }
-}
 .title{
   margin: 1rem;
-  margin-left: 0;
 }
 .categories-wrapper{
   flex-wrap: wrap;

--- a/src/app/shell/all-categories/all-categories.component.scss
+++ b/src/app/shell/all-categories/all-categories.component.scss
@@ -1,0 +1,27 @@
+.shell-search {
+  background: white;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 40%;
+  height: 34px;
+  gap: 15px;
+  border-radius: 60px;
+  padding: 0 20px;
+  .shell-searchbar {
+    flex-grow: 1;
+    width: 70%;
+  }
+  .shell-city {
+    border-right: 1px solid #E3E3E3;
+    width: 30%;
+  }
+}
+.title{
+  margin-right: 2rem;
+}
+.categories-wrapper{
+  flex-wrap: wrap;
+  gap: 2rem;
+  margin: 2rem 0;
+}

--- a/src/app/shell/all-categories/all-categories.component.spec.ts
+++ b/src/app/shell/all-categories/all-categories.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AllCategoriesComponent } from './all-categories.component';
+
+describe('AllCategoriesComponent', () => {
+  let component: AllCategoriesComponent;
+  let fixture: ComponentFixture<AllCategoriesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AllCategoriesComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AllCategoriesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shell/all-categories/all-categories.component.spec.ts
+++ b/src/app/shell/all-categories/all-categories.component.spec.ts
@@ -1,4 +1,7 @@
+import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NgxsModule } from '@ngxs/store';
+import { Direction } from 'src/app/shared/models/category.model';
 
 import { AllCategoriesComponent } from './all-categories.component';
 
@@ -8,9 +11,17 @@ describe('AllCategoriesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ AllCategoriesComponent ]
+      imports: [
+        NgxsModule.forRoot([]),
+      ],
+      declarations: [
+        AllCategoriesComponent,
+        MockAllCategoriesSearchbarComponent,
+        MockAllCategoriesCityFilterComponent,
+        MockAllCategoriesCardComponent
+      ]
     })
-    .compileComponents();
+      .compileComponents();
   });
 
   beforeEach(() => {
@@ -23,3 +34,24 @@ describe('AllCategoriesComponent', () => {
     expect(component).toBeTruthy();
   });
 });
+
+@Component({
+  selector: 'app-city-filter',
+  template: ''
+})
+class MockAllCategoriesCityFilterComponent {
+}
+@Component({
+  selector: 'app-searchbar',
+  template: ''
+})
+class MockAllCategoriesSearchbarComponent {
+}
+@Component({
+  selector: 'app-category-card',
+  template: ''
+})
+class MockAllCategoriesCardComponent {
+  @Input() direction: Direction;
+  @Input() icons: {};
+}

--- a/src/app/shell/all-categories/all-categories.component.spec.ts
+++ b/src/app/shell/all-categories/all-categories.component.spec.ts
@@ -17,7 +17,6 @@ describe('AllCategoriesComponent', () => {
       declarations: [
         AllCategoriesComponent,
         MockAllCategoriesSearchbarComponent,
-        MockAllCategoriesCityFilterComponent,
         MockAllCategoriesCardComponent
       ]
     })
@@ -36,13 +35,7 @@ describe('AllCategoriesComponent', () => {
 });
 
 @Component({
-  selector: 'app-city-filter',
-  template: ''
-})
-class MockAllCategoriesCityFilterComponent {
-}
-@Component({
-  selector: 'app-searchbar',
+  selector: 'app-full-search-bar',
   template: ''
 })
 class MockAllCategoriesSearchbarComponent {

--- a/src/app/shell/all-categories/all-categories.component.ts
+++ b/src/app/shell/all-categories/all-categories.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { Select, Store } from '@ngxs/store';
+import { Observable } from 'rxjs';
+import { NavBarName } from 'src/app/shared/enum/navigation-bar';
+import { Direction } from 'src/app/shared/models/category.model';
+import { NavigationBarService } from 'src/app/shared/services/navigation-bar/navigation-bar.service';
+import { GetDirections } from 'src/app/shared/store/meta-data.actions';
+import { MetaDataState } from 'src/app/shared/store/meta-data.state';
+import { AddNavPath, DeleteNavPath } from 'src/app/shared/store/navigation.actions';
+
+@Component({
+  selector: 'app-all-categories',
+  templateUrl: './all-categories.component.html',
+  styleUrls: ['./all-categories.component.scss']
+})
+export class AllCategoriesComponent implements OnInit {
+
+  @Select(MetaDataState.directions)
+  directions$: Observable<Direction[]>;
+
+  constructor(
+    private store: Store,
+    public navigationBarService: NavigationBarService,
+  ) { }
+
+  ngOnInit(): void {
+    this.store.dispatch([
+      new AddNavPath(this.navigationBarService.creatOneNavPath(
+        { name: NavBarName.TopDestination, isActive: false, disable: true }
+      )),
+      new GetDirections()
+    ]);
+  }
+
+  ngOnDestroy(): void {
+    this.store.dispatch(new DeleteNavPath());
+  }
+
+}

--- a/src/app/shell/main/main.component.html
+++ b/src/app/shell/main/main.component.html
@@ -2,7 +2,7 @@
   <div class="main_categories">
     <div class="main_header" fxLayoutAlign="space-between center">
       <h3>Найпопулярніші напрямки</h3>
-      <a routerLink="/result" class="main_link">
+      <a routerLink="/all-categories" class="main_link">
         Переглянути всі <span class="material-icons arrow">arrow_forward</span>
       </a>
     </div>

--- a/src/app/shell/result/result.component.html
+++ b/src/app/shell/result/result.component.html
@@ -12,20 +12,20 @@
     </button>
   </div>
   <div fxFlex fxLayout="row" fxLayoutAlign="space-between center">
-    <div class="shell-search">
-      <app-city-filter class="shell-city"></app-city-filter>
-      <app-searchbar class="shell-searchbar"></app-searchbar>
-    </div>
+    <app-full-search-bar></app-full-search-bar>
     <div fxLayout="row" fxLayoutAlign="center center" fxLayoutGap='1rem'>
       <app-ordering></app-ordering>
       <mat-button-toggle-group #group="matButtonToggleGroup" [value]="currentView"
         (change)="SetCurrentView(group.value)">
-        <mat-button-toggle class = "list"value="show-data" aria-label="show-data" fxLayout="row" fxLayoutAlign="center center"><mat-icon>view_module</mat-icon>Список
+        <mat-button-toggle class="list" value="show-data" aria-label="show-data" fxLayout="row"
+          fxLayoutAlign="center center">
+          <mat-icon>view_module</mat-icon>Список
 
         </mat-button-toggle>
 
 
-        <mat-button-toggle class="map" value="map" aria-label="map" fxLayout="row" fxLayoutAlign="center center"><mat-icon> map</mat-icon> Карта
+        <mat-button-toggle class="map" value="map" aria-label="map" fxLayout="row" fxLayoutAlign="center center">
+          <mat-icon> map</mat-icon> Карта
         </mat-button-toggle>
       </mat-button-toggle-group>
     </div>

--- a/src/app/shell/result/result.component.scss
+++ b/src/app/shell/result/result.component.scss
@@ -29,7 +29,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 50%;
+  width: 40%;
   height: 34px;
   gap: 15px;
   border-radius: 60px;
@@ -90,7 +90,7 @@
 ::ng-deep .mat-button-toggle-checked {
   color: #3849F9 !important;
   background-color: #E3E3E3;
- 
+
 }
 
 ::ng-deep .mat-button-toggle-group[_ngcontent-mxx-c204]{
@@ -110,7 +110,7 @@
   border-top-left-radius: 1rem;
   border-bottom-left-radius: 1rem;
   border: 2px solid #3849F9;
-} 
+}
 
 ::ng-deep .mat-button-toggle-appearance-standard .mat-button-toggle-label-content{
   padding: 0px !important;
@@ -121,5 +121,3 @@
    border-left: 2px solid #3849F9;
  }
 }
-
-

--- a/src/app/shell/result/result.component.scss
+++ b/src/app/shell/result/result.component.scss
@@ -24,25 +24,6 @@
     background: #FFFFFF;
   }
 }
-.shell-search {
-  background: white;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 40%;
-  height: 34px;
-  gap: 15px;
-  border-radius: 60px;
-  padding: 0 20px;
-  .shell-searchbar {
-    flex-grow: 1;
-    width: 70%;
-  }
-  .shell-city {
-    border-right: 1px solid #E3E3E3;
-    width: 30%;
-  }
-}
 .mat-button-toggle-group {
   height: 2rem;
   align-items: center;

--- a/src/app/shell/result/result.component.spec.ts
+++ b/src/app/shell/result/result.component.spec.ts
@@ -28,7 +28,6 @@ describe('ResultComponent', () => {
         MockSearchbarComponent,
         MockOrderingComponent,
         MockFiltersListComponent,
-        MockCityFilterComponent,
         MockWorkshopCardsListComponent,
         MockWorkshopMapViewListComponent
       ]
@@ -48,7 +47,7 @@ describe('ResultComponent', () => {
 });
 
 @Component({
-  selector: 'app-searchbar',
+  selector: 'app-full-search-bar',
   template: ''
 })
 class MockSearchbarComponent {
@@ -66,13 +65,6 @@ class MockOrderingComponent {
   template: ''
 })
 class MockFiltersListComponent {
-}
-
-@Component({
-  selector: 'app-city-filter',
-  template: ''
-})
-class MockCityFilterComponent {
 }
 @Component({
   selector: 'app-workshop-cards-list',

--- a/src/app/shell/result/result.component.spec.ts
+++ b/src/app/shell/result/result.component.spec.ts
@@ -20,6 +20,7 @@ describe('ResultComponent', () => {
         MatButtonToggleModule,
         MatSidenavModule,
         BrowserAnimationsModule,
+        MatIconModule
       ],
       declarations: [
         ResultComponent,

--- a/src/app/shell/result/result.component.spec.ts
+++ b/src/app/shell/result/result.component.spec.ts
@@ -20,8 +20,6 @@ describe('ResultComponent', () => {
         MatButtonToggleModule,
         MatSidenavModule,
         BrowserAnimationsModule,
-        MatIconModule
-
       ],
       declarations: [
         ResultComponent,

--- a/src/app/shell/shell-routing.module.ts
+++ b/src/app/shell/shell-routing.module.ts
@@ -14,10 +14,12 @@ import { CreateApplicationComponent } from './personal-cabinet/parent/create-app
 import { CreateProviderGuard } from './personal-cabinet/provider/create-provider/create-provider.guard';
 import { UserConfigEditComponent } from './personal-cabinet/user-config/user-config-edit/user-config-edit.component';
 import { CreateGuard } from './personal-cabinet/create.guard';
+import { AllCategoriesComponent } from './all-categories/all-categories.component';
 
 const routes: Routes = [
   { path: '', component: MainComponent },
   { path: 'result', component: ResultComponent },
+  { path: 'all-categories', component: AllCategoriesComponent },
   {
     path: 'personal-cabinet', component: PersonalCabinetComponent,
     loadChildren: () => import('./personal-cabinet/personal-cabinet.module').then(m => m.PersonalCabinetModule),

--- a/src/app/shell/shell.module.ts
+++ b/src/app/shell/shell.module.ts
@@ -20,6 +20,7 @@ import { ParentGuard } from './personal-cabinet/parent/parent.guard';
 import { CreateProviderGuard } from './personal-cabinet/provider/create-provider/create-provider.guard';
 import { WorkshopMapViewListComponent } from './result/workshop-map-view-list/workshop-map-view-list.component';
 import { MAT_DATE_LOCALE } from '@angular/material/core';
+import { AllCategoriesComponent } from './all-categories/all-categories.component';
 @NgModule({
   declarations: [
     MainComponent,
@@ -28,6 +29,7 @@ import { MAT_DATE_LOCALE } from '@angular/material/core';
     OrderingComponent,
     PersonalCabinetComponent,
     WorkshopMapViewListComponent,
+    AllCategoriesComponent,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
If you click on "Переглянути всі" next to category card on the main page, you will be redirected to all-categories page, where categories card displayed. If you click on some specific category, you will be redirected to the result page.
![image](https://user-images.githubusercontent.com/27493959/124730286-e12e0c80-df19-11eb-9f61-173cb5dc4f53.png)
![image](https://user-images.githubusercontent.com/27493959/124730682-3ff38600-df1a-11eb-8af7-c5cfc2330d71.png)

The full search bar component combines city filter and search bar and applies styles for them. This component was reused in all the others+ checked the mobile view.


