### PR TITLE
litviniuk/increased maximum scss files capacity

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -71,8 +71,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
-                  "maximumError": "10kb"
+                  "maximumWarning": "8kb",
+                  "maximumError": "12kb"
                 }
               ]
             },

--- a/src/app/shared/components/navigation-bar/navigation-bar.component.scss
+++ b/src/app/shared/components/navigation-bar/navigation-bar.component.scss
@@ -31,9 +31,7 @@
 
   .pathLink {
     line-height: 1;
-    // temporarily commented font-family
-    //font-family: 'Innerspace', serif;
-
+    font-family: 'Innerspace', serif;
     .mat-icon {
       transform: translateY(10%);
     }

--- a/src/app/shared/styles/theme/index.scss
+++ b/src/app/shared/styles/theme/index.scss
@@ -3,7 +3,7 @@
 @use '@angular/material' as mat;
 
 @font-face {
-  font-family: 'Innerspace', sans-serif;
+  font-family: 'Innerspace';
   src:
     local('Innerspace'),
     url('../../../../assets/fonts/Innerspace/Innerspace-normal.ttf') format('truetype'),
@@ -13,7 +13,7 @@
 $config: mat.define-typography-config(
   $font-family: 'Innerspace',
   // temporarily font-family for buttons
-  $button: mat.define-typography-level(13px, 15px, 700, 'Open Sans')
+  $button: mat.define-typography-level(13px, 15px, 700, 'Innerspace', sans-serif)
 );
 
 @mixin mat-form-typography($config) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Restored the use of the 'Innerspace' font for navigation links.
  - Updated button typography to use 'Innerspace' as the primary font with 'sans-serif' as fallback.
  - Adjusted font declarations for improved consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->