### PR TITLE
Spelina/[create competition] registration dates are no longer required

### DIFF
--- a/src/app/shared/components/validation-hint/validation-hint.component.ts
+++ b/src/app/shared/components/validation-hint/validation-hint.component.ts
@@ -218,7 +218,7 @@ export class ValidationHintComponent implements OnInit, OnDestroy, OnChanges {
       },
       // DateTimePicker validation
       {
-        condition: () => errors?.matDatepickerParse && this.errors.includes(ValidationMessages.REQUIRED_INPUT),
+        condition: () => errors?.matDatepickerParse,
         message: ValidationMessages.INVALID_DATE_FIELD
       },
       {

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
@@ -1,8 +1,9 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
-import { Constants } from 'shared/constants/constants';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
+
+import { Constants } from 'shared/constants/constants';
 import { MUST_CONTAIN_LETTERS } from 'shared/constants/regex-constants';
 import { ValidationConstants } from 'shared/constants/validation';
 import { TypeOfCompetition } from 'shared/enum/competition';

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
@@ -181,8 +181,8 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
           Validators.min(ValidationConstants.AGE_MIN)
         ]),
         registrationDateRangeGroup: this.formBuilder.group({
-          start: new FormControl<Date | null>(null, Validators.required),
-          end: new FormControl<Date | null>(null, Validators.required)
+          start: new FormControl<Date | null>(null),
+          end: new FormControl<Date | null>(null)
         }),
         competitiveEventAccountingTypeId: new FormControl<number | null>(null, Validators.required),
         parentCompetitionControl: new FormControl(null),

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -161,7 +161,7 @@
       "USER_REGISTRATION": "Реєстрація користувача",
       "EMPLOYEES": "Співробітники",
       "NEW_COMPETITION": "Реєстрація конкурсу",
-      "EDIT_COMPETITION": "Новий конкурс",
+      "EDIT_COMPETITION": "Редагування конкурсу",
       "WORKSHOP_DRAFTS": "Чернетки гуртків"
     },
     "WORKSHOP_DRAFT": {


### PR DESCRIPTION
#2908 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display logic for invalid date field validation messages to ensure users are always informed when an invalid date is entered.
- **Refactor**
  - Made registration date fields optional in the competition creation form, allowing users to proceed without filling these dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->