### PR TITLE
Smyk / 2820 The Description tab can be skipped when creating competition

### DIFF
--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.html
@@ -34,7 +34,7 @@
           </div>
         </mat-step>
 
-        <mat-step [stepControl]="DescriptionFormGroup" [completed]="!RequiredFormGroup.invalid">
+        <mat-step [stepControl]="DescriptionFormGroup" [completed]="!RequiredFormGroup.invalid && !DescriptionFormGroup.invalid">
           <ng-template matStepLabel>
             <p class="step-name">{{ 'TITLES.DESCRIPTION' | translate }}</p>
           </ng-template>
@@ -58,7 +58,9 @@
           </div>
         </mat-step>
 
-        <mat-step [stepControl]="ContactsFormArray" [completed]="!RequiredFormGroup.invalid && !DescriptionFormGroup.invalid">
+        <mat-step
+          [stepControl]="ContactsFormArray"
+          [completed]="!RequiredFormGroup.invalid && !DescriptionFormGroup.invalid && !ContactsFormArray.invalid">
           <ng-template matStepLabel>
             <p class="step-name">{{ 'TITLES.CONTACTS' | translate }}</p>
           </ng-template>


### PR DESCRIPTION
#2820

Changed stepper's "completed" conditions to prevent skipping incomple



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the competition creation workflow by refining the form validation logic. Now, each step in the multi-step form checks that all sections are properly completed before allowing progression. This update ensures that users only advance when every relevant field meets validation criteria, reducing potential errors during competition setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->