### PR TITLE
Update .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,8 +26,7 @@
           "always"
         ],
         "linebreak-style": [
-          "error",
-          "windows"
+          "error"
         ],
         "eol-last": "warn",
         "no-console": ["error", { "allow": ["warn", "error"]}],


### PR DESCRIPTION
* fixed a error when a line break from a non-windows OS was considered an error