### PR TITLE
Display parent workshop

### DIFF
--- a/src/app/shared/components/workshop-card/workshop-card.component.html
+++ b/src/app/shared/components/workshop-card/workshop-card.component.html
@@ -59,20 +59,22 @@
 
 <ng-template #ProviderChangeStatus>
   <div fxLayout="row" fxLayoutAlign="space-between center">
-    <mat-chip class="status chip_{{status}}" fxLayout="row" fxLayoutAlign="center center">
+    <!-- <mat-chip class="status chip_{{status}}" fxLayout="row" fxLayoutAlign="center center">
       <p class="status_text">{{ status === 'approved'
         ? "Набір відкрито" : "Набір завершено" }}</p>
     </mat-chip>
-    <p class="card_link status_action" *ngIf="status === 'approved'" (click)="onChangeStatus('denied')"> Призупинити
-      набір </p>
+    <p class="card_link status_action" *ngIf="status === 'approved'"> Призупинити
+      набір </p>:TODO add workshop status -->
   </div>
 </ng-template>
 
 <ng-template #ParentChangeStatus>
   <div fxLayout="row" fxLayoutAlign="space-between center">
-    <p class="status_{{status}}"><img src="assets/icons/{{status}}.png" alt="{{status}}"> {{ status === 'approved'
-      ? "Підтверджено" : "Відхилено" }} </p>
-    <p class="card_link status_action" *ngIf="status === 'approved'" (click)="onChangeStatus('denied')">Залишити гурток
+    <p><img src="assets/icons/{{applicationStatus[application.status] }}.png"
+        alt="{{applicationStatus[application.status]}}"> {{
+      applicationStatusUkr[application.status] }} </p>
+    <p class="card_link status_action" *ngIf="applicationStatus[application.status] === applicationStatus.approved"
+      (click)="onWorkshopLeave()">Залишити гурток
     </p>
   </div>
 </ng-template>

--- a/src/app/shared/components/workshop-card/workshop-card.component.html
+++ b/src/app/shared/components/workshop-card/workshop-card.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="(isMainPage || userRole !== role.provider) then UserActions; else ProviderActions">
+<div *ngIf="!(isMainPage || userRole !== role.provider) then ProviderActions;">
 </div>
 <mat-card>
   <div class="card" fxLayout="column" fxLayoutAlign="space-between space-between">
@@ -51,11 +51,11 @@
   </div>
 </ng-template>
 
-<ng-template #UserActions>
+<!-- <ng-template #UserActions>
   <div fxLayout="row" fxLayoutAlign="end start">
     <div class="actions_btn"><img src="assets/icons/fav.png" alt="fav" (click)="onLike()"></div>
   </div>
-</ng-template>
+</ng-template> :TODO add like icon-->
 
 <ng-template #ProviderChangeStatus>
   <div fxLayout="row" fxLayoutAlign="space-between center">

--- a/src/app/shared/components/workshop-card/workshop-card.component.spec.ts
+++ b/src/app/shared/components/workshop-card/workshop-card.component.spec.ts
@@ -9,6 +9,7 @@ import { Workshop } from '../../models/workshop.model';
 import { Address } from '../../models/address.model';
 import { Teacher } from '../../models/teacher.model';
 import { MatChipsModule } from '@angular/material/chips';
+import { Application } from '../../models/application.model';
 
 describe('WorkshopCardComponent', () => {
   let component: WorkshopCardComponent;
@@ -33,6 +34,7 @@ describe('WorkshopCardComponent', () => {
     fixture = TestBed.createComponent(WorkshopCardComponent);
     component = fixture.componentInstance;
     component.status = '';
+    component.application = {status: null} as Application;
     component.workshop = {
       id: 1,
       title: '',

--- a/src/app/shared/components/workshop-card/workshop-card.component.ts
+++ b/src/app/shared/components/workshop-card/workshop-card.component.ts
@@ -1,7 +1,9 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Select, Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
+import { ApplicationStatus, ApplicationStatusUkr } from '../../enum/applications';
 import { Role } from '../../enum/role';
+import { Application } from '../../models/application.model';
 import { User } from '../../models/user.model';
 import { Workshop } from '../../models/workshop.model';
 import { AppState } from '../../store/app.state';
@@ -14,13 +16,19 @@ import { DeleteWorkshopById } from '../../store/user.actions';
 })
 export class WorkshopCardComponent implements OnInit {
 
+  readonly applicationStatusUkr = ApplicationStatusUkr;
+  readonly applicationStatus = ApplicationStatus;
   readonly role: typeof Role = Role;
 
   @Input() workshop: Workshop;
   @Input() userRole: string;
   @Input() isMainPage: boolean;
+  @Input() application: Application;
+
 
   @Output() deleteWorkshop = new EventEmitter<Workshop>();
+  @Output() leaveWorkshop = new EventEmitter<Application>();
+
 
   status: string = 'approved'; //temporary
 
@@ -40,7 +48,7 @@ export class WorkshopCardComponent implements OnInit {
     console.log("I like it")
   }
 
-  onChangeStatus(status): void {
-    this.status = status;
+  onWorkshopLeave(): void {
+    this.leaveWorkshop.emit(this.application);
   }
 }

--- a/src/app/shared/store/user.actions.ts
+++ b/src/app/shared/store/user.actions.ts
@@ -8,10 +8,6 @@ export class GetWorkshopsByProviderId {
   static readonly type = '[user] get Workshops By Provider Id';
   constructor(public payload: number) { }
 }
-export class GetWorkshopsByParentId {
-  static readonly type = '[user] get Workshops By Parent Id';
-  constructor() { } //TODO: add get workshops by ParentId
-}
 export class GetWorkshopById {
   static readonly type = '[user] get Workshop By Wokrshop Id';
   constructor(public payload: number) { }

--- a/src/app/shared/store/user.state.ts
+++ b/src/app/shared/store/user.state.ts
@@ -48,7 +48,6 @@ import {
   OnUpdateUserFail,
   OnUpdateUserSuccess,
   GetWorkshopById,
-  GetWorkshopsByParentId,
   GetApplicationsByProviderId,
   GetApplicationsByParentId,
   OnUpdateApplicationSuccess,
@@ -110,16 +109,6 @@ export class UserState {
   getWorkshopsByProviderId({ patchState }: StateContext<UserStateModel>, { payload }: GetWorkshopsByProviderId) {
     return this.userWorkshopService
       .getWorkshopsByProviderId(payload)
-      .pipe(
-        tap((userWorkshops: Workshop[]) => {
-          return patchState({ workshops: userWorkshops });
-        }));
-  }
-
-  @Action(GetWorkshopsByParentId)
-  getWorkshopsByParentId({ patchState }: StateContext<UserStateModel>, { }: GetWorkshopsByParentId) {
-    return this.userWorkshopService
-      .getWorkshopsByParentId()
       .pipe(
         tap((userWorkshops: Workshop[]) => {
           return patchState({ workshops: userWorkshops });

--- a/src/app/shared/styles/cards.scss
+++ b/src/app/shared/styles/cards.scss
@@ -95,6 +95,7 @@
 .mat-card{
   max-width: 300px !important;
   padding:0 !important;
+  margin: 1rem;
 }
 .mat-card-content,
 .mat-card-footer{

--- a/src/app/shared/styles/list-wrappers.scss
+++ b/src/app/shared/styles/list-wrappers.scss
@@ -1,0 +1,15 @@
+.empty-list-wrapper{
+  min-height: 66px;
+  background: #e5e6f1;
+  border-radius: 5px;
+  padding: 20px 24px;
+  margin-top:20px;
+}
+
+.add-wrapper{
+  min-height: 66px;
+  background: #e5e6f1;
+  border-radius: 5px;
+  padding: 20px 24px;
+  margin-top:20px;
+}

--- a/src/app/shared/styles/list-wrappers.scss
+++ b/src/app/shared/styles/list-wrappers.scss
@@ -1,6 +1,11 @@
 .empty-list-wrapper{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  font-size: 20px;
   min-height: 66px;
-  background: #e5e6f1;
+  background: #ececec;
   border-radius: 5px;
   padding: 20px 24px;
   margin-top:20px;

--- a/src/app/shared/styles/list-wrappers.scss
+++ b/src/app/shared/styles/list-wrappers.scss
@@ -8,7 +8,7 @@
   background: #ececec;
   border-radius: 5px;
   padding: 20px 24px;
-  margin-top:20px;
+  margin-top: 20px;
 }
 
 .add-wrapper{
@@ -16,5 +16,5 @@
   background: #e5e6f1;
   border-radius: 5px;
   padding: 20px 24px;
-  margin-top:20px;
+  margin-top: 20px;
 }

--- a/src/app/shell/personal-cabinet/applications/applications.component.html
+++ b/src/app/shell/personal-cabinet/applications/applications.component.html
@@ -1,7 +1,7 @@
 <div class="container" *ngIf="(applications$ | async)?.length then isApplications; else isEmptyList"></div>
 
 <ng-template #isApplications>
-  <div class="container" *ngIf="(user.role === role.provider) then isProvider; else isParent"></div>
+  <div class="container" *ngIf="(userRole=== role.provider) then isProvider; else isParent"></div>
 </ng-template>
 
 <ng-template #isProvider>

--- a/src/app/shell/personal-cabinet/applications/applications.component.scss
+++ b/src/app/shell/personal-cabinet/applications/applications.component.scss
@@ -1,13 +1,8 @@
 @import "src/app/shared/styles/navigation-tabs.scss";
+@import "src/app/shared/styles/list-wrappers.scss";
+
 .container{
   width: 100%;
-}
-.no-application-wrapper{
-  min-height: 66px;
-  background: #e5e6f1;
-  border-radius: 5px;
-  padding: 20px 24px;
-  margin-top:20px;
 }
 .tab-wrapper{
   bottom: 5.5rem;

--- a/src/app/shell/personal-cabinet/applications/applications.component.ts
+++ b/src/app/shell/personal-cabinet/applications/applications.component.ts
@@ -34,7 +34,8 @@ export class ApplicationsComponent implements OnInit {
   children$: Observable<Child[]>;
 
   workshopList: Workshop[];
-  user: User;
+  userRole: string;
+  id: number;
 
   @ViewChild(InfoBoxHostDirective, { static: true })
   infoBoxHost: InfoBoxHostDirective;
@@ -44,14 +45,14 @@ export class ApplicationsComponent implements OnInit {
     private infoBoxService: InfoBoxService) { }
 
   ngOnInit(): void {
-    this.user = this.store.selectSnapshot<User>(RegistrationState.user);
-    this.getApplication();
+    this.userRole = this.store.selectSnapshot<User>(RegistrationState.user).role;
+    (this.userRole === Role.provider) ? this.getProviderApplications() : this.getParentApplications();
   }
 
   /**
   * This method initialize functionality to open child-info-box
   */
-  activateChildInfoBox(): void {
+   private activateChildInfoBox(): void {
     const viewContainerRef = this.infoBoxHost.viewContainerRef;
 
     this.infoBoxService.isMouseOver$
@@ -72,7 +73,6 @@ export class ApplicationsComponent implements OnInit {
   onApprove(application: Application): void {
     const applicationUpdate = new ApplicationUpdate(application.id, this.applicationStatus.approved);
     this.store.dispatch(new UpdateApplication(applicationUpdate));
-    this.getApplication();
   }
 
   /**
@@ -82,23 +82,25 @@ export class ApplicationsComponent implements OnInit {
   onReject(application: Application): void {
     const applicationUpdate = new ApplicationUpdate(application.id, this.applicationStatus.rejected);
     this.store.dispatch(new UpdateApplication(applicationUpdate));
-    this.getApplication();
   }
 
   /**
-  * This method get data according to teh user roles
+  * This method get data by Provider Id
   */
-  getApplication(): void {
-    if (this.user.role === Role.parent) {
-      const parent = this.store.selectSnapshot<Parent>(RegistrationState.parent);
-      this.store.dispatch(new GetChildrenByParentId(parent.id));
-      this.store.dispatch(new GetApplicationsByParentId(parent.id));
-    } else {
-      const provider = this.store.selectSnapshot<Provider>(RegistrationState.provider);
-      this.store.dispatch(new GetWorkshopsByProviderId(provider.id));
-      this.store.dispatch(new GetApplicationsByProviderId(provider.id));
-      this.activateChildInfoBox();
-    }
+  private getProviderApplications(): void {
+    this.id = this.store.selectSnapshot<Provider>(RegistrationState.provider).id;
+    this.store.dispatch(new GetWorkshopsByProviderId(this.id));
+    this.store.dispatch(new GetApplicationsByProviderId(this.id));
+    this.activateChildInfoBox();
+  }
+
+  /**
+  * This method get data by Parent Id
+  */
+  private getParentApplications(): void {
+    this.id = this.store.selectSnapshot<Provider>(RegistrationState.provider).id;
+    this.store.dispatch(new GetChildrenByParentId(this.id));
+    this.store.dispatch(new GetApplicationsByParentId(this.id));
   }
 
   /**

--- a/src/app/shell/personal-cabinet/applications/applications.component.ts
+++ b/src/app/shell/personal-cabinet/applications/applications.component.ts
@@ -11,10 +11,8 @@ import { Provider } from 'src/app/shared/models/provider.model';
 import { User } from 'src/app/shared/models/user.model';
 import { Workshop } from 'src/app/shared/models/workshop.model';
 import { InfoBoxService } from 'src/app/shared/services/info-box/info-box.service';
-import { GetWorkshops } from 'src/app/shared/store/app.actions';
-import { AppState } from 'src/app/shared/store/app.state';
 import { RegistrationState } from 'src/app/shared/store/registration.state';
-import { GetApplicationsByParentId, GetApplicationsByProviderId, GetChildrenByParentId, GetWorkshopsByParentId, GetWorkshopsByProviderId, UpdateApplication } from 'src/app/shared/store/user.actions';
+import { GetApplicationsByParentId, GetApplicationsByProviderId, GetChildrenByParentId, GetWorkshopsByProviderId, UpdateApplication } from 'src/app/shared/store/user.actions';
 import { UserState } from 'src/app/shared/store/user.state';
 import { Application, ApplicationUpdate } from '../../../shared/models/application.model';
 @Component({
@@ -91,13 +89,10 @@ export class ApplicationsComponent implements OnInit {
   * This method get data according to teh user roles
   */
   getApplication(): void {
-
     if (this.user.role === Role.parent) {
       const parent = this.store.selectSnapshot<Parent>(RegistrationState.parent);
       this.store.dispatch(new GetChildrenByParentId(parent.id));
       this.store.dispatch(new GetApplicationsByParentId(parent.id));
-      this.store.dispatch(new GetWorkshopsByParentId()); //TODO: add parent id
-
     } else {
       const provider = this.store.selectSnapshot<Provider>(RegistrationState.provider);
       this.store.dispatch(new GetWorkshopsByProviderId(provider.id));

--- a/src/app/shell/personal-cabinet/applications/applications.component.ts
+++ b/src/app/shell/personal-cabinet/applications/applications.component.ts
@@ -87,6 +87,9 @@ export class ApplicationsComponent implements OnInit {
     this.getApplication();
   }
 
+  /**
+  * This method get data according to teh user roles
+  */
   getApplication(): void {
 
     if (this.user.role === Role.parent) {

--- a/src/app/shell/personal-cabinet/parent/create-application/create-application.component.ts
+++ b/src/app/shell/personal-cabinet/parent/create-application/create-application.component.ts
@@ -72,7 +72,7 @@ export class CreateApplicationComponent implements OnInit, OnDestroy {
       data: 'Подати заявку?'
     });
 
-    dialogRef.afterClosed().subscribe(result => {
+    dialogRef.afterClosed().subscribe((result: boolean) => {
       if (result) {
         const application = new Application(this.selectedChild, this.workshop, this.parent);
         this.store.dispatch(new CreateApplication(application));

--- a/src/app/shell/personal-cabinet/parent/create-child/create-child.component.ts
+++ b/src/app/shell/personal-cabinet/parent/create-child/create-child.component.ts
@@ -65,7 +65,7 @@ export class CreateChildComponent implements OnInit {
   * This method create new FormGroup
   * @param FormArray array
   */
-  newForm(child?: Child): FormGroup {
+  private newForm(child?: Child): FormGroup {
     const childFormGroup = this.fb.group({
       lastName: new FormControl(''),
       firstName: new FormControl(''),

--- a/src/app/shell/personal-cabinet/parent/favorite-workshops/favorite-workshops.component.ts
+++ b/src/app/shell/personal-cabinet/parent/favorite-workshops/favorite-workshops.component.ts
@@ -2,8 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { Select, Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
 import { Workshop } from 'src/app/shared/models/workshop.model';
-import { GetWorkshopsByParentId } from 'src/app/shared/store/user.actions';
-import { UserState } from 'src/app/shared/store/user.state';
+import { GetWorkshops } from 'src/app/shared/store/app.actions';
+import { AppState } from 'src/app/shared/store/app.state';
 
 @Component({
   selector: 'app-favorite-workshops',
@@ -12,13 +12,13 @@ import { UserState } from 'src/app/shared/store/user.state';
 })
 export class FavoriteWorkshopsComponent implements OnInit {
 
-  @Select(UserState.workshops)
+  @Select(AppState.allWorkshops)
   workshops$: Observable<Workshop[]>;
 
   constructor(private store: Store) { }
 
   ngOnInit(): void {
-    this.store.dispatch(new GetWorkshopsByParentId());
+    this.store.dispatch(new GetWorkshops());
   }
 
 }

--- a/src/app/shell/personal-cabinet/parent/parent-info/parent-info.component.html
+++ b/src/app/shell/personal-cabinet/parent/parent-info/parent-info.component.html
@@ -1,9 +1,9 @@
-<div class="wrapper" fxLayout='row' fxLayoutAlign='space-between center'>
+<div class="add-wrapper" fxLayout='row' fxLayoutAlign='space-between center'>
   <p class="text">Тут ви можете додати інформацію про дитину, щоб записати її у гурток, секцію чи школу</p>
   <a [routerLink]="['/create-child', '']"><button class="btn" mat-raised-button>Додати дитину</button></a>
 </div>
 
-<div *ngIf="(children$ | async)?.length then ChildList"></div>
+<div *ngIf="(children$ | async)?.length then ChildList; else isEmptyList"></div>
 
 <ng-template #ChildList>
   <div class="wrapper-card">
@@ -15,4 +15,8 @@
       </div>
     </ng-container>
   </div>
+</ng-template>
+
+<ng-template #isEmptyList>
+  <p class="empty-list-wrapper">Дітей поки не додано до списку</p>
 </ng-template>

--- a/src/app/shell/personal-cabinet/parent/parent-info/parent-info.component.scss
+++ b/src/app/shell/personal-cabinet/parent/parent-info/parent-info.component.scss
@@ -1,10 +1,4 @@
-.wrapper{
-  min-height: 66px;
-  background: #e5e6f1;
-  border-radius: 5px;
-  padding: 20px 24px;
-  margin-top:20px;
-}
+@import "src/app/shared/styles/list-wrappers.scss";
 .btn{
   color:white;
   background-color:#3849F9;

--- a/src/app/shell/personal-cabinet/parent/parent-info/parent-info.component.ts
+++ b/src/app/shell/personal-cabinet/parent/parent-info/parent-info.component.ts
@@ -33,10 +33,8 @@ export class ParentInfoComponent implements OnInit {
       data: 'Видалити дитину?'
     });
 
-    dialogRef.afterClosed().subscribe(result => {
-      if (result) {
-        this.store.dispatch(new DeleteChildById(childId));
-      }
+    dialogRef.afterClosed().subscribe((result: boolean) => {
+      (result) && this.store.dispatch(new DeleteChildById(childId));
     });
   }
 

--- a/src/app/shell/personal-cabinet/provider/create-provider/create-contacts-form/create-contacts-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-provider/create-contacts-form/create-contacts-form.component.ts
@@ -37,8 +37,8 @@ export class CreateContactsFormComponent implements OnInit {
   ngOnInit(): void {
     this.passActualAddressFormGroup.emit(this.ActualAddressFormGroup);
     this.passLegalAddressFormGroup.emit(this.LegalAddressFormGroup);
-    this.isSameAddressControl.valueChanges.subscribe(val => {
-      (val) ? this.ActualAddressFormGroup.patchValue(this.LegalAddressFormGroup.value) : this.ActualAddressFormGroup.reset();
+    this.isSameAddressControl.valueChanges.subscribe((isSame: boolean) => {
+      (isSame) ? this.ActualAddressFormGroup.patchValue(this.LegalAddressFormGroup.value) : this.ActualAddressFormGroup.reset();
     })
 
     if (this.provider) {

--- a/src/app/shell/personal-cabinet/provider/create-provider/create-provider.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-provider/create-provider.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { MatStepper } from '@angular/material/stepper';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Params } from '@angular/router';
 import { Select, Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
 import { takeWhile } from 'rxjs/operators';
@@ -50,32 +50,30 @@ export class CreateProviderComponent implements OnInit, AfterViewInit {
       this.provider = this.store.selectSnapshot<Provider>(RegistrationState.provider);
     }
 
-    this.RobotFormControl.valueChanges.subscribe(val => this.isNotRobot = val);
-    this.AgreementFormControl.valueChanges.subscribe(val => this.isAgreed = val);
+    this.RobotFormControl.valueChanges.subscribe((val: boolean) => this.isNotRobot = val);
+    this.AgreementFormControl.valueChanges.subscribe((val: boolean) => this.isAgreed = val);
   }
 
   ngAfterViewInit() {
-    this.route.params.subscribe((params) => {
-      this.stepper.selectedIndex = +createProviderSteps[params.param];
-    })
+    this.route.params.subscribe((params: Params) => this.stepper.selectedIndex = +createProviderSteps[params.param]);
   }
 
   /**
    * This method dispatch store action to create a Provider with Form Groups values
    */
   onSubmit() {
-    const legalAddress = new Address(this.ActualAddressFormGroup.value);
-    const actulaAdress = new Address(this.LegalAddressFormGroup.value);
-    const user = this.store.selectSnapshot<User>(RegistrationState.user);
+    const legalAddress: Address = new Address(this.ActualAddressFormGroup.value);
+    const actulaAdress: Address = new Address(this.LegalAddressFormGroup.value);
+    const user: User = this.store.selectSnapshot<User>(RegistrationState.user);
+    let provider: Provider;
 
     if (this.editMode) {
-      const provider = new Provider(this.InfoFormGroup.value, legalAddress, actulaAdress, this.PhotoFormGroup.value, user, this.provider);
+      provider = new Provider(this.InfoFormGroup.value, legalAddress, actulaAdress, this.PhotoFormGroup.value, user, this.provider);
       this.store.dispatch(new UpdateProvider(provider));
     } else {
-      const provider = new Provider(this.InfoFormGroup.value, legalAddress, actulaAdress, this.PhotoFormGroup.value, user);
+      provider = new Provider(this.InfoFormGroup.value, legalAddress, actulaAdress, this.PhotoFormGroup.value, user);
       this.store.dispatch(new CreateProvider(provider));
     }
-
   }
 
   /**
@@ -110,7 +108,7 @@ export class CreateProviderComponent implements OnInit, AfterViewInit {
     this.subscribeOnDirtyForm(form);
   }
 
-  subscribeOnDirtyForm(form: FormGroup): void {
+  private subscribeOnDirtyForm(form: FormGroup): void {
     form.valueChanges
       .pipe(
         takeWhile(() => this.isPristine))

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
@@ -63,25 +63,25 @@ export class CreateAboutFormComponent implements OnInit {
   /**
    * This method makes input enable if radiobutton value is true and sets the value to teh formgroup
    */
-  onPriceCtrlInit(): void {
+  private onPriceCtrlInit(): void {
     this.priceRadioBtn.valueChanges
-    .pipe(
-      takeUntil(this.destroy$),
-    ).subscribe((isPrice: boolean) =>{
-      if(isPrice){
-        this.AboutFormGroup.get('price').enable()
-      }else{
-        this.AboutFormGroup.get('price').setValue(this.constants.MIN_PRICE); 
-        this.AboutFormGroup.get('price').disable();
-      }
-    });
+      .pipe(
+        takeUntil(this.destroy$),
+      ).subscribe((isPrice: boolean) => {
+        if (isPrice) {
+          this.AboutFormGroup.get('price').enable()
+        } else {
+          this.AboutFormGroup.get('price').setValue(this.constants.MIN_PRICE);
+          this.AboutFormGroup.get('price').disable();
+        }
+      });
 
     this.AboutFormGroup.get('price').valueChanges
       .pipe(
         takeUntil(this.destroy$),
         debounceTime(100),
-      ).subscribe((price: number) => this.AboutFormGroup.get('price').setValue(price) 
-    );  
+      ).subscribe((price: number) => this.AboutFormGroup.get('price').setValue(price)
+      );
   }
 
   /**
@@ -108,7 +108,7 @@ export class CreateAboutFormComponent implements OnInit {
   /**
   * This method fills in the info from provider to the workshop if check box is checked
   */
-  useProviderInfo(): void {
+  private useProviderInfo(): void {
     this.useProviderInfoCtrl.valueChanges.subscribe((useProviderInfo: boolean) => {
       if (useProviderInfo) {
         this.AboutFormGroup.get('email').setValue(this.provider.email);
@@ -130,7 +130,7 @@ export class CreateAboutFormComponent implements OnInit {
   /**
   * This method fills inputs with information of edited workshop
   */
-  activateEditMode(): void {
+  private activateEditMode(): void {
     this.AboutFormGroup.patchValue(this.workshop, { emitEvent: false });
     this.workshop.price && this.priceRadioBtn.setValue(true);
   }

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-teacher/create-teacher.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-teacher/create-teacher.component.ts
@@ -27,7 +27,7 @@ export class CreateTeacherComponent implements OnInit {
   * This method add new FormGroup to teh FormArray
   */
   onAddTeacher(teacher?: Teacher): void {
-    this.TeacherFormArray.push(this.onCreateNewForm(teacher));
+    this.TeacherFormArray.push(this.createNewForm(teacher));
     this.passTeacherFormArray.emit(this.TeacherFormArray);
   }
 
@@ -35,7 +35,7 @@ export class CreateTeacherComponent implements OnInit {
   * This method create new FormGroup
   * @param FormArray array
   */
-  onCreateNewForm(teacher?: Teacher): FormGroup {
+  private createNewForm(teacher?: Teacher): FormGroup {
     const teacherFormGroup = this.fb.group({
       img: new FormControl(''),
       lastName: new FormControl(''),

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
@@ -42,7 +42,7 @@ export class CreateWorkshopComponent implements OnInit {
     const workshopId = +this.route.snapshot.paramMap.get('id');
     if (workshopId) {
       this.editMode = true;
-      this.userWorkshopService.getWorkshopById(workshopId).subscribe(workshop => this.workshop = workshop);
+      this.userWorkshopService.getWorkshopById(workshopId).subscribe((workshop: Workshop) => this.workshop = workshop);
     }
   }
 
@@ -50,18 +50,20 @@ export class CreateWorkshopComponent implements OnInit {
    * This method dispatch store action to create a Workshop with Form Groups values
    */
   onSubmit() {
-    const address = new Address(this.AddressFormGroup.value);
-    const teachers = this.createTeachers(this.TeacherFormArray);
-    const provider = this.store.selectSnapshot<Provider>(RegistrationState.provider);
+    const address: Address = new Address(this.AddressFormGroup.value);
+    const teachers: Teacher[] = this.createTeachers(this.TeacherFormArray);
+    const provider: Provider = this.store.selectSnapshot<Provider>(RegistrationState.provider);
 
     const aboutInfo = this.AboutFormGroup.getRawValue();
     const descInfo = this.DescriptionFormGroup.getRawValue();
 
+    let workshop: Workshop;
+
     if (this.editMode) {
-      const workshop = new Workshop(aboutInfo, descInfo, address, teachers, provider, this.workshop.id);
+      workshop = new Workshop(aboutInfo, descInfo, address, teachers, provider, this.workshop.id);
       this.store.dispatch(new UpdateWorkshop(workshop));
     } else {
-      const workshop = new Workshop(aboutInfo, descInfo, address, teachers, provider);
+      workshop = new Workshop(aboutInfo, descInfo, address, teachers, provider);
       this.store.dispatch(new CreateWorkshop(workshop));
     }
   }
@@ -106,7 +108,7 @@ export class CreateWorkshopComponent implements OnInit {
    * This method create array of teachers
    * @param FormArray formArray
    */
-  createTeachers(formArray: FormArray): Teacher[] {
+  private createTeachers(formArray: FormArray): Teacher[] {
     const teachers: Teacher[] = [];
     formArray.controls.forEach((form: FormGroup) => {
       let teacher: Teacher = new Teacher(form.value);
@@ -115,7 +117,7 @@ export class CreateWorkshopComponent implements OnInit {
     return teachers;
   }
 
-  subscribeOnDirtyForm(form: FormGroup | FormArray): void {
+  private subscribeOnDirtyForm(form: FormGroup | FormArray): void {
     form.valueChanges
       .pipe(
         takeWhile(() => this.isPristine))

--- a/src/app/shell/personal-cabinet/workshops/workshops.component.html
+++ b/src/app/shell/personal-cabinet/workshops/workshops.component.html
@@ -1,19 +1,35 @@
-<div *ngIf="userRole === role.provider" class="wrapper" fxLayout='row' fxLayoutAlign='space-between center'>
-  <p class="text">Тут ви можете створити гурток, секцію або групу для навчання</p>
-  <a [routerLink]="['/create-workshop', '']"><button class="btn" mat-raised-button>Додати гурток</button></a>
-</div>
+<div *ngIf="(userRole === role.provider) then isProvider; else isParent"></div>
 
-<div *ngIf="(workshops$ | async)?.length then WorkshopsList"></div>
+<ng-template #isProvider>
+  <div class="add-wrapper" fxLayout='row' fxLayoutAlign='space-between center'>
+    <p class="text">Тут ви можете створити гурток, секцію або групу для навчання</p>
+    <a [routerLink]="['/create-workshop', '']"><button class="btn" mat-raised-button>Додати гурток</button></a>
+  </div>
+
+  <div *ngIf="!(workshops$ | async)?.length then isEmptyList;">
+    <app-workshop-card class="cards" *ngFor="let workshop of workshops$ | async " [workshop]="workshop"
+      [isMainPage]="false" [userRole]="userRole" (deleteWorkshop)="onDelete($event)"></app-workshop-card>
+  </div>
 
 
-<ng-template #WorkshopsList>
-  <div class="wrapper-card">
-    <ng-container>
-      <div fxLayout='row wrap' fxLayoutAlign='start space-evenly' fxLayoutGap="20px grid">
-        <app-workshop-card class="cards" *ngFor="let workshop of workshops$ | async " [workshop]="workshop"
-          [isMainPage]="false" [userRole]="userRole" (deleteWorkshop)="onDelete($event)">
+</ng-template>
+
+<ng-template #isParent>
+  <div *ngIf="applications$ | async">
+    <div *ngFor="let child of children">
+      <h3> {{ child.firstName }} {{ child.lastName }} {{ child.middleName }} ({{ child.dateOfBirth | date
+        :'shortDate'}})</h3>
+      <div fxLayout='row' fxLayoutAlign='start center'>
+        <app-workshop-card class="cards"
+          *ngFor="let application of (applications$ | async | applicationChildFilter : child)"
+          [workshop]="application.workshop" [isMainPage]="false" [userRole]="userRole" [application]="application"
+          (deleteWorkshop)="onDelete($event)" (leaveWorkshop)="onLeaveWorkshop($event)">
         </app-workshop-card>
       </div>
-    </ng-container>
+    </div>
   </div>
+</ng-template>
+
+<ng-template #isEmptyList>
+  <p class="empty-list-wrapper">Гуртків поки немає</p>
 </ng-template>

--- a/src/app/shell/personal-cabinet/workshops/workshops.component.html
+++ b/src/app/shell/personal-cabinet/workshops/workshops.component.html
@@ -5,27 +5,28 @@
     <p class="text">Тут ви можете створити гурток, секцію або групу для навчання</p>
     <a [routerLink]="['/create-workshop', '']"><button class="btn" mat-raised-button>Додати гурток</button></a>
   </div>
-
-  <div *ngIf="!(workshops$ | async)?.length then isEmptyList;">
-    <app-workshop-card class="cards" *ngFor="let workshop of workshops$ | async " [workshop]="workshop"
-      [isMainPage]="false" [userRole]="userRole" (deleteWorkshop)="onDelete($event)"></app-workshop-card>
-  </div>
-
-
+  <ng-container *ngIf="(workshops$ | async)?.length then ProviderWorkshops; else isEmptyList;"></ng-container> >
 </ng-template>
 
 <ng-template #isParent>
-  <div *ngIf="applications$ | async">
-    <div *ngFor="let child of children">
-      <h3> {{ child.firstName }} {{ child.lastName }} {{ child.middleName }} ({{ child.dateOfBirth | date
-        :'shortDate'}})</h3>
-      <div fxLayout='row' fxLayoutAlign='start center'>
-        <app-workshop-card class="cards"
-          *ngFor="let application of (applications$ | async | applicationChildFilter : child)"
-          [workshop]="application.workshop" [isMainPage]="false" [userRole]="userRole" [application]="application"
-          (deleteWorkshop)="onDelete($event)" (leaveWorkshop)="onLeaveWorkshop($event)">
-        </app-workshop-card>
-      </div>
+  <ng-container *ngIf="(applications$ | async)?.length then ParentWorkshops; else isEmptyList;"></ng-container> >
+</ng-template>
+
+<ng-template #ProviderWorkshops>
+  <app-workshop-card class="cards" *ngFor="let workshop of workshops$ | async " [workshop]="workshop"
+    [isMainPage]="false" [userRole]="userRole" (deleteWorkshop)="onDelete($event)"></app-workshop-card>
+</ng-template>
+
+<ng-template #ParentWorkshops>
+  <div *ngFor="let child of children">
+    <h3> {{ child.firstName }} {{ child.lastName }} {{ child.middleName }} ({{ child.dateOfBirth | date
+      :'shortDate'}})</h3>
+    <div fxLayout='row' fxLayoutAlign='start center'>
+      <app-workshop-card class="cards"
+        *ngFor="let application of (applications$ | async | applicationChildFilter : child)"
+        [workshop]="application.workshop" [isMainPage]="false" [userRole]="userRole" [application]="application"
+        (deleteWorkshop)="onDelete($event)" (leaveWorkshop)="onLeaveWorkshop($event)">
+      </app-workshop-card>
     </div>
   </div>
 </ng-template>

--- a/src/app/shell/personal-cabinet/workshops/workshops.component.html
+++ b/src/app/shell/personal-cabinet/workshops/workshops.component.html
@@ -13,26 +13,44 @@
 </ng-template>
 
 <ng-template #ProviderWorkshops>
-  <div fxLayout='row' fxLayoutAlign='start center'>
+  <div fxLayout='row wrap' fxLayoutAlign='start center'>
     <app-workshop-card class="cards" *ngFor="let workshop of workshops$ | async " [workshop]="workshop"
       [isMainPage]="false" [userRole]="userRole" (deleteWorkshop)="onDelete($event)"></app-workshop-card>
   </div>
 </ng-template>
 
 <ng-template #ParentWorkshops>
-  <div *ngFor="let child of children">
-    <h3> {{ child.firstName }} {{ child.lastName }} {{ child.middleName }} ({{ child.dateOfBirth | date
-      :'shortDate'}})</h3>
-    <div fxLayout='row' fxLayoutAlign='start center'>
-      <app-workshop-card class="cards"
-        *ngFor="let application of (applications$ | async | applicationChildFilter : child)"
-        [workshop]="application.workshop" [isMainPage]="false" [userRole]="userRole" [application]="application"
-        (deleteWorkshop)="onDelete($event)" (leaveWorkshop)="onLeaveWorkshop($event)">
-      </app-workshop-card>
-    </div>
-  </div>
+    <mat-tab-group mat-align-tabs="start">
+      <mat-tab label="Активні">
+        <ng-container
+          *ngTemplateOutlet="ParentApplications; context:{$implicit: applications$ | async  | applicationFilter : applicationStatus.pending : applicationStatus.approved : applicationStatus.acceptedForSelection }">
+        </ng-container>
+      </mat-tab>
+      <mat-tab label="Неактивні">
+        <ng-container
+          *ngTemplateOutlet="ParentApplications; context:{$implicit: applications$ | async  | applicationFilter : applicationStatus.rejected : applicationStatus.left }">
+        </ng-container>
+      </mat-tab>
+    </mat-tab-group>
 </ng-template>
 
 <ng-template #isEmptyList>
   <p class="empty-list-wrapper">Гуртків поки немає</p>
+</ng-template>
+
+<ng-template #ParentApplications let-applications>
+  <ng-container *ngIf="applications?.length then Applications; else isEmptyList;"></ng-container>
+
+   <ng-template #Applications>
+    <div *ngFor="let child of children$ | async">
+       <h3> {{ child.firstName }} {{ child.lastName }} {{ child.middleName }} ({{ child.dateOfBirth | date :'shortDate'}})</h3>
+      <div fxLayout='row' fxLayoutAlign='start center'>
+        <app-workshop-card class="cards"
+          *ngFor="let application of applications | applicationChildFilter : child"
+          [workshop]="application.workshop" [isMainPage]="false" [userRole]="userRole" [application]="application" (leaveWorkshop)="onLeaveWorkshops($event)">
+        </app-workshop-card>
+      </div>
+    </div>
+  </ng-template>
+
 </ng-template>

--- a/src/app/shell/personal-cabinet/workshops/workshops.component.html
+++ b/src/app/shell/personal-cabinet/workshops/workshops.component.html
@@ -5,7 +5,7 @@
     <p class="text">Тут ви можете створити гурток, секцію або групу для навчання</p>
     <a [routerLink]="['/create-workshop', '']"><button class="btn" mat-raised-button>Додати гурток</button></a>
   </div>
-  <ng-container *ngIf="(workshops$ | async)?.length then ProviderWorkshops; else isEmptyList;"></ng-container> >
+  <ng-container *ngIf="(workshops$ | async)?.length then ProviderWorkshops; else isEmptyList;"></ng-container>
 </ng-template>
 
 <ng-template #isParent>
@@ -13,8 +13,10 @@
 </ng-template>
 
 <ng-template #ProviderWorkshops>
-  <app-workshop-card class="cards" *ngFor="let workshop of workshops$ | async " [workshop]="workshop"
-    [isMainPage]="false" [userRole]="userRole" (deleteWorkshop)="onDelete($event)"></app-workshop-card>
+  <div fxLayout='row' fxLayoutAlign='start center'>
+    <app-workshop-card class="cards" *ngFor="let workshop of workshops$ | async " [workshop]="workshop"
+      [isMainPage]="false" [userRole]="userRole" (deleteWorkshop)="onDelete($event)"></app-workshop-card>
+  </div>
 </ng-template>
 
 <ng-template #ParentWorkshops>

--- a/src/app/shell/personal-cabinet/workshops/workshops.component.scss
+++ b/src/app/shell/personal-cabinet/workshops/workshops.component.scss
@@ -1,4 +1,5 @@
 @import "src/app/shared/styles/list-wrappers.scss";
+@import "src/app/shared/styles/navigation-tabs.scss";
 .btn{
   color:white;
   background-color:#3849F9;

--- a/src/app/shell/personal-cabinet/workshops/workshops.component.scss
+++ b/src/app/shell/personal-cabinet/workshops/workshops.component.scss
@@ -1,10 +1,4 @@
-.wrapper{
-  min-height: 66px;
-  background: #e5e6f1;
-  border-radius: 5px;
-  padding: 20px 24px;
-  margin-top:20px;
-}
+@import "src/app/shared/styles/list-wrappers.scss";
 .btn{
   color:white;
   background-color:#3849F9;

--- a/src/app/shell/personal-cabinet/workshops/workshops.component.spec.ts
+++ b/src/app/shell/personal-cabinet/workshops/workshops.component.spec.ts
@@ -6,6 +6,10 @@ import { Component, Input } from '@angular/core';
 import { Workshop } from '../../../shared/models/workshop.model';
 import { User } from '../../../shared/models/user.model';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatTabsModule } from '@angular/material/tabs';
+import { Application } from 'src/app/shared/models/application.model';
+import { ApplicationFilterPipe } from 'src/app/shared/pipes/application-filter.pipe';
+import { ApplicationChildFilterPipe } from 'src/app/shared/pipes/application-child-filter.pipe';
 
 describe('WorkshopsComponent', () => {
   let component: WorkshopsComponent;
@@ -17,11 +21,14 @@ describe('WorkshopsComponent', () => {
       imports: [
         RouterTestingModule,
         NgxsModule.forRoot([]),
-        MatDialogModule
+        MatDialogModule,
+        MatTabsModule
       ],
       declarations: [
         WorkshopsComponent,
-        MockWorkshopCardComponent
+        MockWorkshopCardComponent,
+        ApplicationFilterPipe,
+        ApplicationChildFilterPipe,
       ],
     })
       .compileComponents();
@@ -50,4 +57,5 @@ class MockWorkshopCardComponent {
   @Input() workshop: Workshop;
   @Input() isMainPage: boolean;
   @Input() userRole: string;
+  @Input() application: Application;
 }

--- a/src/app/shell/personal-cabinet/workshops/workshops.component.ts
+++ b/src/app/shell/personal-cabinet/workshops/workshops.component.ts
@@ -52,10 +52,9 @@ export class WorkshopsComponent implements OnInit {
       data: 'Видалити гурток?'
     });
 
-    dialogRef.afterClosed().subscribe(result => {
-      if (result) {
-        this.store.dispatch(new DeleteWorkshopById(workshop));
-      }
+    dialogRef.afterClosed().subscribe((result: boolean) => {
+      result && this.store.dispatch(new DeleteWorkshopById(workshop));
+
     });
   }
 
@@ -68,7 +67,7 @@ export class WorkshopsComponent implements OnInit {
       data: 'Залишити гурток?'
     });
 
-    dialogRef.afterClosed().subscribe(result => {
+    dialogRef.afterClosed().subscribe((result: boolean) => {
       if (result) {
         const applicationUpdate = new ApplicationUpdate(application.id, ApplicationStatus.left);
         this.store.dispatch(new UpdateApplication(applicationUpdate));
@@ -79,7 +78,7 @@ export class WorkshopsComponent implements OnInit {
   /**
   * This method get workshops by provider id
   */
-   private getProviderWorkshops(): void {
+  private getProviderWorkshops(): void {
     this.id = this.store.selectSnapshot<Provider>(RegistrationState.provider).id;
     this.store.dispatch(new GetWorkshopsByProviderId(this.id));
   }
@@ -87,7 +86,7 @@ export class WorkshopsComponent implements OnInit {
   /**
   * This method get applications by Parent Id
   */
-   private getParentWorkshops(): void {
+  private getParentWorkshops(): void {
     this.id = this.store.selectSnapshot<Parent>(RegistrationState.parent).id;
     this.store.dispatch(new GetChildrenByParentId(this.id));
     this.store.dispatch(new GetApplicationsByParentId(this.id));

--- a/src/app/shell/personal-cabinet/workshops/workshops.component.ts
+++ b/src/app/shell/personal-cabinet/workshops/workshops.component.ts
@@ -12,7 +12,7 @@ import { Parent } from 'src/app/shared/models/parent.model';
 import { Provider } from 'src/app/shared/models/provider.model';
 import { User } from 'src/app/shared/models/user.model';
 import { RegistrationState } from 'src/app/shared/store/registration.state';
-import { DeleteWorkshopById, GetApplicationsByParentId, GetWorkshopsByParentId, GetWorkshopsByProviderId, UpdateApplication } from 'src/app/shared/store/user.actions';
+import { DeleteWorkshopById, GetApplicationsByParentId, GetWorkshopsByProviderId, UpdateApplication } from 'src/app/shared/store/user.actions';
 import { UserState } from 'src/app/shared/store/user.state';
 import { Workshop } from '../../../shared/models/workshop.model';
 
@@ -25,6 +25,8 @@ export class WorkshopsComponent implements OnInit {
 
   readonly role: typeof Role = Role;
 
+  @Select(UserState.workshops)
+  workshops$: Observable<Workshop[]>;
   @Select(UserState.applications)
   applications$: Observable<Application[]>;
   applications: Application[];

--- a/src/app/shell/personal-cabinet/workshops/workshops.component.ts
+++ b/src/app/shell/personal-cabinet/workshops/workshops.component.ts
@@ -4,11 +4,14 @@ import { Select, Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
 import { ConfirmationModalWindowComponent } from 'src/app/shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { Role } from 'src/app/shared/enum/role';
+import { Application } from 'src/app/shared/models/application.model';
+import { Child } from 'src/app/shared/models/child.model';
+import { Parent } from 'src/app/shared/models/parent.model';
 import { Provider } from 'src/app/shared/models/provider.model';
 import { User } from 'src/app/shared/models/user.model';
 import { AppState } from 'src/app/shared/store/app.state';
 import { RegistrationState } from 'src/app/shared/store/registration.state';
-import { DeleteWorkshopById, GetWorkshopsByParentId, GetWorkshopsByProviderId } from 'src/app/shared/store/user.actions';
+import { DeleteWorkshopById, GetApplicationsByParentId, GetWorkshopsByParentId, GetWorkshopsByProviderId } from 'src/app/shared/store/user.actions';
 import { UserState } from 'src/app/shared/store/user.state';
 import { Workshop } from '../../../shared/models/workshop.model';
 import { GetWorkshops } from '../../../shared/store/app.actions';
@@ -24,6 +27,11 @@ export class WorkshopsComponent implements OnInit {
 
   @Select(UserState.workshops)
   workshops$: Observable<Workshop[]>;
+  @Select(UserState.applications)
+  applications$: Observable<Application[]>;
+
+  workshops: Workshop[];
+  children: Child[];
   userRole: string;
   id: number;
 
@@ -31,13 +39,7 @@ export class WorkshopsComponent implements OnInit {
 
   ngOnInit(): void {
     this.userRole = this.store.selectSnapshot<User>(RegistrationState.user).role;
-
-    if (this.userRole === Role.provider) {
-      this.id = this.store.selectSnapshot<Provider>(RegistrationState.provider).id;
-      this.store.dispatch(new GetWorkshopsByProviderId(this.id));
-    } else {
-      this.store.dispatch(new GetWorkshopsByParentId());
-    }
+    this.getWorkshops();
   }
 
   onDelete(workshop: Workshop): void {
@@ -51,5 +53,16 @@ export class WorkshopsComponent implements OnInit {
         this.store.dispatch(new DeleteWorkshopById(workshop));
       }
     });
+  }
+  getWorkshops(): void {
+
+    if (this.userRole === Role.provider) {
+      this.id = this.store.selectSnapshot<Provider>(RegistrationState.provider).id;
+      this.store.dispatch(new GetWorkshopsByProviderId(this.id));
+    } else {
+      this.id = this.store.selectSnapshot<Parent>(RegistrationState.parent).id;
+      this.store.dispatch(new GetApplicationsByParentId(this.id));
+      this.applications$.subscribe((applications: Application[]) => { })
+    }
   }
 }


### PR DESCRIPTION
1. Provider gets its workshops.
![image](https://user-images.githubusercontent.com/27493959/125725367-abafbdc8-818c-4f2d-b958-715e0f0b0aa6.png)
2. Parent gets applications that are filtered according to their status and displayed in an appropriate tab "Active/Non active". Also the applications are filtered according to the parent-children and for each child, its workshops are displayed as a card-list. 
3. Also action to leave the workshops was added to parent-workshops if the application status is approved.
![image](https://user-images.githubusercontent.com/27493959/125725287-836c8389-7384-4f7d-9b87-727e81760034.png)
4. Added wrappers if there are no workshops (TODO: ask the designer about the wrapper-design)
![image](https://user-images.githubusercontent.com/27493959/125725295-69d82019-3239-426b-b770-c79a5329a52d.png)


TODO: 
1. add appropriate chips to the application status of the workshops for both user roles.
![image](https://user-images.githubusercontent.com/27493959/125725813-c6bd2b6b-441a-49b0-9051-17f9fd605615.png)
![image](https://user-images.githubusercontent.com/27493959/125725860-7870a6d0-7e8d-4227-aa21-e638053095f8.png)
![image](https://user-images.githubusercontent.com/27493959/125726290-5b4f568d-098b-4e8c-9930-6047b2d0a83d.png)
2. Fix the workshop-action layout. For now, the action layout is moved down by bottom styles and it creates the fake space over the card and brokes the card's positioning.
![image](https://user-images.githubusercontent.com/27493959/125725547-07ee3030-f1a5-4a12-90da-40d7d956f04d.png)
3. Edit modal window if parent wants to leave he workshop 
![image](https://user-images.githubusercontent.com/27493959/125725923-394ce6c2-9408-415b-b257-12c314b72f00.png)
![image](https://user-images.githubusercontent.com/27493959/125726028-3da53f63-0ac4-47ff-b8c9-17904c00e6fe.png)


