### PR TITLE
fix console errors on the map page

### DIFF
--- a/src/app/shared/components/filters-list/city-filter/city-filter.component.ts
+++ b/src/app/shared/components/filters-list/city-filter/city-filter.component.ts
@@ -1,7 +1,7 @@
 import { Observable, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, takeUntil } from 'rxjs/operators';
 
-import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { MatAutocomplete, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { Actions, ofActionCompleted, Select, Store } from '@ngxs/store';
@@ -20,7 +20,7 @@ import { MetaDataState } from '../../../store/meta-data.state';
   templateUrl: './city-filter.component.html',
   styleUrls: ['./city-filter.component.scss']
 })
-export class CityFilterComponent implements OnInit, AfterViewInit, OnDestroy {
+export class CityFilterComponent implements OnInit, OnDestroy {
   public readonly Constants = Constants;
   public readonly sliceLength = 25;
 
@@ -65,22 +65,8 @@ export class CityFilterComponent implements OnInit, AfterViewInit, OnDestroy {
         this.codeficatorSearch = searchResult;
       }
     });
-  }
 
-  public ngAfterViewInit(): void {
-    if (this.geolocationService.isCityInStorage()) {
-      this.geolocationService.confirmCity(JSON.parse(localStorage.getItem('cityConfirmation')), true);
-    } else {
-      this.geolocationService.handleUserLocation((coords: Coords) => {
-        if (coords) {
-          this.geolocationService.getNearestByCoordinates(coords, (result: Codeficator) => {
-            this.geolocationService.confirmCity(result, false);
-          });
-        } else {
-          this.geolocationService.confirmCity(Constants.KYIV, false);
-        }
-      });
-    }
+    this.setCurrentGeolocation();
   }
 
   public onSelectedCity(event: MatAutocompleteSelectedEvent): void {
@@ -146,5 +132,21 @@ export class CityFilterComponent implements OnInit, AfterViewInit, OnDestroy {
             .filter((codeficator: Codeficator) => codeficator.settlement.toLowerCase().startsWith(value.toLowerCase()));
         }
       });
+  }
+
+  private setCurrentGeolocation(): void {
+    if (this.geolocationService.isCityInStorage()) {
+      this.geolocationService.confirmCity(JSON.parse(localStorage.getItem('cityConfirmation')), true);
+    } else {
+      this.geolocationService.handleUserLocation((coords: Coords) => {
+        if (coords) {
+          this.geolocationService.getNearestByCoordinates(coords, (result: Codeficator) => {
+            this.geolocationService.confirmCity(result, false);
+          });
+        } else {
+          this.geolocationService.confirmCity(Constants.KYIV, false);
+        }
+      });
+    }
   }
 }

--- a/src/app/shell/result/result.component.ts
+++ b/src/app/shell/result/result.component.ts
@@ -75,11 +75,14 @@ export class ResultComponent implements OnInit, OnDestroy, AfterViewInit {
     this.addNavPath();
     this.setViewType();
     this.setInitialSubscriptions();
+    this.setFiltersFromQueryParamsWhenMapView();
   }
 
   ngAfterViewInit(): void {
     this.setFilterStateURLParams();
+  }
 
+  private setFiltersFromQueryParamsWhenMapView(): void {
     combineLatest([this.route.queryParamMap, this.isMapView$])
       .pipe(takeUntil(this.destroy$))
       .subscribe(([queryParamMap, isMapView]: [ParamMap, boolean]) => {


### PR DESCRIPTION
I noticed console errors on the page with a map. The previous developer chose the wrong lifecycle hook AfterViewInit instead of OnInit. So, I moved code to OnInit.

![city-filter](https://github.com/ita-social-projects/OoS-Frontend/assets/67392473/38f5f0c7-40b9-4b85-b5e3-dacf3f492f35)
![result](https://github.com/ita-social-projects/OoS-Frontend/assets/67392473/b4084798-25a4-4a16-a961-b9245e422469)
