### PR TITLE
Oliinyk / 2127 Fix redirect after canceling dirty form

### DIFF
--- a/src/app/shell/admin-tools/data/admins/create-admin/create-admin.component.html
+++ b/src/app/shell/admin-tools/data/admins/create-admin/create-admin.component.html
@@ -61,7 +61,7 @@
       </app-validation-hint>
 
       <label class="step-label"
-        >{{ 'FORMS.LABELS.SUBORDINATION' | translate }}<span class="step-required">*</span></label
+      >{{ 'FORMS.LABELS.SUBORDINATION' | translate }}<span class="step-required">*</span></label
       >
       <mat-form-field floatLabel="never" appearance="none">
         <mat-select
@@ -76,7 +76,7 @@
           </mat-option>
         </mat-select>
       </mat-form-field>
-      <app-validation-hint [validationFormControl]="institutionFormControl"> </app-validation-hint>
+      <app-validation-hint [validationFormControl]="institutionFormControl"></app-validation-hint>
       <ng-container *ngIf="isRegionAdmin">
         <label class="step-label">{{ 'FORMS.LABELS.REGION' | translate }}<span class="step-required">*</span></label>
         <mat-form-field floatLabel="never" appearance="none">
@@ -102,7 +102,7 @@
               {{ codeficator.fullName || codeficator.settlement | translate }}
             </mat-option>
           </mat-autocomplete>
-        </mat-form-field>      
+        </mat-form-field>
       </ng-container>
       <label class="step-label"> {{ 'FORMS.LABELS.EMAIL' | translate }} <span class="step-required">*</span></label>
       <mat-form-field appearance="none">
@@ -125,7 +125,7 @@
     </div>
 
     <div fxLayout="row" fxLayoutAlign="center center" class="footer">
-      <button mat-raised-button class="btn btn-cancel" (click)="onBack()">{{ 'BUTTONS.CANCEL' | translate }}</button>
+      <button mat-raised-button class="btn btn-cancel" (click)="onCancel()">{{ 'BUTTONS.CANCEL' | translate }}</button>
       <button class="btn" mat-button type="submit" (click)="onSubmit()">{{ 'BUTTONS.SAVE' | translate }}</button>
     </div>
   </div>

--- a/src/app/shell/admin-tools/data/admins/create-admin/create-admin.component.ts
+++ b/src/app/shell/admin-tools/data/admins/create-admin/create-admin.component.ts
@@ -213,6 +213,7 @@ export class CreateAdminComponent extends CreateFormComponent implements OnInit,
   }
 
   public onBack(): void {
+    // TODO: Fix redirection when edit canceled onBack() and then confirm
     this.location.back();
   }
 
@@ -224,7 +225,7 @@ export class CreateAdminComponent extends CreateFormComponent implements OnInit,
       }
     });
 
-    dialogRef.afterClosed().pipe(filter((result: boolean)=>result)).subscribe(() => {      
+    dialogRef.afterClosed().pipe(filter((result: boolean)=>result)).subscribe(() => {
       this.saveAdmin();
     });
   }

--- a/src/app/shell/admin-tools/data/directions-wrapper/directions/create-direction/create-direction.component.html
+++ b/src/app/shell/admin-tools/data/directions-wrapper/directions/create-direction/create-direction.component.html
@@ -17,7 +17,7 @@
         <app-validation-hint [validationFormControl]="directionFormGroup.get('title')"></app-validation-hint>
 
         <div fxLayout="row" fxLayoutAlign="center center" class="footer">
-          <button mat-raised-button class="btn btn-cancel" (click)="onBack()">Скасувати</button>
+          <button mat-raised-button class="btn btn-cancel" (click)="onCancel()">Скасувати</button>
           <button [disabled]="directionFormGroup.invalid" class="btn" (click)="onSubmit()" mat-raised-button>Зберегти</button>
         </div>
       </form>

--- a/src/app/shell/admin-tools/data/directions-wrapper/directions/create-direction/create-direction.component.ts
+++ b/src/app/shell/admin-tools/data/directions-wrapper/directions/create-direction/create-direction.component.ts
@@ -54,7 +54,7 @@ export class CreateDirectionComponent extends CreateFormComponent implements OnI
 
   ngOnInit(): void {
     this.determineEditMode();
-    this.addNavPath(); // TODO: move this to abstract create-form component
+    this.addNavPath();
   }
 
   addNavPath(): void {

--- a/src/app/shell/admin-tools/data/directions-wrapper/directions/create-direction/create-direction.component.ts
+++ b/src/app/shell/admin-tools/data/directions-wrapper/directions/create-direction/create-direction.component.ts
@@ -78,6 +78,7 @@ export class CreateDirectionComponent extends CreateFormComponent implements OnI
   }
 
   onBack(): void {
+    // TODO: Fix redirection when edit canceled onBack() and then confirm
     this.location.back();
   }
 

--- a/src/app/shell/admin-tools/data/directions-wrapper/directions/create-direction/create-direction.component.ts
+++ b/src/app/shell/admin-tools/data/directions-wrapper/directions/create-direction/create-direction.component.ts
@@ -1,22 +1,22 @@
-import { CreateDirection, GetDirectionById, UpdateDirection } from './../../../../../../shared/store/admin.actions';
-import { takeUntil, filter } from 'rxjs/operators';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Select, Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
-import { Location } from '@angular/common';
-import { FormGroup, FormBuilder, FormControl, Validators } from '@angular/forms';
-import { MatDialog } from '@angular/material/dialog';
-import { ConfirmationModalWindowComponent } from '../../../../../../shared/components/confirmation-modal-window/confirmation-modal-window.component';
-import { Constants } from '../../../../../../shared/constants/constants';
-import { ModalConfirmationType } from '../../../../../../shared/enum/modal-confirmation';
-import { NavBarName } from '../../../../../../shared/enum/enumUA/navigation-bar';
-import { Direction } from '../../../../../../shared/models/category.model';
-import { NavigationBarService } from '../../../../../../shared/services/navigation-bar/navigation-bar.service';
-import { AdminState } from '../../../../../../shared/store/admin.state';
-import { AddNavPath } from '../../../../../../shared/store/navigation.actions';
+import { filter, takeUntil } from 'rxjs/operators';
+
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { Constants } from 'shared/constants/constants';
+import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { Direction } from 'shared/models/category.model';
+import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
+import { AdminState } from 'shared/store/admin.state';
+import { AddNavPath } from 'shared/store/navigation.actions';
 import { CreateFormComponent } from '../../../../../personal-cabinet/shared-cabinet/create-form/create-form.component';
+import { CreateDirection, GetDirectionById, UpdateDirection } from 'shared/store/admin.actions';
 
 @Component({
   selector: 'app-create-direction',
@@ -43,7 +43,7 @@ export class CreateDirectionComponent extends CreateFormComponent implements OnI
     protected navigationBarService: NavigationBarService,
     private fb: FormBuilder,
     private matDialog: MatDialog,
-    private location: Location,
+    private router: Router
   ) {
     super(store, route, navigationBarService);
     this.directionFormGroup = this.fb.group({
@@ -77,11 +77,6 @@ export class CreateDirectionComponent extends CreateFormComponent implements OnI
     );
   }
 
-  onBack(): void {
-    // TODO: Fix redirection when edit canceled onBack() and then confirm
-    this.location.back();
-  }
-
   setEditMode(): void {
     const directionId = +this.route.snapshot.paramMap.get('param');
     this.store.dispatch(new GetDirectionById(directionId));
@@ -111,5 +106,9 @@ export class CreateDirectionComponent extends CreateFormComponent implements OnI
         }
       });
     }
+  }
+
+  onCancel(): void {
+    this.router.navigate(['/admin-tools/data/directions']);
   }
 }

--- a/src/app/shell/admin-tools/platform/platform-info/info-edit/info-edit.component.html
+++ b/src/app/shell/admin-tools/platform/platform-info/info-edit/info-edit.component.html
@@ -36,7 +36,7 @@
     </div>
 
     <div fxLayout="row" fxLayoutAlign="center center" class="footer">
-      <button mat-raised-button class="btn btn-cancel" (click)="onBack()">{{ 'BUTTONS.CANCEL' | translate }}</button>
+      <button mat-raised-button class="btn btn-cancel" (click)="onCancel()">{{ 'BUTTONS.CANCEL' | translate }}</button>
       <button
         class="btn"
         mat-button

--- a/src/app/shell/admin-tools/platform/platform-info/info-edit/info-edit.component.ts
+++ b/src/app/shell/admin-tools/platform/platform-info/info-edit/info-edit.component.ts
@@ -144,6 +144,7 @@ export class InfoEditComponent extends CreateFormComponent implements OnInit, On
   }
 
   onBack(): void {
+    // TODO: Fix redirection when edit canceled onBack() and then confirm
     this.location.back();
   }
 

--- a/src/app/shell/admin-tools/platform/platform-info/info-edit/info-edit.component.ts
+++ b/src/app/shell/admin-tools/platform/platform-info/info-edit/info-edit.component.ts
@@ -1,20 +1,20 @@
-import { ActivatedRoute, Params } from '@angular/router';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Select, Store } from '@ngxs/store';
-import { filter, takeUntil, tap } from 'rxjs/operators';
-import { AdminTabsTitles } from './../../../../../shared/enum/enumUA/tech-admin/admin-tabs';
-import { Location } from '@angular/common';
 import { Observable } from 'rxjs';
-import { ValidationConstants } from '../../../../../shared/constants/validation';
-import { NavBarName } from '../../../../../shared/enum/enumUA/navigation-bar';
-import { CompanyInformation, CompanyInformationSectionItem } from '../../../../../shared/models/сompanyInformation.model';
-import { NavigationBarService } from '../../../../../shared/services/navigation-bar/navigation-bar.service';
-import { UpdatePlatformInfo, GetPlatformInfo } from '../../../../../shared/store/admin.actions';
-import { AdminState } from '../../../../../shared/store/admin.state';
-import { AddNavPath } from '../../../../../shared/store/navigation.actions';
+import { filter, takeUntil, tap } from 'rxjs/operators';
+
+import { ValidationConstants } from 'shared/constants/validation';
+import { AdminTabTypes } from 'shared/enum/admins';
+import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
+import { AdminTabsTitles } from 'shared/enum/enumUA/tech-admin/admin-tabs';
+import { CompanyInformation, CompanyInformationSectionItem } from 'shared/models/сompanyInformation.model';
+import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
+import { GetPlatformInfo, UpdatePlatformInfo } from 'shared/store/admin.actions';
+import { AdminState } from 'shared/store/admin.state';
+import { AddNavPath } from 'shared/store/navigation.actions';
 import { CreateFormComponent } from '../../../../personal-cabinet/shared-cabinet/create-form/create-form.component';
-import { AdminTabTypes } from '../../../../../shared/enum/admins';
 
 @Component({
   selector: 'app-info-edit',
@@ -47,7 +47,7 @@ export class InfoEditComponent extends CreateFormComponent implements OnInit, On
     protected route: ActivatedRoute,
     protected navigationBarService: NavigationBarService,
     private fb: FormBuilder,
-    private location: Location
+    private router: Router
   ) {
     super(store, route, navigationBarService);
   }
@@ -77,7 +77,7 @@ export class InfoEditComponent extends CreateFormComponent implements OnInit, On
             isActive: false,
             disable: false
           },
-          { name: `Редагувати інфомацію "${NavBarName[this.platformInfoType]}"`, isActive: false, disable: true }
+          { name: `Редагувати інформацію "${NavBarName[this.platformInfoType]}"`, isActive: false, disable: true }
         )
       )
     );
@@ -143,9 +143,8 @@ export class InfoEditComponent extends CreateFormComponent implements OnInit, On
     this.PlatformInfoItemArray.removeAt(index);
   }
 
-  onBack(): void {
-    // TODO: Fix redirection when edit canceled onBack() and then confirm
-    this.location.back();
+  onCancel(): void {
+    this.router.navigate(['/admin-tools/platform']);
   }
 
   onSubmit(): void {

--- a/src/app/shell/personal-cabinet/parent/create-child/create-child.component.ts
+++ b/src/app/shell/personal-cabinet/parent/create-child/create-child.component.ts
@@ -221,6 +221,7 @@ export class CreateChildComponent extends CreateFormComponent implements OnInit,
    * This method navigate back
    */
   onCancel(): void {
+    // TODO: Fix redirection when edit canceled onBack() and then confirm
     this.location.back();
   }
 

--- a/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.html
@@ -143,7 +143,7 @@
       </form>
     </div>
     <div fxLayout="row" fxLayoutAlign="center center" class="footer">
-      <button class="btn btn-cancel" mat-raised-button (click)="onBack()">{{ 'BUTTONS.CANCEL' | translate }}</button>
+      <button class="btn btn-cancel" mat-raised-button (click)="onCancel()">{{ 'BUTTONS.CANCEL' | translate }}</button>
       <button class="btn" mat-button type="submit" (click)="onSubmit()" [disabled]="AchievementFormGroup.invalid">
         {{ 'BUTTONS.SAVE' | translate }}
       </button>

--- a/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.ts
@@ -1,39 +1,34 @@
-import { ProviderState } from './../../../../shared/store/provider.state';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Observable, Subject, combineLatest } from 'rxjs';
-import { ActivatedRoute } from '@angular/router';
-import { filter, takeUntil } from 'rxjs/operators';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
-import { Select, Store } from '@ngxs/store';
 import { MatDialog } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Select, Store } from '@ngxs/store';
+import { combineLatest, Observable, Subject } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
+
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { Constants } from 'shared/constants/constants';
+import { ValidationConstants } from 'shared/constants/validation';
+import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { Role } from 'shared/enum/role';
+import { Achievement, AchievementType } from 'shared/models/achievement.model';
+import { Child } from 'shared/models/child.model';
+import { Navigation } from 'shared/models/navigation.model';
+import { SearchResponse } from 'shared/models/search.model';
+import { Person } from 'shared/models/user.model';
+import { Workshop } from 'shared/models/workshop.model';
+import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
+import { GetAchievementsType } from 'shared/store/meta-data.actions';
+import { MetaDataState } from 'shared/store/meta-data.state';
+import { AddNavPath } from 'shared/store/navigation.actions';
+import { CreateAchievement, GetAchievementById, GetChildrenByWorkshopId, UpdateAchievement } from 'shared/store/provider.actions';
+import { ProviderState } from 'shared/store/provider.state';
+import { RegistrationState } from 'shared/store/registration.state';
+import { GetWorkshopById, ResetProviderWorkshopDetails } from 'shared/store/shared-user.actions';
+import { SharedUserState } from 'shared/store/shared-user.state';
+import { Util } from 'shared/utils/utils';
 import { CreateFormComponent } from '../../shared-cabinet/create-form/create-form.component';
-import { Location } from '@angular/common';
-import {
-  CreateAchievement,
-  GetAchievementById,
-  GetChildrenByWorkshopId,
-  UpdateAchievement
-} from './../../../../shared/store/provider.actions';
-import { ConfirmationModalWindowComponent } from '../../../../shared/components/confirmation-modal-window/confirmation-modal-window.component';
-import { Constants } from '../../../../shared/constants/constants';
-import { ValidationConstants } from '../../../../shared/constants/validation';
-import { ModalConfirmationType } from '../../../../shared/enum/modal-confirmation';
-import { NavBarName } from '../../../../shared/enum/enumUA/navigation-bar';
-import { Role } from '../../../../shared/enum/role';
-import { Achievement, AchievementType } from '../../../../shared/models/achievement.model';
-import { Person } from '../../../../shared/models/user.model';
-import { Workshop } from '../../../../shared/models/workshop.model';
-import { NavigationBarService } from '../../../../shared/services/navigation-bar/navigation-bar.service';
-import { GetAchievementsType } from '../../../../shared/store/meta-data.actions';
-import { MetaDataState } from '../../../../shared/store/meta-data.state';
-import { AddNavPath } from '../../../../shared/store/navigation.actions';
-import { RegistrationState } from '../../../../shared/store/registration.state';
-import { GetWorkshopById, ResetProviderWorkshopDetails } from '../../../../shared/store/shared-user.actions';
-import { SharedUserState } from '../../../../shared/store/shared-user.state';
-import { Util } from '../../../../shared/utils/utils';
-import { Navigation } from '../../../../shared/models/navigation.model';
-import { SearchResponse } from '../../../../shared/models/search.model';
-import { Child } from '../../../../shared/models/child.model';
 
 @Component({
   selector: 'app-create-achievement',
@@ -77,8 +72,7 @@ export class CreateAchievementComponent extends CreateFormComponent implements O
     protected navigationBarService: NavigationBarService,
     private formBuilder: FormBuilder,
     private matDialog: MatDialog,
-    private location: Location,
-    private routeParams: ActivatedRoute
+    private router: Router
   ) {
     super(store, route, navigationBarService);
     this.AchievementFormGroup = this.formBuilder.group({
@@ -101,7 +95,7 @@ export class CreateAchievementComponent extends CreateFormComponent implements O
   }
 
   determineEditMode(): void {
-    this.achievementId = this.routeParams.snapshot.queryParams['achievementId'];
+    this.achievementId = this.route.snapshot.paramMap.get('achievementId');
     this.editMode = !!this.achievementId;
     if (this.editMode) {
       this.setEditMode();
@@ -173,11 +167,6 @@ export class CreateAchievementComponent extends CreateFormComponent implements O
     );
   }
 
-  onBack(): void {
-    // TODO: Fix redirection when edit canceled onBack() and then confirm
-    this.location.back();
-  }
-
   onSubmit(): void {
     if (this.editMode) {
       const achievement = new Achievement(this.AchievementFormGroup.getRawValue(), this.workshopId, this.achievement);
@@ -199,6 +188,10 @@ export class CreateAchievementComponent extends CreateFormComponent implements O
         this.store.dispatch(new CreateAchievement(achievement));
       }
     });
+  }
+
+  onCancel(): void {
+    this.router.navigate(['/details/workshop', this.workshopId], { queryParams: { status: 'Achievements' } });
   }
 
   onRemoveItem(item: string, control: string): void {

--- a/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.ts
@@ -174,6 +174,7 @@ export class CreateAchievementComponent extends CreateFormComponent implements O
   }
 
   onBack(): void {
+    // TODO: Fix redirection when edit canceled onBack() and then confirm
     this.location.back();
   }
 

--- a/src/app/shell/personal-cabinet/provider/create-provider-admin/create-provider-admin.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-provider-admin/create-provider-admin.component.html
@@ -128,7 +128,7 @@
 
         <div fxLayout="row" fxLayoutAlign="center center" class="footer">
           <button class="btn" mat-raised-button matStepperPrevious>{{ 'BUTTONS.BACK' | translate }}</button>
-          <button mat-raised-button class="btn btn-cancel" (click)="onBack()">
+          <button mat-raised-button class="btn btn-cancel" (click)="onCancel()">
             {{ 'BUTTONS.CANCEL' | translate }}
           </button>
           <button class="btn" mat-button type="submit" [disabled]="!isDeputy && !managedWorkshopIds" (click)="onSubmit()">

--- a/src/app/shell/personal-cabinet/provider/create-provider-admin/create-provider-admin.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-provider-admin/create-provider-admin.component.ts
@@ -177,6 +177,7 @@ export class CreateProviderAdminComponent extends CreateFormComponent implements
   }
 
   public onBack(): void {
+    // TODO: Fix redirection when edit canceled onBack() and then confirm
     this.location.back();
   }
 

--- a/src/app/shell/personal-cabinet/provider/create-provider-admin/create-provider-admin.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-provider-admin/create-provider-admin.component.ts
@@ -1,40 +1,30 @@
-import { combineLatest, Observable } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, take, takeUntil } from 'rxjs/operators';
-
-import { Location } from '@angular/common';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Select, Store } from '@ngxs/store';
+import { combineLatest, Observable } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
-import {
-  ConfirmationModalWindowComponent
-} from '../../../../shared/components/confirmation-modal-window/confirmation-modal-window.component';
-import { Constants } from '../../../../shared/constants/constants';
-import { NAME_REGEX } from '../../../../shared/constants/regex-constants';
-import { ValidationConstants } from '../../../../shared/constants/validation';
-import { WorkshopDeclination } from '../../../../shared/enum/enumUA/declinations/declination';
-import { NavBarName } from '../../../../shared/enum/enumUA/navigation-bar';
-import {
-  ProviderAdminsFormTitlesEdit, ProviderAdminsFormTitlesNew
-} from '../../../../shared/enum/enumUA/provider-admin';
-import { ModalConfirmationType } from '../../../../shared/enum/modal-confirmation';
-import { ProviderAdminRole } from '../../../../shared/enum/provider-admin';
-import { Role } from '../../../../shared/enum/role';
-import { TruncatedItem } from '../../../../shared/models/item.model';
-import { Provider } from '../../../../shared/models/provider.model';
-import { ProviderAdmin } from '../../../../shared/models/providerAdmin.model';
-import {
-  NavigationBarService
-} from '../../../../shared/services/navigation-bar/navigation-bar.service';
-import { AddNavPath } from '../../../../shared/store/navigation.actions';
-import {
-  CreateProviderAdmin, GetProviderAdminById, GetWorkshopListByProviderId, UpdateProviderAdmin
-} from '../../../../shared/store/provider.actions';
-import { ProviderState } from '../../../../shared/store/provider.state';
-import { RegistrationState } from '../../../../shared/store/registration.state';
-import { Util } from '../../../../shared/utils/utils';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { Constants } from 'shared/constants/constants';
+import { NAME_REGEX } from 'shared/constants/regex-constants';
+import { ValidationConstants } from 'shared/constants/validation';
+import { WorkshopDeclination } from 'shared/enum/enumUA/declinations/declination';
+import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
+import { ProviderAdminsFormTitlesEdit, ProviderAdminsFormTitlesNew } from 'shared/enum/enumUA/provider-admin';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { ProviderAdminRole } from 'shared/enum/provider-admin';
+import { Role } from 'shared/enum/role';
+import { TruncatedItem } from 'shared/models/item.model';
+import { Provider } from 'shared/models/provider.model';
+import { ProviderAdmin } from 'shared/models/providerAdmin.model';
+import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
+import { AddNavPath } from 'shared/store/navigation.actions';
+import { CreateProviderAdmin, GetProviderAdminById, GetWorkshopListByProviderId, UpdateProviderAdmin } from 'shared/store/provider.actions';
+import { ProviderState } from 'shared/store/provider.state';
+import { RegistrationState } from 'shared/store/registration.state';
+import { Util } from 'shared/utils/utils';
 import { CreateFormComponent } from '../../shared-cabinet/create-form/create-form.component';
 
 const defaultValidators: ValidatorFn[] = [
@@ -78,7 +68,7 @@ export class CreateProviderAdminComponent extends CreateFormComponent implements
     protected navigationBarService: NavigationBarService,
     private formBuilder: FormBuilder,
     private matDialog: MatDialog,
-    private location: Location
+    private router: Router
   ) {
     super(store, route, navigationBarService);
 
@@ -142,9 +132,9 @@ export class CreateProviderAdminComponent extends CreateFormComponent implements
     let navBarTitle: string;
 
     if (this.editMode) {
-      this.isDeputy ? (navBarTitle = NavBarName.UpdateProviderDeputy) : (navBarTitle = NavBarName.UpdateProviderAdmin);
+      navBarTitle = this.isDeputy ? NavBarName.UpdateProviderDeputy : NavBarName.UpdateProviderAdmin;
     } else {
-      this.isDeputy ? (navBarTitle = NavBarName.CreateProviderDeputy) : (navBarTitle = NavBarName.CreateProviderAdmin);
+      navBarTitle = this.isDeputy ? NavBarName.CreateProviderDeputy : NavBarName.CreateProviderAdmin;
     }
 
     this.store.dispatch(
@@ -176,22 +166,13 @@ export class CreateProviderAdminComponent extends CreateFormComponent implements
     });
   }
 
-  public onBack(): void {
-    // TODO: Fix redirection when edit canceled onBack() and then confirm
-    this.location.back();
-  }
-
   public onSubmit(): void {
     let confirmationType: string;
 
     if (this.editMode) {
-      this.isDeputy
-        ? (confirmationType = ModalConfirmationType.updateProviderAdminDeputy)
-        : (confirmationType = ModalConfirmationType.updateProviderAdmin);
+      confirmationType = this.isDeputy ? ModalConfirmationType.updateProviderAdminDeputy : ModalConfirmationType.updateProviderAdmin;
     } else {
-      this.isDeputy
-        ? (confirmationType = ModalConfirmationType.createProviderAdminDeputy)
-        : (confirmationType = ModalConfirmationType.createProviderAdmin);
+      confirmationType = this.isDeputy ? ModalConfirmationType.createProviderAdminDeputy : ModalConfirmationType.createProviderAdmin;
     }
 
     const dialogRef = this.matDialog.open(ConfirmationModalWindowComponent, {
@@ -215,5 +196,9 @@ export class CreateProviderAdminComponent extends CreateFormComponent implements
         );
       }
     });
+  }
+
+  public onCancel(): void {
+    this.router.navigate(['/personal-cabinet/provider/administration']);
   }
 }

--- a/src/app/shell/personal-cabinet/provider/create-provider/create-provider.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-provider/create-provider.component.ts
@@ -1,36 +1,29 @@
-import { takeUntil } from 'rxjs/operators';
-
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
-import {
-  AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild
-} from '@angular/core';
+import { AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatStepper } from '@angular/material/stepper';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Store } from '@ngxs/store';
+import { takeUntil } from 'rxjs/operators';
 
-import {
-  ConfirmationModalWindowComponent
-} from '../../../../shared/components/confirmation-modal-window/confirmation-modal-window.component';
-import { Constants } from '../../../../shared/constants/constants';
-import { NavBarName } from '../../../../shared/enum/enumUA/navigation-bar';
-import { ModalConfirmationType } from '../../../../shared/enum/modal-confirmation';
-import { CreateProviderSteps } from '../../../../shared/enum/provider';
-import { Role } from '../../../../shared/enum/role';
-import { Address } from '../../../../shared/models/address.model';
-import { FeaturesList } from '../../../../shared/models/featuresList.model';
-import { Provider } from '../../../../shared/models/provider.model';
-import { User } from '../../../../shared/models/user.model';
-import {
-  NavigationBarService
-} from '../../../../shared/services/navigation-bar/navigation-bar.service';
-import { MetaDataState } from '../../../../shared/store/meta-data.state';
-import { AddNavPath } from '../../../../shared/store/navigation.actions';
-import { CreateProvider, UpdateProvider } from '../../../../shared/store/provider.actions';
-import { Logout } from '../../../../shared/store/registration.actions';
-import { RegistrationState } from '../../../../shared/store/registration.state';
-import { Util } from '../../../../shared/utils/utils';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { Constants } from 'shared/constants/constants';
+import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { CreateProviderSteps } from 'shared/enum/provider';
+import { Role } from 'shared/enum/role';
+import { Address } from 'shared/models/address.model';
+import { FeaturesList } from 'shared/models/featuresList.model';
+import { Provider } from 'shared/models/provider.model';
+import { User } from 'shared/models/user.model';
+import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
+import { MetaDataState } from 'shared/store/meta-data.state';
+import { AddNavPath } from 'shared/store/navigation.actions';
+import { CreateProvider, UpdateProvider } from 'shared/store/provider.actions';
+import { Logout } from 'shared/store/registration.actions';
+import { RegistrationState } from 'shared/store/registration.state';
+import { Util } from 'shared/utils/utils';
 import { CreateFormComponent } from '../../shared-cabinet/create-form/create-form.component';
 
 @Component({
@@ -124,20 +117,20 @@ export class CreateProviderComponent extends CreateFormComponent implements OnIn
       const user: User = this.store.selectSnapshot<User>(RegistrationState.user);
       this.isImagesFeature = this.store.selectSnapshot<FeaturesList>(MetaDataState.featuresList).images;
       let legalAddress: Address;
-      let actulaAdress: Address;
+      let actualAddress: Address;
       let provider: Provider;
 
       if (this.editMode) {
         legalAddress = new Address(this.LegalAddressFormGroup.value, this.provider.legalAddress);
-        actulaAdress = this.ActualAddressFormGroup.disabled
+        actualAddress = this.ActualAddressFormGroup.disabled
           ? null
           : new Address(this.ActualAddressFormGroup.value, this.provider.actualAddress);
-        provider = new Provider(this.InfoFormGroup.value, legalAddress, actulaAdress, this.PhotoFormGroup.value, user, this.provider);
+        provider = new Provider(this.InfoFormGroup.value, legalAddress, actualAddress, this.PhotoFormGroup.value, user, this.provider);
         this.store.dispatch(new UpdateProvider(provider, this.isImagesFeature));
       } else {
         legalAddress = new Address(this.LegalAddressFormGroup.value);
-        actulaAdress = this.ActualAddressFormGroup.disabled ? null : new Address(this.ActualAddressFormGroup.value);
-        provider = new Provider(this.InfoFormGroup.value, legalAddress, actulaAdress, this.PhotoFormGroup.value, user);
+        actualAddress = this.ActualAddressFormGroup.disabled ? null : new Address(this.ActualAddressFormGroup.value);
+        provider = new Provider(this.InfoFormGroup.value, legalAddress, actualAddress, this.PhotoFormGroup.value, user);
         this.store.dispatch(new CreateProvider(provider, this.isImagesFeature));
       }
     }
@@ -169,7 +162,7 @@ export class CreateProviderComponent extends CreateFormComponent implements OnIn
   }
 
   /**
-   * This method receives a from from create-photo child component and assigns to the Info FormGroup
+   * This method receives a form from create-photo child component and assigns to the Info FormGroup
    * @param FormGroup form
    */
   public onReceivePhotoFormGroup(form: FormGroup): void {

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.html
@@ -25,9 +25,9 @@
             (PassAboutFormGroup)="onReceiveAboutFormGroup($event)">
           </app-create-about-form>
           <div fxLayout="row" fxLayoutAlign="center center" class="footer">
-            <a [routerLink]="'/personal-cabinet/provider/workshops'"
-              ><button mat-raised-button class="btn btn-cancel">{{ 'BUTTONS.CANCEL' | translate }}</button></a
-            >
+            <button class="btn btn-cancel" mat-raised-button (click)="onCancel()">
+              {{ 'BUTTONS.CANCEL' | translate }}
+            </button>
             <button class="btn" mat-raised-button matStepperNext [disabled]="AboutFormGroup.invalid">
               {{ 'BUTTONS.NEXT' | translate }}
             </button>
@@ -47,10 +47,12 @@
             (passDescriptionFormGroup)="onReceiveDescriptionFormGroup($event)">
           </app-create-description-form>
           <div fxLayout="row" fxLayoutAlign="center center" class="footer">
-            <button class="btn" mat-raised-button matStepperPrevious>{{ 'BUTTONS.BACK' | translate }}</button>
-            <a [routerLink]="'/personal-cabinet/provider/workshops'"
-              ><button mat-raised-button class="btn btn-cancel">{{ 'BUTTONS.CANCEL' | translate }}</button></a
-            >
+            <button class="btn" mat-raised-button matStepperPrevious>
+              {{ 'BUTTONS.BACK' | translate }}
+            </button>
+            <button class="btn btn-cancel" mat-raised-button (click)="onCancel()">
+              {{ 'BUTTONS.CANCEL' | translate }}
+            </button>
             <button class="btn" mat-raised-button matStepperNext [disabled]="DescriptionFormGroup?.invalid">
               {{ 'BUTTONS.NEXT' | translate }}
             </button>
@@ -66,10 +68,12 @@
           <app-create-workshop-address [address]="workshop?.address" (passAddressFormGroup)="onReceiveAddressFormGroup($event)">
           </app-create-workshop-address>
           <div fxLayout="row" fxLayoutAlign="center center" class="footer">
-            <button class="btn" mat-raised-button matStepperPrevious>{{ 'BUTTONS.BACK' | translate }}</button>
-            <a [routerLink]="'/personal-cabinet/provider/workshops'"
-              ><button mat-raised-button class="btn btn-cancel">{{ 'BUTTONS.CANCEL' | translate }}</button></a
-            >
+            <button class="btn" mat-raised-button matStepperPrevious>
+              {{ 'BUTTONS.BACK' | translate }}
+            </button>
+            <button class="btn btn-cancel" mat-raised-button (click)="onCancel()">
+              {{ 'BUTTONS.CANCEL' | translate }}
+            </button>
             <button class="btn" mat-raised-button matStepperNext [disabled]="AddressFormGroup?.invalid">
               {{ 'BUTTONS.NEXT' | translate }}
             </button>
@@ -89,10 +93,12 @@
           </app-create-teacher>
 
           <div fxLayout="row" fxLayoutAlign="center center" class="footer">
-            <button class="btn" mat-raised-button matStepperPrevious>{{ 'BUTTONS.BACK' | translate }}</button>
-            <a [routerLink]="'/personal-cabinet/provider/workshops'"
-              ><button mat-raised-button class="btn btn-cancel">{{ 'BUTTONS.CANCEL' | translate }}</button></a
-            >
+            <button class="btn" mat-raised-button matStepperPrevious>
+              {{ 'BUTTONS.BACK' | translate }}
+            </button>
+            <button class="btn btn-cancel" mat-raised-button (click)="onCancel()">
+              {{ 'BUTTONS.CANCEL' | translate }}
+            </button>
             <button
               [disabled]="(isLoading$ | async) || TeacherFormArray?.invalid"
               class="btn"

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
@@ -1,24 +1,25 @@
-import { GetWorkshopById, ResetProviderWorkshopDetails } from '../../../../shared/store/shared-user.actions';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormArray, FormGroup } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Select, Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
+
+import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
+import { Role } from 'shared/enum/role';
+import { Address } from 'shared/models/address.model';
+import { Provider } from 'shared/models/provider.model';
+import { Teacher } from 'shared/models/teacher.model';
+import { Workshop } from 'shared/models/workshop.model';
+import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
+import { AddNavPath } from 'shared/store/navigation.actions';
+import { CreateWorkshop, UpdateWorkshop } from 'shared/store/provider.actions';
+import { RegistrationState } from 'shared/store/registration.state';
+import { GetWorkshopById, ResetProviderWorkshopDetails } from 'shared/store/shared-user.actions';
+import { SharedUserState } from 'shared/store/shared-user.state';
+import { Util } from 'shared/utils/utils';
 import { CreateFormComponent } from '../../shared-cabinet/create-form/create-form.component';
-import { NavBarName } from '../../../../shared/enum/enumUA/navigation-bar';
-import { Role } from '../../../../shared/enum/role';
-import { Address } from '../../../../shared/models/address.model';
-import { Teacher } from '../../../../shared/models/teacher.model';
-import { Workshop } from '../../../../shared/models/workshop.model';
-import { NavigationBarService } from '../../../../shared/services/navigation-bar/navigation-bar.service';
-import { AddNavPath } from '../../../../shared/store/navigation.actions';
-import { UpdateWorkshop, CreateWorkshop } from '../../../../shared/store/provider.actions';
-import { RegistrationState } from '../../../../shared/store/registration.state';
-import { SharedUserState } from '../../../../shared/store/shared-user.state';
-import { Util } from '../../../../shared/utils/utils';
-import { Provider } from '../../../../shared/models/provider.model';
 
 @Component({
   selector: 'app-create-workshop',
@@ -27,9 +28,9 @@ import { Provider } from '../../../../shared/models/provider.model';
   providers: [
     {
       provide: STEPPER_GLOBAL_OPTIONS,
-      useValue: { displayDefaultIndicatorType: false },
-    },
-  ],
+      useValue: { displayDefaultIndicatorType: false }
+    }
+  ]
 })
 export class CreateWorkshopComponent extends CreateFormComponent implements OnInit, OnDestroy {
   @Select(RegistrationState.provider)
@@ -48,7 +49,8 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
   constructor(
     protected store: Store,
     protected route: ActivatedRoute,
-    protected navigationBarService: NavigationBarService
+    protected navigationBarService: NavigationBarService,
+    private router: Router
   ) {
     super(store, route, navigationBarService);
   }
@@ -77,12 +79,12 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
             name: personalCabinetTitle,
             path: '/personal-cabinet/provider/administration',
             isActive: false,
-            disable: false,
+            disable: false
           },
           {
             name: this.editMode ? NavBarName.EditWorkshop : NavBarName.NewWorkshop,
             isActive: false,
-            disable: true,
+            disable: true
           }
         )
       )
@@ -141,7 +143,7 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
   }
 
   /**
-   * This method receives  a from form create-about child component and assigns to the About FormGroup
+   * This method receives a form from create-about child component and assigns to the About FormGroup
    * @param FormGroup form
    */
   onReceiveAboutFormGroup(form: FormGroup): void {
@@ -156,6 +158,10 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
   onReceiveDescriptionFormGroup(form: FormGroup): void {
     this.DescriptionFormGroup = form;
     this.subscribeOnDirtyForm(form);
+  }
+
+  onCancel(): void {
+    this.router.navigate(['/personal-cabinet/provider/workshops']);
   }
 
   /**

--- a/src/app/shell/personal-cabinet/shared-cabinet/create-form/create-form.component.ts
+++ b/src/app/shell/personal-cabinet/shared-cabinet/create-form/create-form.component.ts
@@ -1,21 +1,18 @@
-import { Observable, Subject } from 'rxjs';
-import { takeWhile } from 'rxjs/operators';
-
 import { Component, EventEmitter, OnDestroy, OnInit } from '@angular/core';
 import { FormArray, FormGroup } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { Select, Store } from '@ngxs/store';
+import { Observable, Subject } from 'rxjs';
+import { takeWhile } from 'rxjs/operators';
 
-import { ModeConstants } from '../../../../shared/constants/constants';
-import { FeaturesList } from '../../../../shared/models/featuresList.model';
-import {
-  NavigationBarService
-} from '../../../../shared/services/navigation-bar/navigation-bar.service';
-import { MarkFormDirty } from '../../../../shared/store/app.actions';
-import { AppState } from '../../../../shared/store/app.state';
-import { MetaDataState } from '../../../../shared/store/meta-data.state';
-import { DeleteNavPath } from '../../../../shared/store/navigation.actions';
-import { SharedUserState } from '../../../../shared/store/shared-user.state';
+import { ModeConstants } from 'shared/constants/constants';
+import { FeaturesList } from 'shared/models/featuresList.model';
+import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
+import { MarkFormDirty } from 'shared/store/app.actions';
+import { AppState } from 'shared/store/app.state';
+import { MetaDataState } from 'shared/store/meta-data.state';
+import { DeleteNavPath } from 'shared/store/navigation.actions';
+import { SharedUserState } from 'shared/store/shared-user.state';
 
 @Component({
   selector: 'app-create-form',
@@ -40,6 +37,8 @@ export abstract class CreateFormComponent implements OnInit, OnDestroy {
 
   public abstract setEditMode(): void;
   public abstract addNavPath(): void;
+  public abstract onSubmit(): void;
+  public abstract onCancel(): void;
 
   protected determineRelease(): void {
     this.featuresList$

--- a/src/app/shell/personal-cabinet/shared-cabinet/user-config/user-config-edit/user-config-edit.component.ts
+++ b/src/app/shell/personal-cabinet/shared-cabinet/user-config/user-config-edit/user-config-edit.component.ts
@@ -1,13 +1,11 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Select, Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
-
-import { Location } from '@angular/common';
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import {
-  AbstractControl, FormBuilder, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators
-} from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
-import { Select, Store } from '@ngxs/store';
+import { Navigation } from 'shared/models/navigation.model';
+import { NavigationState } from 'shared/store/navigation.state';
 
 import { Constants } from '../../../../../shared/constants/constants';
 import { NAME_REGEX } from '../../../../../shared/constants/regex-constants';
@@ -15,9 +13,7 @@ import { ValidationConstants } from '../../../../../shared/constants/validation'
 import { NavBarName } from '../../../../../shared/enum/enumUA/navigation-bar';
 import { Role } from '../../../../../shared/enum/role';
 import { User } from '../../../../../shared/models/user.model';
-import {
-  NavigationBarService
-} from '../../../../../shared/services/navigation-bar/navigation-bar.service';
+import { NavigationBarService } from '../../../../../shared/services/navigation-bar/navigation-bar.service';
 import { AddNavPath, DeleteNavPath } from '../../../../../shared/store/navigation.actions';
 import { UpdateUser } from '../../../../../shared/store/registration.actions';
 import { RegistrationState } from '../../../../../shared/store/registration.state';
@@ -33,6 +29,9 @@ export class UserConfigEditComponent extends CreateFormComponent implements OnIn
   public readonly role = Role;
   public readonly validationConstants = ValidationConstants;
   public readonly phonePrefix = Constants.PHONE_PREFIX;
+
+  @Select(NavigationState.navigationPaths)
+  private navigationPaths$: Observable<Navigation[]>;
 
   @Select(RegistrationState.user)
   private user$: Observable<User>;
@@ -50,7 +49,7 @@ export class UserConfigEditComponent extends CreateFormComponent implements OnIn
     protected store: Store,
     protected navigationBarService: NavigationBarService,
     private fb: FormBuilder,
-    private location: Location
+    private router: Router
   ) {
     super(store, route, navigationBarService);
 
@@ -124,6 +123,11 @@ export class UserConfigEditComponent extends CreateFormComponent implements OnIn
   }
 
   public onCancel(): void {
-    this.location.back();
+    this.navigationPaths$
+      .subscribe((value) => {
+        const path = value[value.length - 2].path ?? '/personal-cabinet/config';
+        this.router.navigate([path]);
+      })
+      .unsubscribe();
   }
 }

--- a/src/app/shell/personal-cabinet/shared-cabinet/user-config/user-config-edit/user-config-edit.component.ts
+++ b/src/app/shell/personal-cabinet/shared-cabinet/user-config/user-config-edit/user-config-edit.component.ts
@@ -4,20 +4,18 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Select, Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import { Navigation } from 'shared/models/navigation.model';
-import { NavigationState } from 'shared/store/navigation.state';
 
-import { Constants } from '../../../../../shared/constants/constants';
-import { NAME_REGEX } from '../../../../../shared/constants/regex-constants';
-import { ValidationConstants } from '../../../../../shared/constants/validation';
-import { NavBarName } from '../../../../../shared/enum/enumUA/navigation-bar';
-import { Role } from '../../../../../shared/enum/role';
-import { User } from '../../../../../shared/models/user.model';
-import { NavigationBarService } from '../../../../../shared/services/navigation-bar/navigation-bar.service';
-import { AddNavPath, DeleteNavPath } from '../../../../../shared/store/navigation.actions';
-import { UpdateUser } from '../../../../../shared/store/registration.actions';
-import { RegistrationState } from '../../../../../shared/store/registration.state';
-import { Util } from '../../../../../shared/utils/utils';
+import { Constants } from 'shared/constants/constants';
+import { NAME_REGEX } from 'shared/constants/regex-constants';
+import { ValidationConstants } from 'shared/constants/validation';
+import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
+import { Role } from 'shared/enum/role';
+import { User } from 'shared/models/user.model';
+import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
+import { AddNavPath, DeleteNavPath } from 'shared/store/navigation.actions';
+import { UpdateUser } from 'shared/store/registration.actions';
+import { RegistrationState } from 'shared/store/registration.state';
+import { Util } from 'shared/utils/utils';
 import { CreateFormComponent } from '../../create-form/create-form.component';
 
 @Component({
@@ -29,9 +27,6 @@ export class UserConfigEditComponent extends CreateFormComponent implements OnIn
   public readonly role = Role;
   public readonly validationConstants = ValidationConstants;
   public readonly phonePrefix = Constants.PHONE_PREFIX;
-
-  @Select(NavigationState.navigationPaths)
-  private navigationPaths$: Observable<Navigation[]>;
 
   @Select(RegistrationState.user)
   private user$: Observable<User>;
@@ -71,7 +66,10 @@ export class UserConfigEditComponent extends CreateFormComponent implements OnIn
         Validators.minLength(ValidationConstants.INPUT_LENGTH_1),
         Validators.maxLength(ValidationConstants.INPUT_LENGTH_60)
       ]),
-      phoneNumber: new FormControl('', [Validators.required, Validators.minLength(ValidationConstants.PHONE_LENGTH)])
+      phoneNumber: new FormControl('', [
+        Validators.required,
+        Validators.minLength(ValidationConstants.PHONE_LENGTH)
+      ])
     });
   }
 
@@ -123,11 +121,6 @@ export class UserConfigEditComponent extends CreateFormComponent implements OnIn
   }
 
   public onCancel(): void {
-    this.navigationPaths$
-      .subscribe((value) => {
-        const path = value[value.length - 2].path ?? '/personal-cabinet/config';
-        this.router.navigate([path]);
-      })
-      .unsubscribe();
+    this.router.navigate(['../'], { relativeTo: this.route });
   }
 }


### PR DESCRIPTION
#2127 

Bug is caused by using `this.location.back()` in components with such edit/create forms and with CreateGuard.
The reason is that `location` navigates through navigation story regardless of CreateGuard approach. So, if user will change some info in such forms, try to cancel, reject canceling and then trying to cancel once more and then confirm canceling, navigation tree will be shifted as times as user rejected cancel.