### PR TITLE
Pryshchenko/fixed-the-bug-1715-remove-the-addition-of-achievement

### DIFF
--- a/src/app/shared/components/notifications/notifications.component.spec.ts
+++ b/src/app/shared/components/notifications/notifications.component.spec.ts
@@ -10,6 +10,7 @@ import { SignalRService } from 'shared/services/signalR/signal-r.service';
 import { ChatStateModel } from 'shared/store/chat.state';
 import { NotificationStateModel } from 'shared/store/notification.state';
 import { RegistrationStateModel } from 'shared/store/registration.state';
+import { MetaDataStateModel } from 'shared/store/meta-data.state';
 import { MockOidcSecurityService } from '../../mocks/mock-services';
 import { NotificationsComponent } from './notifications.component';
 
@@ -19,7 +20,11 @@ describe('NotificationsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([MockNotificationState, MockChatState, MockRegistrationState]), MatMenuModule, MatIconModule],
+      imports: [
+        NgxsModule.forRoot([MockNotificationState, MockChatState, MockRegistrationState, MockMetaDataState]),
+        MatMenuModule,
+        MatIconModule
+      ],
       declarations: [NotificationsComponent, MockNotificationsListComponent],
       providers: [{ provide: OidcSecurityService, useValue: MockOidcSecurityService }, SignalRService],
       schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA]
@@ -74,3 +79,41 @@ class MockChatState {}
 })
 @Injectable()
 class MockRegistrationState {}
+
+@State<MetaDataStateModel>({
+  name: 'metaDataState',
+  defaults: {
+    directions: null,
+    socialGroups: [],
+    institutionStatuses: null,
+    providerTypes: null,
+    achievementsTypes: null,
+    rating: null,
+    isLoading: false,
+    featuresList: {
+      release1: true,
+      release2: true,
+      release3: true,
+      images: true,
+      showForProduction: true,
+      onlyUkrainianLanguage: false,
+      directionManagement: true,
+      achievementManagement: true,
+      messagingFeature: true,
+      adminsChildrenParentsManagement: true,
+      emailConfirmation: true,
+      emailManagement: true,
+      passwordManagement: true
+    },
+    institutions: null,
+    institutionFieldDesc: null,
+    instituitionsHierarchyAll: null,
+    instituitionsHierarchy: null,
+    editInstituitionsHierarchy: null,
+    codeficatorSearch: [],
+    codeficator: null,
+    languageList: null
+  }
+})
+@Injectable()
+class MockMetaDataState {}

--- a/src/app/shared/components/notifications/notifications.component.ts
+++ b/src/app/shared/components/notifications/notifications.component.ts
@@ -13,6 +13,7 @@ import { GetAmountOfNewUsersNotifications, ReadUsersNotificationsByType } from '
 import { NotificationState } from 'shared/store/notification.state';
 import { RegistrationState } from 'shared/store/registration.state';
 import { isRoleAdmin } from 'shared/utils/admin.utils';
+import { MetaDataState } from 'shared/store/meta-data.state';
 
 @Component({
   selector: 'app-notifications',
@@ -44,9 +45,10 @@ export class NotificationsComponent implements OnInit, AfterViewChecked, OnDestr
   public ngOnInit(): void {
     this.hubConnection = this.signalRService.startConnection(NOTIFICATION_HUB_URL);
     const role = this.store.selectSnapshot(RegistrationState.role);
+    const featuresList = this.store.selectSnapshot(MetaDataState.featuresList);
 
     this.store.dispatch(new GetAmountOfNewUsersNotifications());
-    if (!isRoleAdmin(role)) {
+    if (!isRoleAdmin(role) && featuresList.messagingFeature) {
       this.store.dispatch(new GetUnreadMessagesCount());
     }
     this.hubConnection.on('ReceiveNotification', (receivedNotificationString: string) => {

--- a/src/app/shell/details/workshop-details/workshop-details.component.html
+++ b/src/app/shell/details/workshop-details/workshop-details.component.html
@@ -151,7 +151,10 @@
       <mat-tab *ngIf="role !== Role.unauthorized" class="label" [label]="workshopTitles.Reviews | translate | uppercase">
         <app-reviews [workshop]="workshop" [role]="role"></app-reviews>
       </mat-tab>
-      <mat-tab class="label" label="{{ workshopTitles.Achievements | translate | uppercase }}">
+      <mat-tab
+        *ngIf="(featuresList$ | async)?.achievementManagement"
+        class="label"
+        label="{{ workshopTitles.Achievements | translate | uppercase }}">
         <app-achievements [workshop]="workshop"></app-achievements>
       </mat-tab>
       <mat-tab class="label" label="{{ workshopTitles.Contacts | translate | uppercase }}">

--- a/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
@@ -8,7 +8,7 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
-import { NgxsModule, Store } from '@ngxs/store';
+import { NgxsModule, Store, Actions } from '@ngxs/store';
 import { of } from 'rxjs';
 
 import { ImageCarouselComponent } from 'shared/components/image-carousel/image-carousel.component';
@@ -20,6 +20,8 @@ import { ConfirmationModalWindowComponent } from 'shared/components/confirmation
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Constants } from 'shared/constants/constants';
 import { GetWorkshopDraftIdByWorkshopId } from 'shared/store/provider.actions';
+import { ImagesService } from 'shared/services/images/images.service';
+import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
 import { WorkshopDetailsComponent } from './workshop-details.component';
 
 describe('WorkshopDetailsComponent', () => {
@@ -37,7 +39,18 @@ describe('WorkshopDetailsComponent', () => {
     queryParams: of({ status: '111' })
   };
   const mockStore = {
-    dispatch: jest.fn()
+    dispatch: jest.fn(),
+    select: jest.fn().mockReturnValue(of({}))
+  };
+  const mockActions = {
+    pipe: jest.fn().mockReturnValue(of({}))
+  };
+  const mockImagesService = {
+    getCoverImage: jest.fn().mockReturnValue('test-image.jpg'),
+    getDefaultCoverImage: jest.fn().mockReturnValue('default-image.jpg')
+  };
+  const mockNavigationBarService = {
+    createNavPaths: jest.fn().mockReturnValue([])
   };
   const mockRouter = {
     navigate: jest.fn()
@@ -68,6 +81,9 @@ describe('WorkshopDetailsComponent', () => {
       providers: [
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
         { provide: Store, useValue: mockStore },
+        { provide: Actions, useValue: mockActions },
+        { provide: ImagesService, useValue: mockImagesService },
+        { provide: NavigationBarService, useValue: mockNavigationBarService },
         { provide: Router, useValue: mockRouter }
       ],
       schemas: [NO_ERRORS_SCHEMA]

--- a/src/app/shell/details/workshop-details/workshop-details.component.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.ts
@@ -2,8 +2,8 @@ import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatTabChangeEvent, MatTabGroup } from '@angular/material/tabs';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
-import { Actions, ofAction, Store } from '@ngxs/store';
-import { of, Subject } from 'rxjs';
+import { Actions, ofAction, Store, Select } from '@ngxs/store';
+import { of, Subject, Observable } from 'rxjs';
 import { debounceTime, filter, switchMap, take, takeUntil, tap } from 'rxjs/operators';
 
 import { Constants, PaginationConstants } from 'shared/constants/constants';
@@ -29,6 +29,8 @@ import { ConfirmationModalWindowComponent } from 'shared/components/confirmation
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Util } from 'shared/utils/utils';
 import { isRoleProvider } from 'shared/utils/provider.utils';
+import { MetaDataState } from 'shared/store/meta-data.state';
+import { FeaturesList } from 'shared/models/features-list.model';
 
 @Component({
   selector: 'app-workshop-details',
@@ -51,6 +53,9 @@ export class WorkshopDetailsComponent implements OnInit, OnDestroy {
   public displayActionCard: boolean;
   @Input()
   public currentProvider: Provider;
+
+  @Select(MetaDataState.featuresList)
+  public featuresList$: Observable<FeaturesList>;
 
   public readonly categoryIcons = CategoryIcons;
   public readonly recruitmentStatusEnum = RecruitmentStatusEnum;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "Achievements" tab in workshop details is now only visible if the achievement management feature is enabled.
- **Improvements**
  - Notifications now retrieve unread messages only for non-admin users when the messaging feature is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->