### PR TITLE
Issue#2311 the red mark is missing on the left of the message history on the messages page

### DIFF
--- a/src/app/shared/styles/full-width-card.scss
+++ b/src/app/shared/styles/full-width-card.scss
@@ -21,6 +21,9 @@ p {
   &-new {
     border-left: 5px solid #3849f9;
   }
+  &-blocked {
+    border-left: 5px solid #c72a21;
+  }
 }
 
 .title {

--- a/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.html
+++ b/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.html
@@ -1,5 +1,9 @@
 <mat-card
-  [ngClass]="chatRoom.notReadByCurrentUserMessagesCount ? 'card card-new' : 'card'"
+  class="card"
+  [ngClass]="{
+    'card-new' : chatRoom.notReadByCurrentUserMessagesCount,
+    'card-blocked': role === Role.provider && chatRoom.parent.isBlocked
+  }"
   [routerLink]="['./', chatRoom.id]">
   <mat-card-content class="card-block card-block__message">
     <div class="companion">
@@ -12,6 +16,12 @@
     <div class="last-message text">
       {{ chatRoom.lastMessage.text }}
     </div>
+    <ng-container *ngIf="role === Role.provider && chatRoom.parent.isBlocked">
+      <div class="statuses {{ userStatuses.Blocked }}" fxLayoutAlign="center center">
+        <span> <i class="status-icon {{ userStatusIcons[userStatuses.Blocked] }}"></i></span>
+        <span> {{ userStatusesTitles[userStatuses.Blocked] | translate }}</span>
+      </div>
+    </ng-container>
   </mat-card-content>
   <mat-card-content *ngIf="role === Role.provider" class="card-block card-block__actions">
     <mat-icon class="material-icons material-icons__actions" #stopPropagation [matMenuTriggerFor]="actions"

--- a/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.html
+++ b/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.html
@@ -1,9 +1,7 @@
 <mat-card
   class="card"
-  [ngClass]="{
-    'card-new' : chatRoom.notReadByCurrentUserMessagesCount,
-    'card-blocked': role === Role.provider && chatRoom.parent.isBlocked
-  }"
+  [class.card-new]="chatRoom.notReadByCurrentUserMessagesCount"
+  [class.card-blocked]="role === Role.provider && chatRoom.parent.isBlocked"
   [routerLink]="['./', chatRoom.id]">
   <mat-card-content class="card-block card-block__message">
     <div class="companion">
@@ -18,8 +16,8 @@
     </div>
     <ng-container *ngIf="role === Role.provider && chatRoom.parent.isBlocked">
       <div class="statuses {{ userStatuses.Blocked }}" fxLayoutAlign="center center">
-        <span> <i class="status-icon {{ userStatusIcons[userStatuses.Blocked] }}"></i></span>
-        <span> {{ userStatusesTitles[userStatuses.Blocked] | translate }}</span>
+        <span><i class="status-icon {{ userStatusIcons[userStatuses.Blocked] }}"></i></span>
+        <span>{{ userStatusesTitles[userStatuses.Blocked] | translate }}</span>
       </div>
     </ng-container>
   </mat-card-content>
@@ -33,9 +31,9 @@
         <button mat-menu-item (click)="onBlock()">{{ 'BUTTONS.BLOCK_USER' | translate }}</button>
       </ng-template>
 
-    <ng-template #Unblock>
-      <button mat-menu-item (click)="onUnBlock()">{{ 'BUTTONS.UNBLOCK_USER' | translate }}</button>
-    </ng-template>
+      <ng-template #Unblock>
+        <button mat-menu-item (click)="onUnBlock()">{{ 'BUTTONS.UNBLOCK_USER' | translate }}</button>
+      </ng-template>
     </mat-menu>
   </mat-card-content>
 </mat-card>

--- a/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.html
+++ b/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.html
@@ -28,14 +28,14 @@
       >more_vert</mat-icon
     >
     <mat-menu #actions="matMenu" class="header_menu">
-      <button mat-menu-item (click)="onBlock()">{{ 'BUTTONS.BLOCK_USER' | translate }}</button>
-      <!--
-        TODO: uncomment when value for condition is available
+      <ng-container *ngIf="chatRoom.parent.isBlocked then Unblock; else Block"></ng-container>
+      <ng-template #Block>
+        <button mat-menu-item (click)="onBlock()">{{ 'BUTTONS.BLOCK_USER' | translate }}</button>
+      </ng-template>
 
-        <button mat-menu-item (click)="onUnBlock()">
-          Розблокувати користувача
-        </button>
-      -->
+    <ng-template #Unblock>
+      <button mat-menu-item (click)="onUnBlock()">{{ 'BUTTONS.UNBLOCK_USER' | translate }}</button>
+    </ng-template>
     </mat-menu>
   </mat-card-content>
 </mat-card>

--- a/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.scss
+++ b/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.scss
@@ -16,9 +16,11 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  min-width: 403px;
 }
 .title {
   flex: 1;
+  min-width: 403px;
 }
 .last-message {
   flex: 2;
@@ -28,6 +30,21 @@
   overflow: hidden;
   max-height: 54px;
   word-break: break-word;
+}
+
+.statuses {
+  flex: 1;
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.status-icon {
+  margin-right: 8px;
+}
+
+.Blocked {
+  color: #c72a21;
 }
 
 @media (max-width: 1220px) {

--- a/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.ts
+++ b/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.ts
@@ -1,8 +1,10 @@
-import { AfterViewInit, Component, ElementRef, EventEmitter, Input, Output, ViewChildren } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, Output, ViewChildren } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
 import { Constants } from '../../../../../shared/constants/constants';
 import { Role } from '../../../../../shared/enum/role';
 import { ChatRoom } from '../../../../../shared/models/chat.model';
+import { UserStatusesTitles } from 'shared/enum/enumUA/statuses';
+import { UserStatusIcons, UserStatuses } from 'shared/enum/statuses';
 
 @Component({
   selector: 'app-message-card',
@@ -10,19 +12,23 @@ import { ChatRoom } from '../../../../../shared/models/chat.model';
   styleUrls: ['./message-card.component.scss']
 })
 export class MessageCardComponent implements AfterViewInit {
-  readonly Role = Role;
-  readonly constants = Constants;
+  public readonly Role = Role;
+  public readonly constants = Constants;
+  public readonly userStatusesTitles = UserStatusesTitles;
+  public readonly userStatusIcons = UserStatusIcons;
+  public readonly userStatuses =UserStatuses;
 
-  @Input() chatRoom: ChatRoom;
-  @Input() role: Role;
+  @Input() public chatRoom: ChatRoom;
+  @Input() public role: Role;
 
-  @Output() block = new EventEmitter();
-  @Output() unblock = new EventEmitter();
+  @Output() public block = new EventEmitter();
+  @Output() public unblock = new EventEmitter();
 
-  @ViewChildren('stopPropagation') stopPropagationElements: MatIcon[];
+  @ViewChildren('stopPropagation') public stopPropagationElements: MatIcon[];
 
   constructor() {}
-  ngAfterViewInit(): void {
+
+  public ngAfterViewInit(): void {
     this.stopPropagationElements.forEach((el: MatIcon) => {
       el._elementRef.nativeElement.onclick = (event: PointerEvent) => {
         event.stopPropagation();
@@ -30,11 +36,11 @@ export class MessageCardComponent implements AfterViewInit {
     });
   }
 
-  onBlock(): void {
+  public onBlock(): void {
     this.block.emit(this.chatRoom.parentId);
   }
 
-  onUnBlock(): void {
+  public onUnBlock(): void {
     this.unblock.emit(this.chatRoom.parentId);
   }
 }

--- a/src/app/shell/personal-cabinet/shared-cabinet/messages/messages.component.spec.ts
+++ b/src/app/shell/personal-cabinet/shared-cabinet/messages/messages.component.spec.ts
@@ -1,15 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatDialogModule } from '@angular/material/dialog';
+import { Component, Input } from '@angular/core';
+import { of } from 'rxjs';
+import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
-import { NgxsModule } from '@ngxs/store';
+import { NgxsModule, Store } from '@ngxs/store';
 import { MessagesComponent } from './messages.component';
-import { Component, Input } from '@angular/core';
+import { BlockedParent } from 'shared/models/block.model';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { ReasonModalWindowComponent } from 'shared/components/confirmation-modal-window/reason-modal-window/reason-modal-window.component';
+import { Constants, PaginationConstants } from 'shared/constants/constants';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 
 describe('MessagesComponent', () => {
   let component: MessagesComponent;
   let fixture: ComponentFixture<MessagesComponent>;
+  let matDialog: MatDialog;
+  let store: Store;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -27,11 +35,135 @@ describe('MessagesComponent', () => {
     fixture = TestBed.createComponent(MessagesComponent);
     component = fixture.componentInstance;
     component.filterFormControl = new FormControl('');
+    matDialog = TestBed.inject(MatDialog);
+    store = TestBed.inject(Store);
+
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('onBlock method', () => {
+    let matDialogSpy: jest.SpyInstance;
+    let mockBlockedParent: BlockedParent;
+    let expectedMatDialogData: Object;
+    let dispatchSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      dispatchSpy = jest.spyOn(store, 'dispatch');
+      expectedMatDialogData = {};
+      mockBlockedParent = {
+        parentId: 'parentId',
+        providerId: 'providerId',
+        reason: 'the reason of blocking',
+      };
+    });
+
+    it('should open matDialog with correct parameters on onBlock method', () => {
+      expectedMatDialogData = {
+        data: { type: ModalConfirmationType.blockParent }
+      };
+      matDialogSpy = jest.spyOn(matDialog, 'open').mockReturnValue({
+        afterClosed: () => of(true)
+      } as MatDialogRef<ReasonModalWindowComponent>);
+
+      component.onBlock(mockBlockedParent.parentId);
+
+      expect(matDialogSpy).toHaveBeenCalledTimes(1);
+      expect(matDialogSpy).toHaveBeenCalledWith(ReasonModalWindowComponent, expectedMatDialogData);
+    });
+
+    it('should dispatch BlockParent action with the correct parameters on afterClosed', () => {
+      component.providerId = mockBlockedParent.providerId;
+      const expectedBlockParentDispatchData = {
+        parameters: undefined,
+        payload: new BlockedParent(
+          mockBlockedParent.parentId,
+          mockBlockedParent.providerId,
+          mockBlockedParent.reason,
+        )
+      };
+      expectedBlockParentDispatchData.payload.userIdBlock = mockBlockedParent.providerId;
+      const expectedChatRoomsDispatchData = {
+        parameters: {
+          role: null,
+          workshopIds: null,
+          searchText: null,
+          size: PaginationConstants.CHATROOMS_PER_PAGE
+        },
+      };
+      matDialogSpy = jest.spyOn(matDialog, 'open').mockReturnValue({
+        afterClosed: () => of(expectedBlockParentDispatchData.payload.reason)
+      } as MatDialogRef<ReasonModalWindowComponent>);
+
+      component.onBlock(mockBlockedParent.parentId);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(2);
+      expect(dispatchSpy).toHaveBeenNthCalledWith(1, expectedBlockParentDispatchData);
+      expect(dispatchSpy).toHaveBeenLastCalledWith(expectedChatRoomsDispatchData);
+    });
+  });
+
+  describe('onUnBlock method', () => {
+    let matDialogSpy: jest.SpyInstance;
+    let mockBlockedParent: BlockedParent;
+    let expectedMatDialogData: Object;
+    let dispatchSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      dispatchSpy = jest.spyOn(store, 'dispatch');
+      expectedMatDialogData = {};
+      mockBlockedParent = {
+        parentId: 'parentId',
+        providerId: 'providerId',
+      };
+    });
+
+    it('should open matDialog with correct parameters on onUnBlock method', () => {
+      expectedMatDialogData = {
+        width: Constants.MODAL_SMALL,
+        data: { type: ModalConfirmationType.unBlockParent }
+      };
+      matDialogSpy = jest.spyOn(matDialog, 'open').mockReturnValue({
+        afterClosed: () => of(true)
+      } as MatDialogRef<ConfirmationModalWindowComponent>);
+      
+      component.onUnBlock(mockBlockedParent.parentId);
+
+      expect(matDialogSpy).toHaveBeenCalledTimes(1);
+      expect(matDialogSpy).toHaveBeenCalledWith(ConfirmationModalWindowComponent, expectedMatDialogData);
+    });
+
+    it('should dispatch UnBlockParent action with the correct parameters on afterClosed', () => {
+      component.providerId = mockBlockedParent.providerId;
+      const expectedUnblockParentDispatchData = {
+        parameters: undefined,
+        payload: new BlockedParent(
+          mockBlockedParent.parentId,
+          mockBlockedParent.providerId,
+        )
+      };
+      expectedUnblockParentDispatchData.payload.userIdUnblock = mockBlockedParent.providerId;
+      const expectedChatRoomsDispatchData = {
+        parameters: {
+          role: null,
+          workshopIds: null,
+          searchText: null,
+          size: PaginationConstants.CHATROOMS_PER_PAGE
+        },
+      };
+      matDialogSpy = jest.spyOn(matDialog, 'open').mockReturnValue({
+        afterClosed: () => of(true)
+      } as MatDialogRef<ConfirmationModalWindowComponent>);
+
+      component.onUnBlock(mockBlockedParent.parentId);
+  
+      expect(dispatchSpy).toHaveBeenCalledTimes(2);
+      expect(dispatchSpy).toHaveBeenNthCalledWith(1, expectedUnblockParentDispatchData);
+      expect(dispatchSpy).toHaveBeenLastCalledWith(expectedChatRoomsDispatchData);
+    });
   });
 });
 


### PR DESCRIPTION
- Added the markers on the message history items for a provider when a parent is blocked
- Improved functionality of blocking / unblocking a parent by a provider