### PR TITLE
Oliinyk / 2241 Create workshop localization issue

### DIFF
--- a/src/app/shared/styles/working-hours.scss
+++ b/src/app/shared/styles/working-hours.scss
@@ -33,7 +33,7 @@
   box-sizing: border-box;
   border-radius: 21px;
   margin: 0;
-  padding: 0.5rem 2rem;
+  padding: 0.25em 1.5em;
   max-width: max-content;
   height: 40px;
   align-items: center;

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
@@ -208,17 +208,21 @@
     </mat-radio-group>
   </div>
 
-  <label class="step-label"> Конкурсний відбір </label>
+  <label class="step-label">{{ 'COMPETITIVE_SELECTION' | translate }}</label>
   <mat-radio-group [formControl]="competitiveSelectionRadioBtn" color="primary" fxLayout="column"
-    fxLayoutAlign="center space-between">
-    <mat-radio-button #radio1 name="radioBtn1" [value]="false">Без конкурсного відбору</mat-radio-button>
-    <mat-radio-button #radio2 name="radioBtn2" [value]="true">Є конкурсний відбір</mat-radio-button>
+                   fxLayoutAlign="center space-between">
+    <mat-radio-button #radio1 name="radioBtn1" [value]="false">
+      {{ 'WITHOUT_COMPETITIVE_SELECTION' | translate }}
+    </mat-radio-button>
+    <mat-radio-button #radio2 name="radioBtn2" [value]="true">
+      {{ 'WITH_COMPETITIVE_SELECTION' | translate }}
+    </mat-radio-button>
     <ng-container *ngIf="AboutFormGroup.get('competitiveSelection').value">
       <div class="step-label-combined">
-        <label class="step-label"> Інформація про відбір<span class="step-required">*</span></label>
+        <label class="step-label">{{ 'INFO_ABOUT_SELECTION' | translate }}<span class="step-required">*</span></label>
         <label class="step-characters-count">
           <ng-container *ngIf="AboutFormGroup.get('competitiveSelectionDescription').value; else elseBlock">
-            {{AboutFormGroup.get('competitiveSelectionDescription').value?.length}}/{{validationConstants.MAX_DESCRIPTION_LENGTH_500}}
+            {{ AboutFormGroup.get('competitiveSelectionDescription').value?.length }}/{{ validationConstants.MAX_DESCRIPTION_LENGTH_500 }}
           </ng-container>
           <ng-template #elseBlock>
             0/{{validationConstants.MAX_DESCRIPTION_LENGTH_500}}
@@ -226,8 +230,11 @@
         </label>
       </div>
       <textarea matInput class="step-textarea step-textarea-short"
-        placeholder="Максимум {{validationConstants.MAX_DESCRIPTION_LENGTH_500}} символів"
-        formControlName="competitiveSelectionDescription" maxlength="{{validationConstants.MAX_DESCRIPTION_LENGTH_500}}"></textarea>
+                placeholder="{{ 'FORMS.PLACEHOLDERS.MAXIMUM' | translate }} {{
+                validationConstants.MAX_DESCRIPTION_LENGTH_500 }} {{ 'FORMS.PLACEHOLDERS.SYMBOLS' | translate }}"
+                formControlName="competitiveSelectionDescription"
+                [maxLength]="validationConstants.MAX_DESCRIPTION_LENGTH_500">
+      </textarea>
     </ng-container>
   </mat-radio-group>
 </form>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -272,6 +272,9 @@
   },
   "EXACT_MATCH": "Exact match",
   "FOR_FREE": "For free",
+  "WITHOUT_COMPETITIVE_SELECTION": "Without competitive selection",
+  "WITH_COMPETITIVE_SELECTION": "Competitive selection exists",
+  "INFO_ABOUT_SELECTION": "Information about selection",
   "FORMS": {
     "ADD_TEACHER_LATER": "Teachers can be added to the workshop later",
     "MATCH_ACTUAL_ADDRESS": "Actual address matches the legal address",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -272,6 +272,9 @@
   },
   "EXACT_MATCH": "Повний збіг",
   "FOR_FREE": "Безкоштовні",
+  "WITHOUT_COMPETITIVE_SELECTION": "Без конкурсного відбору",
+  "WITH_COMPETITIVE_SELECTION": "Є конкурсний відбір",
+  "INFO_ABOUT_SELECTION": "Інформація про відбір",
   "FORMS": {
     "ADD_TEACHER_LATER": "Вчителів до гуртка можна додати пізніше",
     "MATCH_ACTUAL_ADDRESS": "Збігається з юридичною адресою",


### PR DESCRIPTION
#2241

Fixed working hours input padding on eng translate & competitive selection translation.

Couldn't fix that bug because labels are coming from backend
![image](https://github.com/ita-social-projects/OoS-Frontend/assets/68949838/59336cdc-220b-407d-947a-96d37b500ed5)
