### PR TITLE
Horeslavskyi / [SP, Applications] The text of the button "Прийняти до відбору" is transferred to 2 lines when using a high-resolution screen

### DIFF
--- a/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.scss
+++ b/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.scss
@@ -72,7 +72,7 @@
   font-weight: bold;
   font-size: 13px;
   line-height: 15px;
-  padding: 0.6rem 1.9rem;
+  padding: 0.6rem 1.7rem;
   margin: 0 8px;
   min-width: 10rem;
   text-transform: uppercase;


### PR DESCRIPTION
https://github.com/ita-social-projects/OoS-Frontend/issues/2387

Before:
![before](https://github.com/ita-social-projects/OoS-Frontend/assets/67392473/62326f1f-34ff-4d67-b95e-1e46b16db048)

After:
![after](https://github.com/ita-social-projects/OoS-Frontend/assets/67392473/2452726b-a79c-470d-9743-47796e5a7f96)
