### PR TITLE
 Pasternak/create-competition-validation-#2799

### DIFF
--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.html
@@ -82,7 +82,15 @@
 
   <label class="step-label">{{ 'FORMS.LABELS.COMPETITION_RANGE' | translate }}<span class="step-required">*</span></label>
   <mat-form-field appPlaceholderStyling class="step-input step-input-date-range" floatLabel="never">
-    <mat-date-range-input [rangePicker]="competitionPicker" formGroupName="competitionDateRangeGroup" [min]="minDate" [max]="maxDate">
+    <mat-date-range-input
+      [rangePicker]="competitionPicker"
+      formGroupName="competitionDateRangeGroup"
+      [min]="
+        RequiredFormGroup.get('registrationDateRangeGroup.end').value
+          ? RequiredFormGroup.get('registrationDateRangeGroup.end').value
+          : minDate
+      "
+      [max]="maxDate">
       <input matStartDate placeholder="{{ 'FORMS.PLACEHOLDERS.SHORT_DATE_FORMAT' | translate }}" formControlName="start" />
       <input matEndDate placeholder="{{ 'FORMS.PLACEHOLDERS.SHORT_DATE_FORMAT' | translate }}" formControlName="end" />
     </mat-date-range-input>
@@ -98,7 +106,7 @@
       [rangePicker]="registrationPicker"
       formGroupName="registrationDateRangeGroup"
       [min]="minDate"
-      [max]="RequiredFormGroup.get('competitionDateRangeGroup.end').value">
+      [max]="RequiredFormGroup.get('competitionDateRangeGroup.start').value">
       <input matStartDate placeholder="{{ 'FORMS.PLACEHOLDERS.SHORT_DATE_FORMAT' | translate }}" formControlName="start" />
       <input matEndDate placeholder="{{ 'FORMS.PLACEHOLDERS.SHORT_DATE_FORMAT' | translate }}" formControlName="end" />
     </mat-date-range-input>

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
@@ -38,7 +38,7 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
   public useProviderInfoCtrl: FormControl = new FormControl(false);
   public filteredTypeOfCompetition: { key: string; value: string }[] = [];
 
-  protected minDate: Date = new Date(new Date().setMonth(new Date().getMonth() - 1));
+  protected minDate: Date = new Date(new Date().setMonth(new Date().getMonth()));
   protected maxDate: Date = new Date(new Date().setFullYear(new Date().getFullYear() + 1));
   protected readonly TypeOfCompetition = TypeOfCompetition;
   protected readonly InfoMenuType = InfoMenuType;


### PR DESCRIPTION
Added additional validation to ensure that registration date cannot be later than the competition date(last day of registration **can** also be the first for competition) 
-min date can now not be in the past

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Date pickers for competition and registration periods now enforce improved constraints, ensuring the competition cannot start before registration ends, and registration cannot extend beyond the competition start date.

- **Bug Fixes**
  - Updated minimum selectable dates to prevent users from selecting past dates outside the current month when creating a competition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->