### PR TITLE
Zhylka/#2742 incorrect naming of the edit cancellation confirmation button

### DIFF
--- a/src/app/shared/components/confirmation-modal-window/confirmation-modal-window.component.html
+++ b/src/app/shared/components/confirmation-modal-window/confirmation-modal-window.component.html
@@ -14,7 +14,7 @@
       mat-button
       cdkFocusInitial
       [mat-dialog-close]="data.type === modalConfirmationType.rate ? ratingSelectControl?.value : true">
-      {{ (data.type === modalConfirmationType.delete ? 'BUTTONS.REMOVE' : 'BUTTONS.SEND') | translate | uppercase }}
+      {{ getConfirmationButtonMessage() | translate | uppercase }}
     </button>
     <button class="btn-cancel btn" mat-button [mat-dialog-close]="false">
       {{ 'BUTTONS.CANCEL' | translate | uppercase }}

--- a/src/app/shared/components/confirmation-modal-window/confirmation-modal-window.component.spec.ts
+++ b/src/app/shared/components/confirmation-modal-window/confirmation-modal-window.component.spec.ts
@@ -5,7 +5,7 @@ import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/materia
 import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { ModalConfirmationTypeWithQuotes } from 'shared/enum/modal-confirmation';
+import { ModalConfirmationButtonText, ModalConfirmationType, ModalConfirmationTypeWithQuotes } from 'shared/enum/modal-confirmation';
 import { StarsComponent } from '../../../shell/details/details-tabs/reviews/stars/stars.component';
 import { ConfirmationModalWindowComponent } from './confirmation-modal-window.component';
 
@@ -38,5 +38,21 @@ describe('ConfirmationModalWindowComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should return rate confirmation button text when data.type is rate', () => {
+    component.data.type = ModalConfirmationType.rate;
+
+    const message = component.getConfirmationButtonMessage();
+
+    expect(message).toBe(ModalConfirmationButtonText.rate);
+  });
+
+  it('should return default confirmation button text when data.type is undefined', () => {
+    component.data.type = undefined;
+
+    const message = component.getConfirmationButtonMessage();
+
+    expect(message).toBe(ModalConfirmationButtonText.default);
   });
 });

--- a/src/app/shared/components/confirmation-modal-window/confirmation-modal-window.component.ts
+++ b/src/app/shared/components/confirmation-modal-window/confirmation-modal-window.component.ts
@@ -3,6 +3,7 @@ import { FormControl } from '@angular/forms';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 import {
+  ModalConfirmationButtonText,
   ModalConfirmationText,
   ModalConfirmationTitle,
   ModalConfirmationType,
@@ -40,5 +41,10 @@ export class ConfirmationModalWindowComponent implements OnInit {
         this.modalConfirmationProperty = `"${this.modalConfirmationProperty}"`;
       }
     }
+  }
+
+  public getConfirmationButtonMessage(): string {
+    const buttonText = ModalConfirmationButtonText[this.data.type];
+    return buttonText || ModalConfirmationButtonText.default;
   }
 }

--- a/src/app/shared/enum/modal-confirmation.ts
+++ b/src/app/shared/enum/modal-confirmation.ts
@@ -157,3 +157,9 @@ export enum ModalConfirmationDescription {
   unregisteredMessageWarning = 'SERVICE_MESSAGES.UNREGISTERED_MESSAGE',
   unregisteredApplicationWarning = 'SERVICE_MESSAGES.UNREGISTERED_APPLICATION'
 }
+
+export enum ModalConfirmationButtonText {
+  delete = 'BUTTONS.DELETE',
+  rate = 'BUTTONS.SEND',
+  default = 'BUTTONS.CONFIRM'
+}

--- a/src/app/shell/personal-cabinet/provider/create-position/create-position.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-position/create-position.component.ts
@@ -49,6 +49,7 @@ export class CreatePositionComponent extends CreateFormComponent implements OnIn
         filter((provider: Provider) => Boolean(provider)),
         tap((provider: Provider) => {
           this.provider = provider;
+          this.cdr.markForCheck();
         }),
         takeUntil(this.destroy$)
       )


### PR DESCRIPTION
#2742 
Also fixed the create workshop form not displaying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Confirmation dialogs now display context-specific button labels, offering clearer actions.
  - The position creation view updates instantly to reflect the latest changes.

- **Tests**
  - Enhanced test coverage ensures the confirmation dialogs return the correct button text based on different confirmation types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->