### PR TITLE
Smyk / 2533 The messages/applications lists aren't displayed according to the mock-up

### DIFF
--- a/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.html
+++ b/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.html
@@ -1,4 +1,4 @@
-<mat-card class="card" [class.card-new]="application.status === ApplicationStatuses.Pending">
+<mat-card class="card" [class.card-new]="application.status === ApplicationStatuses.Pending" fxLayout="row" fxLayoutAlign="space-between center">
   <mat-card-content class="card-block" [class.card-block__parent]="userRole === Role.parent">
     <div class="card-block__info">
       <div fxLayout="column" fxLayoutAlign="start start" fxLayoutGap="8px">

--- a/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.scss
+++ b/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.scss
@@ -2,6 +2,7 @@
 @import 'src/app/shared/styles/full-width-card.scss';
 
 .card-block {
+  width: 100%;
   &__parent {
     flex: 2;
   }

--- a/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.html
+++ b/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.html
@@ -1,8 +1,9 @@
 <mat-card class="card" [class.card-new]="chatRoom.notReadByCurrentUserMessagesCount"
   [class.card-blocked]="role === Role.provider && chatRoom.isBlockedByProvider" [routerLink]="['./', chatRoom.id]">
-  <mat-card-content class="card-block card-block__message">
+  <mat-card-content class="card-block card-block__message" fxLayout="row" fxLayoutAlign="space-between center">
     <div class="companion">
       <h4 class="title">{{ chatRoom.parent | getFullName }}</h4>
+      <p class="workshop-title">{{ chatRoom.workshop.title }}</p>
       <ng-container *ngIf="chatRoom.lastMessage !== null; else emptyChatDateTitle">
         <p class="text">
           {{ chatRoom.lastMessage.createdDateTime | date: Constants.FULL_DATE_FORMAT : '': translateService.currentLang}}
@@ -14,7 +15,6 @@
         </p>
       </ng-template>
     </div>
-    <h4 class="title">{{ chatRoom.workshop.title }}</h4>
     <div class="last-message text">
       {{ chatRoom.lastMessage?.text | emptyValueTransform: Constants.DASH_VALUE }}
     </div>

--- a/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.scss
+++ b/src/app/shell/personal-cabinet/shared-cabinet/messages/message-card/message-card.component.scss
@@ -6,6 +6,7 @@
 }
 
 .card-block {
+  width: 100%;
   &__message {
     display: flex;
     > * {
@@ -14,11 +15,15 @@
   }
 }
 
+.workshop-title {
+  color: blue;
+}
+
 .companion {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 6px;
   min-width: 30%;
 }
 


### PR DESCRIPTION
#2533 

Fixed display of messages/application lists according to mock-up
![image](https://github.com/ita-social-projects/OoS-Frontend/assets/71979027/2565eafb-8c6c-430e-b22d-afff5ab91faa)
![image](https://github.com/ita-social-projects/OoS-Frontend/assets/71979027/a874baba-7b81-4b0e-9c5e-1df65e54261d)

The message button in message card is redundant for reason that chat opens if clicked on card