### PR TITLE
Pasternak/#2842-provider-personal-cabinet-redirections-fix

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,5 +1,5 @@
 <div class="header" [ngClass]="{ 'header-secondary': !isRouter('/'), 'header-disabled': isRouter('/server-error') }">
-    <div [ngClass]="{ 'hide-content': (isAuthorizationLoading$ | async) }">
+  <div [ngClass]="{ 'hide-content': (isAuthorizationLoading$ | async) }">
     <div class="flex flex-row justify-between">
       <div class="logo-wrapper" *ngIf="isMobileScreen && !!navigationPaths?.length; then mobileNavTmpl; else logoTmpl"></div>
       <div class="link-wrapper">
@@ -59,7 +59,7 @@
   <app-navigation-mobile-bar [ngClass]="'nav-mobile'"></app-navigation-mobile-bar>
 </ng-template>
 
-<ng-template #logoTmpl> 
+<ng-template #logoTmpl>
   <a routerLink="/"><img class="logo" src="assets/images/Logo.svg" alt="Позашкілля" /></a>
 </ng-template>
 
@@ -157,7 +157,7 @@
         {{ 'ENUM.NAV_BAR_NAME.SUBJECTS' | translate }}
       </button>
     </a>
-    <a *ngIf="user.role === Role.provider || user.role === Role.providerDeputy" [routerLink]="'./personal-cabinet/provider/administration'">
+    <a *ngIf="user.role === Role.providerDeputy" [routerLink]="'./personal-cabinet/provider/administration'">
       <button mat-menu-item>
         {{ 'ENUM.NAV_BAR_NAME.ADMINISTRATION' | translate }}
       </button>

--- a/src/app/shared/store/provider.state.ts
+++ b/src/app/shared/store/provider.state.ts
@@ -746,7 +746,7 @@ export class ProviderState {
         type: 'success'
       })
     ]);
-    this.router.navigate(['/personal-cabinet/provider/administration']);
+    this.router.navigate(['/personal-cabinet/provider/provider-employees']);
   }
 
   @Action(providerActions.BlockEmployeeById)
@@ -836,7 +836,7 @@ export class ProviderState {
         type: 'success'
       })
     ]);
-    this.router.navigate(['/personal-cabinet/provider/administration']);
+    this.router.navigate(['/personal-cabinet/provider/provider-employees']);
   }
 
   @Action(providerActions.UpdateWorkshopStatus)

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
@@ -96,7 +96,7 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
         this.navigationBarService.createNavPaths(
           {
             name: personalCabinetTitle,
-            path: '/personal-cabinet/provider/administration',
+            path: '/personal-cabinet/provider/competitions',
             isActive: false,
             disable: false
           },

--- a/src/app/shell/personal-cabinet/provider/create-employee/create-employee.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-employee/create-employee.component.html
@@ -58,13 +58,15 @@
           <mat-form-field appearance="fill">
             <input matInput class="step-input" type="email" formControlName="email" appTrimValue [placeholder]="mailFormPlaceholder" />
           </mat-form-field>
-          <app-validation-hint [maxCharacters]="validationConstants.INPUT_LENGTH_254" [validationFormControl]="EmployeeFormGroup.get('email')"></app-validation-hint>
+          <app-validation-hint
+            [maxCharacters]="validationConstants.INPUT_LENGTH_254"
+            [validationFormControl]="EmployeeFormGroup.get('email')"></app-validation-hint>
         </form>
 
         <ng-container *ngTemplateOutlet="AgreementsTmpl"></ng-container>
 
         <div class="footer flex flex-row justify-center items-center">
-          <a [routerLink]="'/personal-cabinet/provider/administration'">
+          <a [routerLink]="'/personal-cabinet/provider/provider-employees'">
             <button mat-raised-button class="btn btn-cancel">{{ 'BUTTONS.CANCEL' | translate }}</button>
           </a>
           <button

--- a/src/app/shell/personal-cabinet/provider/create-employee/create-employee.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-employee/create-employee.component.ts
@@ -150,7 +150,7 @@ export class CreateEmployeeComponent extends CreateFormComponent implements OnIn
         this.navigationBarService.createNavPaths(
           {
             name: personalCabinetTitle,
-            path: '/personal-cabinet/provider/administration',
+            path: '/personal-cabinet/provider/provider-employees',
             isActive: false,
             disable: false
           },
@@ -204,7 +204,7 @@ export class CreateEmployeeComponent extends CreateFormComponent implements OnIn
   }
 
   public onCancel(): void {
-    this.router.navigate(['/personal-cabinet/provider/administration']);
+    this.router.navigate(['/personal-cabinet/provider/provider-employees']);
   }
 
   /**

--- a/src/app/shell/personal-cabinet/provider/create-position/create-position.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-position/create-position.component.ts
@@ -111,7 +111,7 @@ export class CreatePositionComponent extends CreateFormComponent implements OnIn
         this.navigationBarService.createNavPaths(
           {
             name: personalCabinetTitle,
-            path: '/personal-cabinet/provider/administration',
+            path: '/personal-cabinet/provider/positions',
             isActive: false,
             disable: false
           },

--- a/src/app/shell/personal-cabinet/provider/create-study-subject/create-study-subject.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-study-subject/create-study-subject.component.ts
@@ -126,7 +126,7 @@ export class CreateStudySubjectComponent extends CreateFormComponent implements 
         this.navigationBarService.createNavPaths(
           {
             name: personalCabinetTitle,
-            path: '/personal-cabinet/provider/administration',
+            path: '/personal-cabinet/provider/study-subjects',
             isActive: false,
             disable: false
           },

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
@@ -142,7 +142,7 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
         this.navigationBarService.createNavPaths(
           {
             name: personalCabinetTitle,
-            path: '/personal-cabinet/provider/administration',
+            path: '/personal-cabinet/provider/workshops',
             isActive: false,
             disable: false
           },


### PR DESCRIPTION
changed routing in provider components to avoid redirection to nonexistent page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- The "Administration" navigation link in the user menu is now only visible to users with the "providerDeputy" role.
	- Cancel buttons and navigation actions in employee management now correctly redirect to the "provider-employees" page instead of "administration".

- **Refactor**
	- Updated navigation paths in various provider personal cabinet sections (competitions, positions, study subjects, workshops) to point to their respective pages instead of the administration page.
	- Minor formatting improvements in templates for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->