### PR TITLE
Zhylka/#2852 add no limit radio button to workshop age

### DIFF
--- a/src/app/shared/models/workshop.model.ts
+++ b/src/app/shared/models/workshop.model.ts
@@ -12,8 +12,9 @@ export abstract class WorkshopBase {
   id?: string;
   title: string;
   shortTitle: string;
-  minAge: number;
-  maxAge: number;
+  noAgeRestrictions: boolean;
+  minAge?: number;
+  maxAge?: number;
   dateTimeRanges: DateTimeRanges[];
   price: number;
   payRate: PayRateType;
@@ -58,6 +59,7 @@ export abstract class WorkshopBase {
   ) {
     this.title = about?.title;
     this.shortTitle = about?.shortTitle;
+    this.noAgeRestrictions = about?.noAgeRestrictions;
     this.minAge = about?.minAge;
     this.maxAge = about?.maxAge;
     this.dateTimeRanges = about?.dateTimeRanges;
@@ -231,8 +233,9 @@ export interface WorkshopCardParameters extends PaginationParameters {
 export interface WorkshopAbout {
   title: string;
   shortTitle: string;
-  minAge: number;
-  maxAge: number;
+  noAgeRestrictions: boolean;
+  minAge?: number;
+  maxAge?: number;
   dateTimeRanges: DateTimeRanges[];
   formOfLearning: FormOfLearning;
   availableSeats: number;

--- a/src/app/shared/services/workshops/user-workshop/user-workshop.service.ts
+++ b/src/app/shared/services/workshops/user-workshop/user-workshop.service.ts
@@ -201,13 +201,14 @@ export class UserWorkshopService {
     const formData = new FormData();
     const formNames = ['dateTimeRanges', 'keywords', 'imageIds', 'workshopDescriptionItems', 'tagIds', 'teachers', 'contacts'];
     const imageFiles = ['imageFiles', 'coverImage'];
+    const skipNullKeys = ['maxAge', 'minAge'];
 
     Object.keys(workshop).forEach((key: string) => {
       if (imageFiles.includes(key)) {
         workshop[key].forEach((file: File) => formData.append(`${preKey}${key}`, file));
       } else if (formNames.includes(key)) {
         formData.append(`${preKey}${key}`, JSON.stringify(workshop[key]));
-      } else {
+      } else if (!(skipNullKeys.includes(key) && workshop[key] === null)) {
         formData.append(`${preKey}${key}`, workshop[key]);
       }
     });

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
@@ -35,32 +35,46 @@
   </app-validation-hint>
 
   <label for="age" class="step-label">{{ 'FORMS.LABELS.AGE_OF_PARTICIPANTS' | translate }}<span class="step-required">*</span></label>
-  <div class="flex flex-row justify-start">
-    <div class="flex flex-col justify-start items-start">
-      <div class="flex flex-row justify-start items-center">
-        <p class="step-text">{{ 'FROM' | translate }}</p>
-        <input matInput class="step-input step-input-age" type="number" formControlName="minAge" appDigitOnly />
-      </div>
-      <app-validation-hint
-        [validationFormControl]="AboutFormGroup.get('minAge')"
-        isNumberValue="true"
-        [minValue]="validationConstants.AGE_MIN"
-        [maxValue]="validationConstants.BIRTH_AGE_MAX"></app-validation-hint>
-      <app-validation-hint formLevelValidation="true" [validationFormControl]="AboutFormGroup"></app-validation-hint>
-    </div>
+  <mat-radio-group color="primary" formControlName="noAgeRestrictions" class="flex flex-col justify-between items-stretch">
+    <mat-radio-button [value]="true">
+      {{ 'UNLIMITED' | translate }}
+    </mat-radio-button>
+    <div>
+      <mat-radio-button [value]="false" class="age-radio-btn">
+        <div class="flex flex-row justify-start">
+          <div class="flex flex-col justify-start items-start">
+            <div class="flex flex-row justify-start items-center">
+              <p class="step-text">{{ 'FROM' | translate }}</p>
+              <input matInput class="step-input step-input-age" type="number" formControlName="minAge" appDigitOnly />
+            </div>
+          </div>
 
-    <div class="flex flex-col justify-start items-start">
-      <div class="flex flex-row justify-start items-center">
-        <p class="step-text">{{ 'TO' | translate }}</p>
-        <input matInput class="step-input step-input-age" type="number" formControlName="maxAge" appDigitOnly />
+          <div class="flex flex-col justify-start items-start">
+            <div class="flex flex-row justify-start items-center">
+              <p class="step-text">{{ 'TO' | translate }}</p>
+              <input matInput class="step-input step-input-age" type="number" formControlName="maxAge" appDigitOnly />
+            </div>
+          </div>
+        </div>
+      </mat-radio-button>
+      <div class="pl-[33px] flex">
+        <div class="w-[225px]">
+          <app-validation-hint
+            [validationFormControl]="AboutFormGroup.get('minAge')"
+            isNumberValue="true"
+            [minValue]="validationConstants.AGE_MIN"
+            [maxValue]="validationConstants.BIRTH_AGE_MAX"></app-validation-hint>
+          <app-validation-hint formLevelValidation="true" [validationFormControl]="AboutFormGroup"></app-validation-hint>
+        </div>
+        <app-validation-hint
+          class="w-[225px] ml-4"
+          [validationFormControl]="AboutFormGroup.get('maxAge')"
+          isNumberValue="true"
+          [minValue]="validationConstants.AGE_MIN"
+          [maxValue]="validationConstants.BIRTH_AGE_MAX"></app-validation-hint>
       </div>
-      <app-validation-hint
-        [validationFormControl]="AboutFormGroup.get('maxAge')"
-        isNumberValue="true"
-        [minValue]="validationConstants.AGE_MIN"
-        [maxValue]="validationConstants.BIRTH_AGE_MAX"></app-validation-hint>
     </div>
-  </div>
+  </mat-radio-group>
 
   <div class="flex flex-row items-center">
     <label class="step-label">{{ 'FORMS.LABELS.WORKING_HOURS' | translate }}<span class="step-required">*</span></label>

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
@@ -44,14 +44,14 @@
         <div class="flex flex-row justify-start">
           <div class="flex flex-col justify-start items-start">
             <div class="flex flex-row justify-start items-center">
-              <p class="step-text">{{ 'FROM' | translate }}</p>
+              <p class="step-text font-sans">{{ 'FROM' | translate }}</p>
               <input matInput class="step-input step-input-age" type="number" formControlName="minAge" appDigitOnly />
             </div>
           </div>
 
           <div class="flex flex-col justify-start items-start">
             <div class="flex flex-row justify-start items-center">
-              <p class="step-text">{{ 'TO' | translate }}</p>
+              <p class="step-text font-sans">{{ 'TO' | translate }}</p>
               <input matInput class="step-input step-input-age" type="number" formControlName="maxAge" appDigitOnly />
             </div>
           </div>

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.scss
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.scss
@@ -29,3 +29,10 @@
 :host ::ng-deep .mat-form-field-infix {
   width: auto !important;
 }
+
+::ng-deep .age-radio-btn {
+  .mdc-label {
+    padding: 0;
+    padding-left: 8px;
+  }
+}

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.spec.ts
@@ -87,6 +87,7 @@ describe('CreateAboutFormComponent', () => {
       shortTitle: new FormControl(''),
       phone: new FormControl(''),
       email: new FormControl(''),
+      noAgeRestrictions: new FormControl(false),
       minAge: new FormControl(''),
       maxAge: new FormControl(''),
       image: new FormControl(''),
@@ -164,6 +165,8 @@ describe('CreateAboutFormComponent', () => {
     component.workshop.noAgeRestrictions = true;
     component.workshop.minAge = 0;
     component.workshop.maxAge = 120;
+
+    component.activateEditMode();
 
     expect(component.AboutFormGroup.controls.minAge.value).toBe(null);
     expect(component.AboutFormGroup.controls.maxAge.value).toBe(null);

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.spec.ts
@@ -141,6 +141,33 @@ describe('CreateAboutFormComponent', () => {
       expect(component.isShowHintAboutWorkshopAutoClosing).toBe(false);
     });
   });
+
+  it('should disable age input fields if noAgeRestrictions is true', () => {
+    component.AboutFormGroup.controls.noAgeRestrictions.setValue(true);
+
+    expect(component.AboutFormGroup.controls.minAge.disabled).toBe(true);
+    expect(component.AboutFormGroup.controls.maxAge.disabled).toBe(true);
+    expect(component.AboutFormGroup.controls.minAge.value).toBe(null);
+    expect(component.AboutFormGroup.controls.maxAge.value).toBe(null);
+  });
+
+  it('should enable age input fields if noAgeRestrictions is false', () => {
+    component.AboutFormGroup.controls.noAgeRestrictions.setValue(false);
+
+    expect(component.AboutFormGroup.controls.minAge.disabled).toBe(false);
+    expect(component.AboutFormGroup.controls.maxAge.disabled).toBe(false);
+    expect(component.AboutFormGroup.controls.minAge.touched).toBe(false);
+    expect(component.AboutFormGroup.controls.maxAge.touched).toBe(false);
+  });
+
+  it('should set null value to age input fields if noAgeRestrictions is true', () => {
+    component.workshop.noAgeRestrictions = true;
+    component.workshop.minAge = 0;
+    component.workshop.maxAge = 120;
+
+    expect(component.AboutFormGroup.controls.minAge.value).toBe(null);
+    expect(component.AboutFormGroup.controls.maxAge.value).toBe(null);
+  });
 });
 
 @Component({
@@ -164,6 +191,9 @@ class MockValidationHintAboutComponent {
   @Input() minMaxDate: boolean;
   @Input() isPhoneNumber: boolean;
   @Input() minNumberValue: boolean;
+  @Input() maxValue: boolean;
+  @Input() minValue: boolean;
+  @Input() isNumberValue: boolean;
 }
 
 @Component({

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
@@ -125,6 +125,14 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
       this.availableSeatsRadioBtnControl.setValue(false);
     }
 
+    if (this.workshop.noAgeRestrictions) {
+      this.AboutFormGroup.get('maxAge').setValue(null, { emitEvent: false });
+      this.AboutFormGroup.get('minAge').setValue(null, { emitEvent: false });
+    } else {
+      this.AboutFormGroup.get('minAge').enable({ emitEvent: true });
+      this.AboutFormGroup.get('maxAge').enable({ emitEvent: true });
+    }
+
     if (this.route.snapshot.paramMap.get('entity') === 'workshop') {
       this.listenToChanges();
     }
@@ -145,16 +153,21 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
           Validators.pattern(MUST_CONTAIN_LETTERS),
           Validators.minLength(ValidationConstants.INPUT_LENGTH_1)
         ]),
-        minAge: new FormControl(null, [
-          Validators.required,
-          Validators.max(ValidationConstants.BIRTH_AGE_MAX),
-          Validators.min(ValidationConstants.AGE_MIN)
-        ]),
-        maxAge: new FormControl(null, [
-          Validators.required,
-          Validators.max(ValidationConstants.BIRTH_AGE_MAX),
-          Validators.min(ValidationConstants.AGE_MIN)
-        ]),
+        noAgeRestrictions: new FormControl(true),
+        minAge: new FormControl(
+          {
+            value: null,
+            disabled: true
+          },
+          [Validators.required, Validators.max(ValidationConstants.BIRTH_AGE_MAX), Validators.min(ValidationConstants.AGE_MIN)]
+        ),
+        maxAge: new FormControl(
+          {
+            value: null,
+            disabled: true
+          },
+          [Validators.required, Validators.max(ValidationConstants.BIRTH_AGE_MAX), Validators.min(ValidationConstants.AGE_MIN)]
+        ),
         image: new FormControl(''),
         dateTimeRanges: this.dateTimeRangesArray,
         formOfLearning: new FormControl(FormOfLearning.Offline, [Validators.required]),
@@ -179,11 +192,12 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
     this.availableSeatsControlListener();
     this.validateAgeControls();
     this.showHintAboutClosingWorkshop();
+    this.noAgeRestrictionsControlListener();
   }
 
   /**
    * This method add listener to availableSeats control and
-   * makes formGroup input enable if radiobutton value is true
+   * makes formGroup input enable if radio button value is true
    */
   private availableSeatsControlListener(): void {
     this.availableSeatsRadioBtnControl.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((noLimit: boolean) => {
@@ -194,6 +208,31 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
         this.setAvailableSeatsControlValue(this.availableSeats, 'enable');
       }
     });
+  }
+
+  /**
+   * This method add listener to unlimitedAge control and
+   * makes formGroup input disable if radio button value is true
+   */
+  private noAgeRestrictionsControlListener(): void {
+    this.AboutFormGroup.get('noAgeRestrictions')
+      .valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((noLimit: boolean) => {
+        const ageFormControls = ['maxAge', 'minAge'];
+        if (noLimit) {
+          ageFormControls.forEach((field) => {
+            const control = this.AboutFormGroup.get(field);
+            control?.disable();
+            control?.setValue(null, { emitEvent: false });
+          });
+        } else {
+          ageFormControls.forEach((field) => {
+            const control = this.AboutFormGroup.get(field);
+            control?.enable({ emitEvent: false });
+            control?.markAsUntouched();
+          });
+        }
+      });
   }
 
   /**

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
@@ -222,7 +222,7 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
         if (noLimit) {
           ageFormControls.forEach((field) => {
             const control = this.AboutFormGroup.get(field);
-            control?.disable();
+            control?.disable({ emitEvent: true });
             control?.setValue(null, { emitEvent: false });
           });
         } else {

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
@@ -129,8 +129,8 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
       this.AboutFormGroup.get('maxAge').setValue(null, { emitEvent: false });
       this.AboutFormGroup.get('minAge').setValue(null, { emitEvent: false });
     } else {
-      this.AboutFormGroup.get('minAge').enable({ emitEvent: true });
-      this.AboutFormGroup.get('maxAge').enable({ emitEvent: true });
+      this.AboutFormGroup.get('minAge').enable();
+      this.AboutFormGroup.get('maxAge').enable();
     }
 
     if (this.route.snapshot.paramMap.get('entity') === 'workshop') {
@@ -222,7 +222,7 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
         if (noLimit) {
           ageFormControls.forEach((field) => {
             const control = this.AboutFormGroup.get(field);
-            control?.disable({ emitEvent: true });
+            control?.disable();
             control?.setValue(null, { emitEvent: false });
           });
         } else {


### PR DESCRIPTION
#2852 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to specify whether a workshop has no age restrictions or requires a specific age range when creating or editing a workshop.
- **Improvements**
  - The age input section now uses a radio button group, allowing users to easily toggle between unlimited age and setting minimum/maximum ages.
  - Age fields are automatically enabled or disabled based on the selected restriction option.
- **Style**
  - Updated styles for the age restriction radio buttons to improve layout and readability.
- **Bug Fixes**
  - Prevented submission of empty age fields for workshops with no age restrictions.
- **Tests**
  - Added tests to verify the behavior of age restriction controls and their interaction in the workshop creation form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->