### PR TITLE
Dvorak/2605 Rewrote some styles for application cards

### DIFF
--- a/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.html
+++ b/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.html
@@ -105,9 +105,7 @@
   </mat-card-content>
 
   <ng-template #whenParentIsBlocked>
-    <mat-card-content
-      *ngIf="userRole !== Role.provider && application.isBlockedByProvider"
-      class="card-block card-block__buttons"></mat-card-content>
+    <mat-card-content class="card-block card-block__buttons"></mat-card-content>
   </ng-template>
 
   <ng-container *ngIf="!isMobileView; then actionsBlock"></ng-container>

--- a/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.scss
+++ b/src/app/shell/personal-cabinet/shared-cabinet/applications/application-card/application-card.component.scss
@@ -93,7 +93,7 @@
 }
 
 .hidden {
-  visibility: hidden;
+  display: none;
 }
 
 .organization {
@@ -109,11 +109,11 @@
 
 @media (max-width: 1220px) {
   .card-block {
-    width: auto;
     &__buttons {
       flex-direction: column;
       justify-content: center;
       gap: 10px;
+      width: 176px;
     }
   }
 }


### PR DESCRIPTION
#2605 
- Fixed application card positioning when user is blocked. Now it looks fine on all screens.
- Also fixed buttons("Reject", "Enroll" etc.) positioning for smaller screens. Now they positioned without strange spaces that used to appear when some buttons were hidden.
![image](https://github.com/user-attachments/assets/77ebed55-ce6f-46f1-a7f2-fa752362b050)
![image](https://github.com/user-attachments/assets/fae6ac98-ee54-4f12-ba0f-4a17de570c29)
