### PR TITLE
images are replaced with mat-icons

### DIFF
--- a/src/app/shared/components/child-card/child-card.component.html
+++ b/src/app/shared/components/child-card/child-card.component.html
@@ -1,9 +1,12 @@
 <div *ngIf="child">
   <mat-card class="position">
     <div fxLayout="row" fxLayoutAlign="end start" class="actions">
-      <div class="actions_btn" [routerLink]="['/create-child', child.id]"><mat-icon>edit</mat-icon>
+      <div class="actions_btn" [routerLink]="['/create-child', child.id]">
+        <mat-icon>edit</mat-icon>
       </div>
-      <div class="actions_btn" (click)="onDelete()"><mat-icon>delete</mat-icon></div>
+      <div class="actions_btn" (click)="onDelete()">
+        <mat-icon>delete</mat-icon>
+      </div>
     </div>
     <div class="card" fxLayout="column" fxLayoutAlign="space-evenly space-between">
       <div fxLayout="row" fxLayoutAlign="center">
@@ -15,9 +18,13 @@
           </mat-card-title>
         </mat-card-header>
         <mat-card-content fxLayout="column" fxLayoutAlign="space-between start">
-          <p class="card_text"><img src="assets/icons/calendar.png" alt="calendar"> {{child.dateOfBirth | date:
-            'shortDate'}} </p>
-          <h5 class="card_text"><img src="assets/icons/group.png" alt="name"> Гуртки </h5>
+          <p class="card_text">
+            <mat-icon class="card_icon">calendar_today</mat-icon> {{child.dateOfBirth | date:
+            'shortDate'}}
+          </p>
+          <h5 class="card_text">
+            <mat-icon class="card_icon">apps</mat-icon>Гуртки
+          </h5>
           <div *ngIf="workshops?.length then WorkshopsList; else NoWorkshops "></div>
         </mat-card-content>
       </div>

--- a/src/app/shared/components/workshop-card/workshop-card.component.html
+++ b/src/app/shared/components/workshop-card/workshop-card.component.html
@@ -92,7 +92,7 @@
 </ng-template>
 
 <ng-template #ParentChangeStatus>
-  <div fxLayout="row" fxLayoutAlign="space-between center">
+  <div fxLayout="row" fxLayoutAlign="space-between center" class="parent-status">
     <p class="{{applicationStatus[application.status]}} icon">
       <mat-icon>how_to_reg</mat-icon>{{
       applicationStatusUkr[application.status] }}

--- a/src/app/shared/components/workshop-card/workshop-card.component.html
+++ b/src/app/shared/components/workshop-card/workshop-card.component.html
@@ -63,10 +63,10 @@
 
 <ng-template #ProviderActions>
   <div fxLayout="row" fxLayoutAlign="end start" class="actions">
-    <div class="actions_btn action" [routerLink]="['/create-workshop', workshop.id]">
+    <div class="actions_btn action-icon" [routerLink]="['/create-workshop', workshop.id]">
       <mat-icon>edit</mat-icon>
     </div>
-    <div class="actions_btn action" (click)="onDelete()">
+    <div class="actions_btn action-icon" (click)="onDelete()">
       <mat-icon>delete</mat-icon>
     </div>
   </div>
@@ -74,7 +74,7 @@
 
 <ng-template #UserActions>
   <div fxLayout="row" fxLayoutAlign="end start" class="actions">
-    <div class="actions_btn action">
+    <div class="actions_btn action-icon">
       <mat-icon (click)="onLike()">favorite_border</mat-icon>
     </div>
   </div>

--- a/src/app/shared/components/workshop-card/workshop-card.component.html
+++ b/src/app/shared/components/workshop-card/workshop-card.component.html
@@ -1,13 +1,12 @@
 <mat-card class="position">
   <div *ngIf="(isMainPage || userRole !== role.provider) then UserActions; else ProviderActions;">
-</div>
+  </div>
   <div class="card" fxLayout="column" fxLayoutAlign="space-between space-between">
     <img mat-card-image src="assets/icons/workshop.png" alt="workshop-photo">
     <mat-card-header>
       <mat-card-title [matTooltip]="workshop.title" showTooltipIfTruncated [matTooltipPosition]="below">
         {{workshop.title}}</mat-card-title>
-      <img class="card_category" src="assets/icons/lang.png"
-        alt="workshop-category">
+      <img class="card_category" src="assets/icons/lang.png" alt="workshop-category">
     </mat-card-header>
     <div *ngIf="isMainPage then MainView; else UserView"></div>
     <mat-card-footer fxLayout="row" fxLayoutAlign="end">
@@ -21,40 +20,63 @@
 
 <ng-template #MainView>
   <mat-card-content fxLayout="column" fxLayoutAlign="space-between">
-    <p class="card_text"><img src="assets/icons/rate.png" alt="rate"> {{ workshop.rate }} </p>
-    <p class="card_text"><img src="assets/icons/name.png" alt="name"> {{ workshop.providerTitle }} </p>
-    <p class="card_text"><img src="assets/icons/age.png" alt="age"> {{ workshop.minAge }} - {{ workshop.maxAge }} років
+    <p class="card_text">
+      <mat-icon class="card_icon">star</mat-icon> {{ workshop.rate }}
     </p>
-    <p class="card_text" *ngIf="!workshop.price"><img src="assets/icons/price.png" alt="price"> Безкоштовно </p>
-    <p class="card_text" *ngIf="workshop.price"><img src="assets/icons/price.png" alt="price"> {{ workshop.price }} грн/
+    <p class="card_text">
+      <mat-icon class="card_icon">home</mat-icon>{{ workshop.providerTitle }}
+    </p>
+    <p class="card_text">
+      <mat-icon class="card_icon">person</mat-icon>{{ workshop.minAge }} - {{ workshop.maxAge }} років
+    </p>
+    <p class="card_text" *ngIf="!workshop.price">
+      <mat-icon class="card_icon"> attach_money</mat-icon> Безкоштовно
+    </p>
+    <p class="card_text" *ngIf="workshop.price">
+      <mat-icon class="card_icon"> attach_money</mat-icon> {{ workshop.price }} грн/
       {{ workshop.isPerMonth
-      ? 'місяць' : 'заняття' }} </p>
-    <p class="card_text"><img src="assets/icons/address.png" alt="address"> {{ workshop.address.city }}, {{
+      ? 'місяць' : 'заняття' }}
+    </p>
+    <p class="card_text">
+      <mat-icon class="card_icon"> place</mat-icon> {{ workshop.address.city }}, {{
       workshop.address.street }}, {{
-      workshop.address.buildingNumber }} </p>
+      workshop.address.buildingNumber }}
+    </p>
   </mat-card-content>
 </ng-template>
 
 <ng-template #UserView>
   <mat-card-content class="user" fxLayout="column" fxLayoutAlign="space-between">
     <div *ngIf="userRole === role.provider then ProviderChangeStatus; else ParentChangeStatus"></div>
-    <p class="card_text user_text"><img src="assets/icons/age.png" alt="age">
-      {{ userRole !== role.provider ? "Всього учасників" : "Доступних місць" }} </p>
-    <p class="card_text user_text"><img src="assets/icons/awaits.png" alt="awaits"> Очікує підтвердження </p>
-    <p class="card_text user_text"><img src="assets/icons/email.png" alt="email"> Повідомлення </p>
+    <p class="card_text">
+      <mat-icon class="card_icon" class="card_icon">person</mat-icon>
+      {{ userRole !== role.provider ? "Всього учасників" : "Доступних місць" }}
+    </p>
+    <p class="card_text">
+      <mat-icon class="card_icon">access_time</mat-icon> Очікує підтвердження
+    </p>
+    <p class="card_text">
+      <mat-icon class="card_icon"> email</mat-icon> Повідомлення
+    </p>
   </mat-card-content>
 </ng-template>
 
 <ng-template #ProviderActions>
   <div fxLayout="row" fxLayoutAlign="end start" class="actions">
-    <div class="actions_btn" [routerLink]="['/create-workshop', workshop.id]"><mat-icon>edit</mat-icon></div>
-    <div class="actions_btn" (click)="onDelete()"><mat-icon>delete</mat-icon></div>
+    <div class="actions_btn action" [routerLink]="['/create-workshop', workshop.id]">
+      <mat-icon>edit</mat-icon>
+    </div>
+    <div class="actions_btn action" (click)="onDelete()">
+      <mat-icon>delete</mat-icon>
+    </div>
   </div>
 </ng-template>
 
 <ng-template #UserActions>
   <div fxLayout="row" fxLayoutAlign="end start" class="actions">
-    <div class="actions_btn"><mat-icon (click)="onLike()">favorite_border</mat-icon></div>
+    <div class="actions_btn action">
+      <mat-icon (click)="onLike()">favorite_border</mat-icon>
+    </div>
   </div>
 </ng-template>
 
@@ -71,9 +93,10 @@
 
 <ng-template #ParentChangeStatus>
   <div fxLayout="row" fxLayoutAlign="space-between center">
-    <p><img src="assets/icons/{{applicationStatus[application.status] }}.png"
-        alt="{{applicationStatus[application.status]}}"> {{
-      applicationStatusUkr[application.status] }} </p>
+    <p class="{{applicationStatus[application.status]}} icon">
+      <mat-icon>how_to_reg</mat-icon>{{
+      applicationStatusUkr[application.status] }}
+    </p>
     <p class="card_link status_action" *ngIf="applicationStatus[application.status] === applicationStatus.approved"
       (click)="onWorkshopLeave()">Залишити гурток
     </p>

--- a/src/app/shared/components/workshop-card/workshop-card.component.html
+++ b/src/app/shared/components/workshop-card/workshop-card.component.html
@@ -92,7 +92,7 @@
 </ng-template>
 
 <ng-template #ParentChangeStatus>
-  <div fxLayout="row" fxLayoutAlign="space-between center" class="status">
+  <div fxLayout="row" fxLayoutAlign="space-between center" class="parent-status">
     <p class="{{applicationStatus[application.status]}} icon">
       <mat-icon>how_to_reg</mat-icon>{{
       applicationStatusUkr[application.status] }}

--- a/src/app/shared/components/workshop-card/workshop-card.component.html
+++ b/src/app/shared/components/workshop-card/workshop-card.component.html
@@ -92,7 +92,7 @@
 </ng-template>
 
 <ng-template #ParentChangeStatus>
-  <div fxLayout="row" fxLayoutAlign="space-between center" class="parent-status">
+  <div fxLayout="row" fxLayoutAlign="space-between center" class="status">
     <p class="{{applicationStatus[application.status]}} icon">
       <mat-icon>how_to_reg</mat-icon>{{
       applicationStatusUkr[application.status] }}

--- a/src/app/shared/components/workshop-card/workshop-card.component.scss
+++ b/src/app/shared/components/workshop-card/workshop-card.component.scss
@@ -9,7 +9,7 @@
 .action-icon {
   color: #fff;
 }
-.status{
+.parent-status{
   .approved{
     color:#199953
   }

--- a/src/app/shared/components/workshop-card/workshop-card.component.scss
+++ b/src/app/shared/components/workshop-card/workshop-card.component.scss
@@ -9,15 +9,17 @@
 .action-icon {
   color: #fff;
 }
-.approved{
-  color:#199953
-}
-.pending{
-  color: #FFBD00;
-}
-.acceptedForSelection{
-  color: #27A3FF;
-}
-.rejected, .left, .blocked{
-  color: #C72A21;
+.parent-status{
+  .approved{
+    color:#199953
+  }
+  .pending{
+    color: #FFBD00;
+  }
+  .acceptedForSelection{
+    color: #27A3FF;
+  }
+  .rejected, .left, .blocked{
+    color: #C72A21;
+  }
 }

--- a/src/app/shared/components/workshop-card/workshop-card.component.scss
+++ b/src/app/shared/components/workshop-card/workshop-card.component.scss
@@ -1,5 +1,23 @@
 @import "src/app/shared/styles/cards.scss";
-
-.mat-icon {
+.icon{
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  font-weight: 500;
+}
+.action {
   color: #fff;
+}
+.approved{
+  color:#199953
+}
+.pending{
+  color: #FFBD00;
+}
+.acceptedForSelection{
+  color: #27A3FF;
+}
+.rejected, .left, .blocked{
+  color: #C72A21;
 }

--- a/src/app/shared/components/workshop-card/workshop-card.component.scss
+++ b/src/app/shared/components/workshop-card/workshop-card.component.scss
@@ -6,7 +6,7 @@
   align-items: center;
   font-weight: 500;
 }
-.action {
+.action-icon {
   color: #fff;
 }
 .approved{

--- a/src/app/shared/components/workshop-card/workshop-card.component.scss
+++ b/src/app/shared/components/workshop-card/workshop-card.component.scss
@@ -9,7 +9,7 @@
 .action-icon {
   color: #fff;
 }
-.parent-status{
+.status{
   .approved{
     color:#199953
   }

--- a/src/app/shared/styles/cards.scss
+++ b/src/app/shared/styles/cards.scss
@@ -33,11 +33,18 @@
     font-weight: 700;
   }
   &_text {
-    padding: 0;
-    margin: 0.5rem;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
     font-size: 0.813rem;
     line-height: 1.125rem;
     color: #333333;
+    margin: 0.3rem;
+    padding: 0;
+  }
+  &_icon{
+    color: #AAAAAA;
+    margin-right: 0.2rem;
   }
 }
 .actions_btn {
@@ -74,6 +81,8 @@
     font-size: 11px;
     line-height: 12px;
     color: #FFFFFF;
+    margin: 0;
+    padding: 0;
   }
 
   &_action{

--- a/src/app/shell/workshop-details/workshop-page/workshop-page.component.html
+++ b/src/app/shell/workshop-details/workshop-page/workshop-page.component.html
@@ -17,12 +17,16 @@
 
       </div>
       <p fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px">
-        <img src="assets/icons/rate.png" alt="">
-        <span>{{workshop.rating}}</span>
+        <span class="icon-text">
+          <mat-icon class="icon">star</mat-icon>
+          {{workshop.rating}}
+        </span>
       </p>
       <p fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px">
-        <img src="assets/icons/home.svg" alt="">
-        <a [routerLink]="'./provider-about'" class="workshop-link">Школа танців</a>
+        <a [routerLink]="'./provider-about'" class="workshop-link">
+          <mat-icon>home</mat-icon>
+          Школа танців
+        </a>
       </p>
     </div>
     <mat-tab-group>

--- a/src/app/shell/workshop-details/workshop-page/workshop-page.component.scss
+++ b/src/app/shell/workshop-details/workshop-page/workshop-page.component.scss
@@ -19,6 +19,9 @@
     margin:1rem;
   }
   &-link{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
     color:#3849F9;
     &:hover{
       color:#a6ade7;
@@ -60,4 +63,17 @@
     margin: 0 10px 0 0;
     font-size: 20px;
   }
+}
+.icon-text {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-size: 0.813rem;
+  line-height: 1.125rem;
+  color: #333333;
+  padding: 0;
+}
+.icon{
+  color: #AAAAAA;
+  margin-right: 0.2rem;
 }


### PR DESCRIPTION
Among all the icons, I found only the "approved" status, but not the others. Should we ask to replace these icons with those that we can have from mat-icons, or should we use images for displaying these statuses? 
https://www.angularjswiki.com/angular/angular-material-icons-list-mat-icon-list/
![image](https://user-images.githubusercontent.com/27493959/126120840-9d3b56e1-0c63-4d6e-8e7d-0d8374893f21.png)
