### PR TITLE
Smyk / 2812 The workshop creation form shifts after selecting the country's phone code in the field "Телефон -Телефон" in the section "Контакти".

### DIFF
--- a/src/app/shared/components/phone-form-control/phone-form-control.component.scss
+++ b/src/app/shared/components/phone-form-control/phone-form-control.component.scss
@@ -61,6 +61,10 @@
   }
 }
 
+:host ::ng-deep .mat-mdc-input-element.phone-number-input {
+  margin-left: 0 !important;
+}
+
 .invalid {
   outline: none;
   border: 1px solid #c72a21;


### PR DESCRIPTION
#2812 
Changed styles of phone form control to prevent form shifting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the phone number input styling by resetting the left margin for improved alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->