### PR TITLE
Pasternak/study-subjects-navbar-fix

### DIFF
--- a/src/app/shell/personal-cabinet/provider/provider-study-subjects/provider-study-subjects.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-study-subjects/provider-study-subjects.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSort } from '@angular/material/sort';
@@ -27,7 +27,7 @@ import { ProviderComponent } from '../provider.component';
   templateUrl: './provider-study-subjects.component.html',
   styleUrls: ['./provider-study-subjects.component.scss']
 })
-export class ProviderStudySubjectsComponent extends ProviderComponent implements OnInit, OnDestroy {
+export class ProviderStudySubjectsComponent extends ProviderComponent implements OnInit {
   @ViewChild(MatSort) public sort: MatSort;
   @ViewChild(MatDateRangePicker) public picker: MatDateRangePicker<Date>;
 
@@ -145,11 +145,6 @@ export class ProviderStudySubjectsComponent extends ProviderComponent implements
   public onPageChange(page: PaginationElement): void {
     this.currentPage = page;
     this.getStudySubjects();
-  }
-
-  public ngOnDestroy(): void {
-    this.destroy$.next(true);
-    this.destroy$.unsubscribe();
   }
 
   public closeDatePicker(): void {


### PR DESCRIPTION
Removed OnDestroy lifecycle hook which resulted in navBar bugs -> 
![image](https://github.com/user-attachments/assets/922dd6b0-0dc1-4eb0-934b-10e4ed916cdc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal processes in the study subjects section of the Personal Cabinet to ensure more consistent performance and a smoother user experience.
  - Updated lifecycle management in the Provider Study Subjects component for improved resource handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->