### PR TITLE
fixed child info icon with big fullname 

### DIFF
--- a/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.html
+++ b/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.html
@@ -2,8 +2,8 @@
   <mat-card-content [ngClass]="userRole === role.parent ? 'card-block card-block__parent' : 'card-block'">
     <div class="card-block__info">
       <div fxLayout="column" fxLayoutAlign="start start" fxLayoutGap="8px">
-        <div fxLayout="row" fxLayoutAlign="start">
-          <h4 class="title">{{ childFullName }}</h4>
+        <div fxLayout="row" fxLayoutAlign="space-between" class="card-block__child-name">
+          <h4 class="title" showTooltipIfTruncated matTooltip="{{ childFullName }}" matTooltipClass="tooltip">{{ childFullName }}</h4>
           <i
             [ngClass]="
               childTrigger.menuOpen ? 'material-icons status-info-icon activeInfoBtn' : 'material-icons status-info-icon inactiveInfoBtn'

--- a/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.scss
+++ b/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.scss
@@ -17,6 +17,16 @@
         padding-left: 8px;
       }
     }
+    & > div > .card-block__child-name {
+      min-width: 250px !important;
+
+      & > h4 {
+        max-width: 200px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
   }
 
   &__buttons {


### PR DESCRIPTION
Issue: (#2266)
Added conditional matToolTip  

Used fxLayoutAlign="space-between" to ensure a good and flat appearance with various full name.

![image](https://github.com/ita-social-projects/OoS-Frontend/assets/130310750/7f2a60f4-a389-41ac-9297-fe6f5fc1a7ae)
