### PR TITLE
[Service provider] 'Адміністрування' tab - redirect to the personal cabinet after successfully provider Admin creating

### DIFF
--- a/src/app/shared/store/user.state.ts
+++ b/src/app/shared/store/user.state.ts
@@ -371,6 +371,7 @@ export class UserState {
   onCreateProviderAdminSuccess({ dispatch }: StateContext<UserStateModel>, { payload }: OnCreateProviderAdminSuccess): void {
     dispatch(new MarkFormDirty(false));
     dispatch(new ShowMessageBar({ message: 'Користувача успішно створено', type: 'success' }));
+    this.router.navigate(['/personal-cabinet/administration']);
   }
 
   @Action(CreateApplication)


### PR DESCRIPTION
Task https://github.com/ita-social-projects/OoS-Frontend/issues/995

Add redirection to '/personal-cabinet/administration' after successful creating provider admin 