### PR TITLE
feat: add providerOwnership field to the card

### DIFF
--- a/src/app/shared/components/workshop-card/workshop-card.component.html
+++ b/src/app/shared/components/workshop-card/workshop-card.component.html
@@ -92,6 +92,9 @@
     <p class="card_text_label" [matTooltip]="workshop.providerTitle" showTooltipIfTruncated matTooltipClass="tooltip"
       [matTooltipPosition]="below">{{ workshop.providerTitle }}</p>
   </div>
+  <p class="card_text" *ngIf="ownershipTypeUkr[workshop.providerOwnership]">
+    <mat-icon class="card_icon">account_balance</mat-icon> Форма власності: {{ ownershipTypeUkr[workshop.providerOwnership] }}
+  </p>
   <p class="card_text" [ngClass]="isCreateApplicationView ? 'hide': ''">
     <mat-icon class="card_icon">person</mat-icon>{{ workshop.minAge }} - {{ workshop.maxAge }} років
   </p>

--- a/src/app/shared/components/workshop-card/workshop-card.component.html
+++ b/src/app/shared/components/workshop-card/workshop-card.component.html
@@ -92,8 +92,8 @@
     <p class="card_text_label" [matTooltip]="workshop.providerTitle" showTooltipIfTruncated matTooltipClass="tooltip"
       [matTooltipPosition]="below">{{ workshop.providerTitle }}</p>
   </div>
-  <p class="card_text" *ngIf="ownershipTypeUkr[workshop.providerOwnership]">
-    <mat-icon class="card_icon">account_balance</mat-icon> Форма власності: {{ ownershipTypeUkr[workshop.providerOwnership] }}
+  <p class="card_text" *ngIf="ownershipType">
+    <mat-icon class="card_icon">account_balance</mat-icon> Форма власності: {{ ownershipType }}
   </p>
   <p class="card_text" [ngClass]="isCreateApplicationView ? 'hide': ''">
     <mat-icon class="card_icon">person</mat-icon>{{ workshop.minAge }} - {{ workshop.maxAge }} років

--- a/src/app/shared/components/workshop-card/workshop-card.component.ts
+++ b/src/app/shared/components/workshop-card/workshop-card.component.ts
@@ -14,6 +14,7 @@ import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { CategoryIcons } from '../../enum/category-icons';
+import { OwnershipTypeUkr} from 'src/app/shared/enum/provider';
 
 @Component({
   selector: 'app-workshop-card',
@@ -25,6 +26,7 @@ export class WorkshopCardComponent implements OnInit, OnDestroy {
   readonly applicationTitles = ApplicationTitles;
   readonly applicationStatus = ApplicationStatus;
   readonly Role: typeof Role = Role;
+  readonly ownershipTypeUkr = OwnershipTypeUkr;
   public categoryIcons = CategoryIcons;
   public below = 'below';
   favoriteWorkshops: Favorite[];

--- a/src/app/shared/components/workshop-card/workshop-card.component.ts
+++ b/src/app/shared/components/workshop-card/workshop-card.component.ts
@@ -14,7 +14,7 @@ import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { CategoryIcons } from '../../enum/category-icons';
-import { OwnershipTypeUkr} from 'src/app/shared/enum/provider';
+import { OwnershipTypeUkr } from 'src/app/shared/enum/provider';
 
 @Component({
   selector: 'app-workshop-card',
@@ -26,13 +26,13 @@ export class WorkshopCardComponent implements OnInit, OnDestroy {
   readonly applicationTitles = ApplicationTitles;
   readonly applicationStatus = ApplicationStatus;
   readonly Role: typeof Role = Role;
-  readonly ownershipTypeUkr = OwnershipTypeUkr;
   public categoryIcons = CategoryIcons;
   public below = 'below';
   favoriteWorkshops: Favorite[];
   isFavorite: boolean;
   favoriteWorkshopId: Favorite;
   pendingApplicationAmount: number;
+  ownershipType: string;
 
   @Input() workshop: WorkshopCard;
   @Input() userRoleView: string;
@@ -67,6 +67,7 @@ export class WorkshopCardComponent implements OnInit, OnDestroy {
     public dialog: MatDialog) { }
 
   ngOnInit(): void {
+    this.ownershipType = OwnershipTypeUkr[this.workshop.providerOwnership];
     this.favoriteWorkshops$
       .pipe(takeUntil(this.destroy$))
       .subscribe((favorites: Favorite[]) => {

--- a/src/app/shared/models/workshop.model.ts
+++ b/src/app/shared/models/workshop.model.ts
@@ -83,6 +83,7 @@ export interface WorkshopCard {
   price: number;
   providerId: string;
   providerTitle: string;
+  providerOwnership: string;
   rating: number;
   title: string;
   workshopId: string;


### PR DESCRIPTION
the task https://github.com/ita-social-projects/OoS-Frontend/issues/813

display field "Форма власності" in the workshop card.

![image](https://user-images.githubusercontent.com/8740198/151525992-2a3a218e-5bfb-4d4c-acad-4cc459bdaa79.png)
