### PR TITLE
[Personal cabinet] Broken pop-up on status hover

### DIFF
--- a/src/app/shell/personal-cabinet/applications/application-card/application-card.component.html
+++ b/src/app/shell/personal-cabinet/applications/application-card/application-card.component.html
@@ -32,17 +32,15 @@
   </mat-card-content>
 
   <mat-card-content class="card-block" fxLayout="column" fxLayoutAlign="start center">
-    <div class="application-status" *ngIf="application" [matMenuTriggerFor]="menu" #trigger="matMenuTrigger"
-      (mouseenter)="trigger.openMenu()" (mouseleave)="trigger.closeMenu()">
-      <div class="application-popup-status {{application.status}}">
+    <div class="application-status" *ngIf="application" [matMenuTriggerFor]="menu" (mouseleave)="closeMenu()">
+      <div class="application-popup-status {{application.status}}" (mouseenter)="openMenu()">
         <span> <i class="status-icon {{applicationIcons[application.status]}}"></i></span>
         <span> {{applicationTitles[application.status]}}</span>
-      </div>
+      </div>      
     </div>
-    <mat-menu class="status-menu" [hasBackdrop]="false" disabled #menu="matMenu" [overlapTrigger]="false"
-      (mouseleave)="trigger.closeMenu()" class="mat-application-menu">
+    <mat-menu class="status-menu" [hasBackdrop]="false"  #menu="matMenu" [overlapTrigger]="false" xPosition="after" class="mat-application-menu">
       <app-status-info-card [application]="application"></app-status-info-card>
-    </mat-menu>
+    </mat-menu>    
   </mat-card-content>
 
   <mat-card-content class="card-block card-block-buttons" *ngIf="userRole === role.provider">

--- a/src/app/shell/personal-cabinet/applications/application-card/application-card.component.html
+++ b/src/app/shell/personal-cabinet/applications/application-card/application-card.component.html
@@ -32,13 +32,14 @@
   </mat-card-content>
 
   <mat-card-content class="card-block" fxLayout="column" fxLayoutAlign="start center">
-    <div class="application-status" *ngIf="application" [matMenuTriggerFor]="menu" #trigger="matMenuTrigger" (mouseleave)="trigger.closeMenu()">
+    <div class="application-status" *ngIf="application" [matMenuTriggerFor]="menu" #trigger="matMenuTrigger"
+      (mouseleave)="trigger.closeMenu()">
       <div class="application-popup-status {{application.status}}" (mouseenter)="trigger.openMenu()">
         <span> <i class="status-icon {{applicationIcons[application.status]}}"></i></span>
         <span> {{applicationTitles[application.status]}}</span>
       </div>      
     </div>
-    <mat-menu class="status-menu" [hasBackdrop]="false"  #menu="matMenu" [overlapTrigger]="false" xPosition="after" class="mat-application-menu">
+    <mat-menu class="status-menu" [hasBackdrop]="false"  #menu="matMenu" disabled [overlapTrigger]="false" xPosition="after" class="mat-application-menu">
       <app-status-info-card [application]="application"></app-status-info-card>
     </mat-menu>    
   </mat-card-content>

--- a/src/app/shell/personal-cabinet/applications/application-card/application-card.component.html
+++ b/src/app/shell/personal-cabinet/applications/application-card/application-card.component.html
@@ -32,8 +32,8 @@
   </mat-card-content>
 
   <mat-card-content class="card-block" fxLayout="column" fxLayoutAlign="start center">
-    <div class="application-status" *ngIf="application" [matMenuTriggerFor]="menu" (mouseleave)="closeMenu()">
-      <div class="application-popup-status {{application.status}}" (mouseenter)="openMenu()">
+    <div class="application-status" *ngIf="application" [matMenuTriggerFor]="menu" #trigger="matMenuTrigger" (mouseleave)="trigger.closeMenu()">
+      <div class="application-popup-status {{application.status}}" (mouseenter)="trigger.openMenu()">
         <span> <i class="status-icon {{applicationIcons[application.status]}}"></i></span>
         <span> {{applicationTitles[application.status]}}</span>
       </div>      

--- a/src/app/shell/personal-cabinet/applications/application-card/application-card.component.scss
+++ b/src/app/shell/personal-cabinet/applications/application-card/application-card.component.scss
@@ -74,6 +74,9 @@ p {
   align-items: center;
   font-weight: 500;
 }
+.application-status {
+  padding: 2px;
+}
 .application-popup-status {
   font-family: 'Open Sans', sans-serif;
   font-weight: 700;

--- a/src/app/shell/personal-cabinet/applications/application-card/application-card.component.ts
+++ b/src/app/shell/personal-cabinet/applications/application-card/application-card.component.ts
@@ -10,7 +10,6 @@ import { MatDialog } from '@angular/material/dialog';
 import { RejectModalWindowComponent } from 'src/app/shared/components/reject-modal-window/reject-modal-window.component';
 import { ConfirmationModalWindowComponent } from 'src/app/shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'src/app/shared/enum/modal-confirmation';
-import { MatMenuTrigger } from '@angular/material/menu';
 
 @Component({
   selector: 'app-application-card',
@@ -28,7 +27,6 @@ export class ApplicationCardComponent implements OnInit {
   childAge: string;
   deviceToogle: boolean;
   infoShowToggle: boolean = false;
-  isOpenMenu: boolean = false;
 
   @Input() application: Application;
   @Input() userRole: string;
@@ -37,8 +35,6 @@ export class ApplicationCardComponent implements OnInit {
   @Output() leave = new EventEmitter();
   @Output() infoShow = new EventEmitter();
   @Output() infoHide = new EventEmitter();
-
-  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
 
   constructor(
     private detectedDevice: DetectedDeviceService,

--- a/src/app/shell/personal-cabinet/applications/application-card/application-card.component.ts
+++ b/src/app/shell/personal-cabinet/applications/application-card/application-card.component.ts
@@ -125,12 +125,4 @@ export class ApplicationCardComponent implements OnInit {
     this.deviceToogle && document.removeEventListener('click', this.onClick.bind(this));
   }
 
-  openMenu() {     
-    this.trigger.openMenu();    
-  }
-  
-  closeMenu() {
-    this.trigger.closeMenu();
-  }
-
 }

--- a/src/app/shell/personal-cabinet/applications/application-card/application-card.component.ts
+++ b/src/app/shell/personal-cabinet/applications/application-card/application-card.component.ts
@@ -10,6 +10,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { RejectModalWindowComponent } from 'src/app/shared/components/reject-modal-window/reject-modal-window.component';
 import { ConfirmationModalWindowComponent } from 'src/app/shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'src/app/shared/enum/modal-confirmation';
+import { MatMenuTrigger } from '@angular/material/menu';
 
 @Component({
   selector: 'app-application-card',
@@ -27,6 +28,7 @@ export class ApplicationCardComponent implements OnInit {
   childAge: string;
   deviceToogle: boolean;
   infoShowToggle: boolean = false;
+  isOpenMenu: boolean = false;
 
   @Input() application: Application;
   @Input() userRole: string;
@@ -35,6 +37,8 @@ export class ApplicationCardComponent implements OnInit {
   @Output() leave = new EventEmitter();
   @Output() infoShow = new EventEmitter();
   @Output() infoHide = new EventEmitter();
+
+  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
 
   constructor(
     private detectedDevice: DetectedDeviceService,
@@ -119,6 +123,14 @@ export class ApplicationCardComponent implements OnInit {
     this.infoShowToggle = false;
     this.infoHide.emit();
     this.deviceToogle && document.removeEventListener('click', this.onClick.bind(this));
+  }
+
+  openMenu() {     
+    this.trigger.openMenu();    
+  }
+  
+  closeMenu() {
+    this.trigger.closeMenu();
   }
 
 }


### PR DESCRIPTION
the issue 772: https://github.com/ita-social-projects/OoS-Frontend/issues/772

I tried many approaches to fix this bug, however only padding css property help to avoid this effect. It divides areas for "mouseenter" and "mouseleave" events.