### PR TITLE
Smyk / Lowered filter fields on Administator's "History of change" tab 

### DIFF
--- a/src/app/shell/admin-tools/data/history-log/history-log-filters/history-log-filters.component.html
+++ b/src/app/shell/admin-tools/data/history-log/history-log-filters/history-log-filters.component.html
@@ -15,7 +15,7 @@
       </mat-form-field>
     </div>
     <ng-container *ngFor="let filter of filtersList">
-      <mat-form-field floatLabel="never" appearance="none">
+      <mat-form-field floatLabel="never" appearance="none" class="select-form-field">
         <mat-select disableOptionCentering [formControl]="filtersForm.controls[filter.controlName]"
           panelClass="dropdown-panel" class="select">
           <mat-option value="" class="dropdown-option">

--- a/src/app/shell/admin-tools/data/history-log/history-log-filters/history-log-filters.component.html
+++ b/src/app/shell/admin-tools/data/history-log/history-log-filters/history-log-filters.component.html
@@ -1,5 +1,5 @@
-<div [formGroup]="filtersForm" class="form-wrapper">
-  <div class="filters-wrapper">
+<div [formGroup]="filtersForm" class="form-wrapper" fxLayoutAlign="end start">
+  <div class="filters-wrapper" fxLayoutAlign="end start">
     <div class="filters-period">
       <span>{{ 'HISTORY_LOG.PERIOD' | translate }}</span>
       <mat-form-field appPlaceholderStyling class="date" appearance="fill">

--- a/src/app/shell/admin-tools/data/history-log/history-log-filters/history-log-filters.component.scss
+++ b/src/app/shell/admin-tools/data/history-log/history-log-filters/history-log-filters.component.scss
@@ -93,8 +93,10 @@
   padding: 0;
 }
 
-:host ::ng-deep .mat-form-field-infix {
-  padding: 0;
+:host ::ng-deep .select-form-field {
+  .mat-form-field-infix {
+    padding: 0;
+  }
 }
 
 .btn {

--- a/src/app/shell/admin-tools/data/history-log/history-log-filters/history-log-filters.component.scss
+++ b/src/app/shell/admin-tools/data/history-log/history-log-filters/history-log-filters.component.scss
@@ -32,6 +32,7 @@
 
   mat-form-field {
     pointer-events: none;
+    max-width: 90%;
   }
 
   mat-datepicker-toggle {
@@ -56,7 +57,7 @@
 :host ::ng-deep .date {
   width: 100%;
   max-width: 250px;
-  padding: 0.35rem 1rem 0.35rem;
+  padding: 0 1rem 0.35rem;
 
   .mat-form-field-flex {
     background-color: transparent;
@@ -89,6 +90,10 @@
 }
 
 :host ::ng-deep .mat-form-field-wrapper {
+  padding: 0;
+}
+
+:host ::ng-deep .mat-form-field-infix {
   padding: 0;
 }
 


### PR DESCRIPTION
Changed field stylesheets so that they are on the same level.
Changed datepicker styles so the content is in the middle of the container.
![image](https://github.com/ita-social-projects/OoS-Frontend/assets/71979027/630a487a-6231-46b1-8b18-95d88d642088)
