### PR TITLE
Pryshchenko/fixed the error

### DIFF
--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,1 +1,3 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();


### PR DESCRIPTION
Warning appears after starting jest - Importing "setup-jest.js" directly is deprecated