### PR TITLE
Oliinyk / 2494 Achievement tooltip word break

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -137,7 +137,7 @@ $config: mat.define-typography-config(
 }
 
 .tooltip {
-  word-break: break-all !important;
+  overflow-wrap: break-word !important;
   white-space: normal !important;
 }
 


### PR DESCRIPTION
#2494

Changed style for whole tooltips word break property as overflow-wrap.
Used `overflow-wrap: break-word` property since `word-break: break-word` is deprecated one.
Style is global and applied for every tooltip, for example city-filter.
![image](https://github.com/ita-social-projects/OoS-Frontend/assets/68949838/2b945216-6941-42a3-93ac-b476ae307e01)
