### PR TITLE
Spelina/reseting competition on destroy

### DIFF
--- a/src/app/shared/store/shared-user.actions.ts
+++ b/src/app/shared/store/shared-user.actions.ts
@@ -97,12 +97,7 @@ export class GetFilteredChildren {
   constructor() {}
 }
 
-export class ResetProviderWorkshopDetails {
-  static readonly type = '[user] clear Provider And Workshop Details';
-  constructor() {}
-}
-
-export class ResetProviderCompetitionDetails {
-  static readonly type = '[user] clear Provider And Competition Details';
+export class ResetProviderWorkshopAndCompetitionDetails {
+  static readonly type = '[user] clear Provider, Workshop, Competition Details';
   constructor() {}
 }

--- a/src/app/shared/store/shared-user.actions.ts
+++ b/src/app/shared/store/shared-user.actions.ts
@@ -97,7 +97,17 @@ export class GetFilteredChildren {
   constructor() {}
 }
 
-export class ResetProviderWorkshopAndCompetitionDetails {
-  static readonly type = '[user] clear Provider, Workshop, Competition Details';
+export class ResetProvider {
+  static readonly type = '[user] clear Provider';
+  constructor() {}
+}
+
+export class ResetWorkshop {
+  static readonly type = '[user] clear Workshop';
+  constructor() {}
+}
+
+export class ResetCompetition {
+  static readonly type = '[user] clear Competition';
   constructor() {}
 }

--- a/src/app/shared/store/shared-user.state.ts
+++ b/src/app/shared/store/shared-user.state.ts
@@ -36,7 +36,9 @@ import {
   OnGetWorkshopDraftByIdSuccess,
   OnUpdateApplicationFail,
   OnUpdateApplicationSuccess,
-  ResetProviderWorkshopAndCompetitionDetails,
+  ResetCompetition,
+  ResetProvider,
+  ResetWorkshop,
   UpdateApplication
 } from './shared-user.actions';
 
@@ -258,8 +260,18 @@ export class SharedUserState {
     ]);
   }
 
-  @Action(ResetProviderWorkshopAndCompetitionDetails)
-  clearProviderWorkshopAndCompetitionDetails({ patchState }: StateContext<SharedUserStateModel>): void {
-    patchState({ selectedWorkshop: null, selectedCompetition: null, selectedProvider: null });
+  @Action(ResetProvider)
+  clearProviderDetails({ patchState }: StateContext<SharedUserStateModel>): void {
+    patchState({ selectedProvider: null });
+  }
+
+  @Action(ResetWorkshop)
+  clearWorkshopDetails({ patchState }: StateContext<SharedUserStateModel>): void {
+    patchState({ selectedWorkshop: null });
+  }
+
+  @Action(ResetCompetition)
+  clearCompetitionDetails({ patchState }: StateContext<SharedUserStateModel>): void {
+    patchState({ selectedCompetition: null });
   }
 }

--- a/src/app/shared/store/shared-user.state.ts
+++ b/src/app/shared/store/shared-user.state.ts
@@ -36,7 +36,7 @@ import {
   OnGetWorkshopDraftByIdSuccess,
   OnUpdateApplicationFail,
   OnUpdateApplicationSuccess,
-  ResetProviderWorkshopDetails,
+  ResetProviderWorkshopAndCompetitionDetails,
   UpdateApplication
 } from './shared-user.actions';
 
@@ -258,8 +258,8 @@ export class SharedUserState {
     ]);
   }
 
-  @Action(ResetProviderWorkshopDetails)
-  clearProviderWorkshopDetails({ patchState }: StateContext<SharedUserStateModel>): void {
-    patchState({ selectedWorkshop: null, selectedProvider: null });
+  @Action(ResetProviderWorkshopAndCompetitionDetails)
+  clearProviderWorkshopAndCompetitionDetails({ patchState }: StateContext<SharedUserStateModel>): void {
+    patchState({ selectedWorkshop: null, selectedCompetition: null, selectedProvider: null });
   }
 }

--- a/src/app/shell/details/competition-details/competition-details.component.ts
+++ b/src/app/shell/details/competition-details/competition-details.component.ts
@@ -21,6 +21,7 @@ import { ImagesService } from 'shared/services/images/images.service';
 import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
 import { AddNavPath } from 'shared/store/navigation.actions';
 import { GetProviderById } from 'shared/store/shared-user.actions';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-competition-details',
@@ -79,6 +80,7 @@ export class CompetitionDetailsComponent implements OnInit {
     dialogRef
       .afterClosed()
       .pipe(
+        take(1),
         filter(Boolean)
         /*
          * todo: this code should be return when

--- a/src/app/shell/details/details.component.html
+++ b/src/app/shell/details/details.component.html
@@ -1,5 +1,5 @@
 <div class="flex flex-col lg:flex-row gap-0 lg:gap-8 justify-between items-stretch box-border">
-  <ng-container *ngIf="workshop && workshopType !== WorkshopType.Competition; then WorkshopDetails; else CompetitionDetails"></ng-container>
+  <ng-container *ngIf="workshop; then WorkshopDetails; else CompetitionDetails"></ng-container>
   <app-side-menu
     *ngIf="provider"
     [workshop]="workshop"

--- a/src/app/shell/details/details.component.ts
+++ b/src/app/shell/details/details.component.ts
@@ -19,7 +19,9 @@ import {
   GetProviderById,
   GetWorkshopById,
   GetWorkshopDraftById,
-  ResetProviderWorkshopAndCompetitionDetails
+  ResetCompetition,
+  ResetProvider,
+  ResetWorkshop
 } from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 import { WorkshopType } from 'shared/enum/workshop';
@@ -66,7 +68,6 @@ export class DetailsComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params: Params) => {
-      this.store.dispatch(new ResetProviderWorkshopAndCompetitionDetails());
       this.workshopType = params.entity;
       this.getEntity(params.id);
 
@@ -77,7 +78,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
-    this.store.dispatch([new DeleteNavPath(), new ResetProviderWorkshopAndCompetitionDetails()]);
+    this.store.dispatch([new DeleteNavPath(), new ResetProvider(), new ResetWorkshop(), new ResetCompetition()]);
     this.destroy$.next(true);
     this.destroy$.unsubscribe();
   }

--- a/src/app/shell/details/details.component.ts
+++ b/src/app/shell/details/details.component.ts
@@ -19,7 +19,7 @@ import {
   GetProviderById,
   GetWorkshopById,
   GetWorkshopDraftById,
-  ResetProviderWorkshopDetails
+  ResetProviderWorkshopAndCompetitionDetails
 } from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 import { WorkshopType } from 'shared/enum/workshop';
@@ -66,7 +66,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params: Params) => {
-      this.store.dispatch(new ResetProviderWorkshopDetails());
+      this.store.dispatch(new ResetProviderWorkshopAndCompetitionDetails());
       this.workshopType = params.entity;
       this.getEntity(params.id);
 
@@ -77,7 +77,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
-    this.store.dispatch([new DeleteNavPath(), new ResetProviderWorkshopDetails()]);
+    this.store.dispatch([new DeleteNavPath(), new ResetProviderWorkshopAndCompetitionDetails()]);
     this.destroy$.next(true);
     this.destroy$.unsubscribe();
   }

--- a/src/app/shell/personal-cabinet/parent/create-application/create-application.component.ts
+++ b/src/app/shell/personal-cabinet/parent/create-application/create-application.component.ts
@@ -23,7 +23,7 @@ import { AddNavPath, DeleteNavPath } from 'shared/store/navigation.actions';
 import { CreateApplication, GetStatusIsAllowToApply, GetUsersChildren } from 'shared/store/parent.actions';
 import { ParentState } from 'shared/store/parent.state';
 import { RegistrationState } from 'shared/store/registration.state';
-import { GetWorkshopById, ResetProviderWorkshopAndCompetitionDetails } from 'shared/store/shared-user.actions';
+import { GetWorkshopById, ResetWorkshop } from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 
 @Component({
@@ -161,7 +161,7 @@ export class CreateApplicationComponent implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
-    this.store.dispatch([new DeleteNavPath(), new ResetProviderWorkshopAndCompetitionDetails()]);
+    this.store.dispatch([new DeleteNavPath(), new ResetWorkshop()]);
     this.destroy$.next(true);
     this.destroy$.unsubscribe();
   }

--- a/src/app/shell/personal-cabinet/parent/create-application/create-application.component.ts
+++ b/src/app/shell/personal-cabinet/parent/create-application/create-application.component.ts
@@ -23,7 +23,7 @@ import { AddNavPath, DeleteNavPath } from 'shared/store/navigation.actions';
 import { CreateApplication, GetStatusIsAllowToApply, GetUsersChildren } from 'shared/store/parent.actions';
 import { ParentState } from 'shared/store/parent.state';
 import { RegistrationState } from 'shared/store/registration.state';
-import { GetWorkshopById, ResetProviderWorkshopDetails } from 'shared/store/shared-user.actions';
+import { GetWorkshopById, ResetProviderWorkshopAndCompetitionDetails } from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 
 @Component({
@@ -161,7 +161,7 @@ export class CreateApplicationComponent implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
-    this.store.dispatch([new DeleteNavPath(), new ResetProviderWorkshopDetails()]);
+    this.store.dispatch([new DeleteNavPath(), new ResetProviderWorkshopAndCompetitionDetails()]);
     this.destroy$.next(true);
     this.destroy$.unsubscribe();
   }

--- a/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.ts
@@ -26,7 +26,7 @@ import { AddNavPath } from 'shared/store/navigation.actions';
 import { CreateAchievement, GetAchievementById, GetChildrenByWorkshopId, UpdateAchievement } from 'shared/store/provider.actions';
 import { ProviderState } from 'shared/store/provider.state';
 import { RegistrationState } from 'shared/store/registration.state';
-import { GetWorkshopById, ResetProviderWorkshopDetails } from 'shared/store/shared-user.actions';
+import { GetWorkshopById, ResetProviderWorkshopAndCompetitionDetails } from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 import { CreateFormComponent } from '../../shared-cabinet/create-form/create-form.component';
 
@@ -229,7 +229,7 @@ export class CreateAchievementComponent extends CreateFormComponent implements O
   }
 
   public ngOnDestroy(): void {
-    this.store.dispatch(new ResetProviderWorkshopDetails());
+    this.store.dispatch(new ResetProviderWorkshopAndCompetitionDetails());
     this.destroy$.next(true);
     this.destroy$.unsubscribe();
   }

--- a/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.ts
@@ -26,7 +26,7 @@ import { AddNavPath } from 'shared/store/navigation.actions';
 import { CreateAchievement, GetAchievementById, GetChildrenByWorkshopId, UpdateAchievement } from 'shared/store/provider.actions';
 import { ProviderState } from 'shared/store/provider.state';
 import { RegistrationState } from 'shared/store/registration.state';
-import { GetWorkshopById, ResetProviderWorkshopAndCompetitionDetails } from 'shared/store/shared-user.actions';
+import { GetWorkshopById, ResetWorkshop } from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 import { CreateFormComponent } from '../../shared-cabinet/create-form/create-form.component';
 
@@ -47,6 +47,7 @@ export class CreateAchievementComponent extends CreateFormComponent implements O
 
   public workshop: Workshop;
   protected readonly dateFilter = DATE_REGEX;
+
   private readonly validationConstants = ValidationConstants;
   private AchievementFormGroup: FormGroup;
   private achievement: Achievement;
@@ -229,7 +230,7 @@ export class CreateAchievementComponent extends CreateFormComponent implements O
   }
 
   public ngOnDestroy(): void {
-    this.store.dispatch(new ResetProviderWorkshopAndCompetitionDetails());
+    this.store.dispatch(new ResetWorkshop());
     this.destroy$.next(true);
     this.destroy$.unsubscribe();
   }

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
@@ -12,7 +12,7 @@ import { Provider } from 'shared/models/provider.model';
 import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
 import { AddNavPath } from 'shared/store/navigation.actions';
 import { RegistrationState } from 'shared/store/registration.state';
-import { GetCompetitionById, ResetProviderWorkshopAndCompetitionDetails } from 'shared/store/shared-user.actions';
+import { GetCompetitionById, ResetCompetition } from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 import { Judge } from 'shared/models/judge.model';
 import { Constants } from 'shared/constants/constants';
@@ -188,7 +188,7 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   public ngOnDestroy(): void {
     super.ngOnDestroy();
-    this.store.dispatch(new ResetProviderWorkshopAndCompetitionDetails());
+    this.store.dispatch(new ResetCompetition());
   }
 
   /**

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
@@ -12,7 +12,7 @@ import { Provider } from 'shared/models/provider.model';
 import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
 import { AddNavPath } from 'shared/store/navigation.actions';
 import { RegistrationState } from 'shared/store/registration.state';
-import { GetCompetitionById, ResetProviderCompetitionDetails } from 'shared/store/shared-user.actions';
+import { GetCompetitionById, ResetProviderWorkshopAndCompetitionDetails } from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 import { Judge } from 'shared/models/judge.model';
 import { Constants } from 'shared/constants/constants';
@@ -148,7 +148,7 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   /**
    * This method receives a form from create-required child component and assigns to the Address FormGroup
-   * @param FormGroup form
+   * @param form
    */
   public onReceiveRequiredFormGroup(form: FormGroup): void {
     this.RequiredFormGroup = form;
@@ -157,7 +157,7 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   /**
    * This method receives a from create-description child component and assigns to the Description FormGroup
-   * @param FormGroup form
+   * @param form
    */
   public onReceiveDescriptionFormGroup(form: FormGroup): void {
     this.DescriptionFormGroup = form;
@@ -166,7 +166,7 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   /**
    * This method receives a form from create-address child component and assigns to the Address FormGroup
-   * @param FormGroup form
+   * @param array
    */
   public onReceiveContactsFormArray(array: FormArray): void {
     this.ContactsFormArray = array;
@@ -175,7 +175,7 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   /**
    * This method receives an array of forms from create-judge child component and assigns to the Judge FormArray
-   * @param FormArray array
+   * @param array
    */
   public onReceiveJudgeFormArray(array: FormArray): void {
     this.JudgeFormArray = array;
@@ -188,7 +188,7 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   public ngOnDestroy(): void {
     super.ngOnDestroy();
-    this.store.dispatch(new ResetProviderCompetitionDetails());
+    this.store.dispatch(new ResetProviderWorkshopAndCompetitionDetails());
   }
 
   /**
@@ -204,7 +204,6 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   /**
    * This method create array of judges
-   * @param FormArray formArray
    */
   private createJudges(): Judge[] {
     const judges: Judge[] = [];

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
@@ -24,7 +24,7 @@ import {
   UpdateWorkshop
 } from 'shared/store/provider.actions';
 import { RegistrationState } from 'shared/store/registration.state';
-import { GetWorkshopById, GetWorkshopDraftById, ResetProviderWorkshopAndCompetitionDetails } from 'shared/store/shared-user.actions';
+import { GetWorkshopById, GetWorkshopDraftById, ResetProvider, ResetWorkshop } from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 import { ShowMessageBar } from 'shared/store/app.actions';
 import { SnackbarText } from 'shared/enum/enumUA/message-bar';
@@ -331,7 +331,7 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
 
   public ngOnDestroy(): void {
     super.ngOnDestroy();
-    this.store.dispatch(new ResetProviderWorkshopAndCompetitionDetails());
+    this.store.dispatch([new ResetProvider(), new ResetWorkshop()]);
   }
 
   // eslint-disable-next-line @typescript-eslint/typedef

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
@@ -24,7 +24,7 @@ import {
   UpdateWorkshop
 } from 'shared/store/provider.actions';
 import { RegistrationState } from 'shared/store/registration.state';
-import { GetWorkshopById, GetWorkshopDraftById, ResetProviderWorkshopDetails } from 'shared/store/shared-user.actions';
+import { GetWorkshopById, GetWorkshopDraftById, ResetProviderWorkshopAndCompetitionDetails } from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 import { ShowMessageBar } from 'shared/store/app.actions';
 import { SnackbarText } from 'shared/enum/enumUA/message-bar';
@@ -331,7 +331,7 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
 
   public ngOnDestroy(): void {
     super.ngOnDestroy();
-    this.store.dispatch(new ResetProviderWorkshopDetails());
+    this.store.dispatch(new ResetProviderWorkshopAndCompetitionDetails());
   }
 
   // eslint-disable-next-line @typescript-eslint/typedef

--- a/src/app/shell/personal-cabinet/shared-cabinet/messages/chat/chat.component.ts
+++ b/src/app/shell/personal-cabinet/shared-cabinet/messages/chat/chat.component.ts
@@ -4,7 +4,7 @@ import { FormControl } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import * as signalR from '@microsoft/signalr';
 import { Select, Store } from '@ngxs/store';
-import { Observable, Subject, asyncScheduler, filter, map, takeUntil } from 'rxjs';
+import { asyncScheduler, filter, map, Observable, Subject, takeUntil } from 'rxjs';
 
 import { ModeConstants } from 'shared/constants/constants';
 import { CHAT_HUB_URL } from 'shared/constants/hubs-url';
@@ -13,7 +13,7 @@ import { SnackbarText } from 'shared/enum/enumUA/message-bar';
 import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
 import { UserStatusesTitles } from 'shared/enum/enumUA/statuses';
 import { Role } from 'shared/enum/role';
-import { UserStatusIcons, UserStatuses } from 'shared/enum/statuses';
+import { UserStatuses, UserStatusIcons } from 'shared/enum/statuses';
 import { ChatRoom, IncomingMessage, MessagesParameters, OutgoingMessage } from 'shared/models/chat.model';
 import { SignalRService } from 'shared/services/signalR/signal-r.service';
 import { ShowMessageBar } from 'shared/store/app.actions';
@@ -28,7 +28,7 @@ import {
 import { ChatState } from 'shared/store/chat.state';
 import { PopNavPath, PushNavPath } from 'shared/store/navigation.actions';
 import { RegistrationState } from 'shared/store/registration.state';
-import { ResetProviderWorkshopDetails } from 'shared/store/shared-user.actions';
+import { ResetProviderWorkshopAndCompetitionDetails } from 'shared/store/shared-user.actions';
 import { isRoleProvider } from 'shared/utils/provider.utils';
 import { Util } from 'shared/utils/utils';
 
@@ -90,7 +90,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
-    this.store.dispatch([new PopNavPath(), new ClearSelectedChatRoom(), new ResetProviderWorkshopDetails()]);
+    this.store.dispatch([new PopNavPath(), new ClearSelectedChatRoom(), new ResetProviderWorkshopAndCompetitionDetails()]);
     this.hubConnection.stop();
     this.destroy$.next(true);
     this.destroy$.unsubscribe();

--- a/src/app/shell/personal-cabinet/shared-cabinet/messages/chat/chat.component.ts
+++ b/src/app/shell/personal-cabinet/shared-cabinet/messages/chat/chat.component.ts
@@ -28,7 +28,7 @@ import {
 import { ChatState } from 'shared/store/chat.state';
 import { PopNavPath, PushNavPath } from 'shared/store/navigation.actions';
 import { RegistrationState } from 'shared/store/registration.state';
-import { ResetProviderWorkshopAndCompetitionDetails } from 'shared/store/shared-user.actions';
+import { ResetProvider } from 'shared/store/shared-user.actions';
 import { isRoleProvider } from 'shared/utils/provider.utils';
 import { Util } from 'shared/utils/utils';
 
@@ -90,7 +90,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
-    this.store.dispatch([new PopNavPath(), new ClearSelectedChatRoom(), new ResetProviderWorkshopAndCompetitionDetails()]);
+    this.store.dispatch([new PopNavPath(), new ClearSelectedChatRoom(), new ResetProvider()]);
     this.hubConnection.stop();
     this.destroy$.next(true);
     this.destroy$.unsubscribe();


### PR DESCRIPTION
#2894 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved observable handling to ensure dialog actions are processed only once after closing.

- **Refactor**
	- Split reset actions to separately clear provider, workshop, and competition details for more precise state management.
	- Streamlined template logic for displaying workshop and competition details.
	- Cleaned up and clarified documentation comments and import order for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->