### PR TITLE
Smyk / 2537 Logo, 'Recruitment is open' label, 'Rating' and 'Formof education' are not aligned 

### DIFF
--- a/src/app/shared/components/workshop-card/workshop-card.component.html
+++ b/src/app/shared/components/workshop-card/workshop-card.component.html
@@ -25,7 +25,7 @@
             [routerLink]="['/details/workshop', workshopData.workshopId]">
             <mat-icon class="icon_launch">launch</mat-icon>
           </a>
-          {{ workshopData.title }}
+          <div class="workshop-title-container">{{ workshopData.title }}</div>
         </mat-card-title>
         <ng-container *ngFor="let id of workshopData.directionIds">
           <img class="img" mat-card-image [src]="categoryIcons[id]" />

--- a/src/app/shared/components/workshop-card/workshop-card.component.scss
+++ b/src/app/shared/components/workshop-card/workshop-card.component.scss
@@ -11,6 +11,11 @@
 .provider-content {
   min-height: 2rem;
 }
+.workshop-title-container{
+  display: flex;
+  align-items: center;
+  height: inherit;
+}
 .icon {
   display: flex;
   flex-direction: row;

--- a/src/app/shell/details/workshop-details/workshop-details.component.html
+++ b/src/app/shell/details/workshop-details/workshop-details.component.html
@@ -5,7 +5,7 @@
   <div class="details-wrapper">
     <div fxLayout="column" fxLayoutAlign="space-between space-between">
       <div fxLayout="row" fxLayoutAlign="space-between center">
-        <div fxLayout="row" fxLayout.lt-sm="row wrap" fxLayoutAlign="start center">
+        <div fxLayout="row" fxLayout.lt-sm="row wrap" fxLayoutAlign="start center" fxLayoutGap="16px">
           <div fxLayout="column" fxLayoutAlign="start center">
             <h1 class="title">{{ workshop.title }}</h1>
             <h3 class="short-title" *ngIf="workshop.shortTitle" fxFlexAlign="start">{{ workshop.shortTitle }}</h3>

--- a/src/app/shell/details/workshop-details/workshop-details.component.scss
+++ b/src/app/shell/details/workshop-details/workshop-details.component.scss
@@ -5,3 +5,11 @@
 .workshop-title {
   margin-bottom: 0;
 }
+
+.icon {
+  min-width: 24px;
+}
+
+.chip{
+  margin-left: 0;
+}


### PR DESCRIPTION
#2537 

Fixed align of logo, 'Recruitment is open' label, 'Rating' and 'Education form'