### PR TITLE
Oliinyk / Personal cabinet navigation hotfix

### DIFF
--- a/src/app/shell/personal-cabinet/personal-cabinet.guard.ts
+++ b/src/app/shell/personal-cabinet/personal-cabinet.guard.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { CanLoad, Router, UrlTree } from '@angular/router';
 import { Select } from '@ngxs/store';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 
 import { ModeConstants } from 'shared/constants/constants';
 import { RegistrationState } from 'shared/store/registration.state';
@@ -18,6 +18,7 @@ export class PersonalCabinetGuard implements CanLoad {
 
   canLoad(): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     return this.isRegistered$.pipe(
+      filter((isRegistered: boolean) => isRegistered !== undefined),
       map((isRegistered: boolean) => isRegistered || this.router.createUrlTree(['/create-provider', ModeConstants.NEW]))
     );
   }


### PR DESCRIPTION
Fixed issue of URL navigation in personal cabinet because of guard was giving `/create-provider` URL when trying to navigate personal cabinet due to `isRegistered` was undefined