### PR TITLE
Spelina/complex date input formatting, digitOnly directive fix 

### DIFF
--- a/src/app/shared/directives/date-input/date-input.directive.ts
+++ b/src/app/shared/directives/date-input/date-input.directive.ts
@@ -5,7 +5,7 @@ import { Directive, ElementRef, HostListener, OnInit } from '@angular/core';
 })
 export class DateInputDirective implements OnInit {
   private indexesToInsert = [2, 5];
-  private dateRegex: RegExp = new RegExp('[^0-9/]*$', 'g');
+  private dateRegex: RegExp = new RegExp('[^0-9/]+', 'g');
 
   constructor(private ref: ElementRef) {}
 
@@ -14,7 +14,7 @@ export class DateInputDirective implements OnInit {
     const value = this.ref.nativeElement.value;
 
     if (event.inputType !== 'deleteContentBackward') {
-      this.ref.nativeElement.value = this.formatDate(value);
+      this.ref.nativeElement.value = this.formatDate(value.replace(this.dateRegex, ''));
     }
   }
 
@@ -24,7 +24,7 @@ export class DateInputDirective implements OnInit {
 
     const pastedText = event.clipboardData?.getData('text') ?? '';
 
-    this.ref.nativeElement.value = this.formatDate(pastedText);
+    this.ref.nativeElement.value = this.formatDate(pastedText.replace(this.dateRegex, ''));
     this.ref.nativeElement.dispatchEvent(new Event('input'));
   }
 
@@ -46,6 +46,6 @@ export class DateInputDirective implements OnInit {
       return formattedDate.split('/')[0] + '/' + formattedDate.split('/')[1] + '/' + formattedDate.split('/').slice(2).join('');
     }
 
-    return formattedDate.replace(this.dateRegex, '');
+    return formattedDate;
   }
 }

--- a/src/app/shared/directives/date-input/date-input.directive.ts
+++ b/src/app/shared/directives/date-input/date-input.directive.ts
@@ -5,6 +5,7 @@ import { Directive, ElementRef, HostListener, OnInit } from '@angular/core';
 })
 export class DateInputDirective implements OnInit {
   private indexesToInsert = [2, 5];
+  private dateRegex: RegExp = new RegExp('[^0-9/]*$', 'g');
 
   constructor(private ref: ElementRef) {}
 
@@ -21,7 +22,7 @@ export class DateInputDirective implements OnInit {
   public onPaste(event: ClipboardEvent): void {
     event.preventDefault();
 
-    const pastedText = event.clipboardData?.getData('text') || '';
+    const pastedText = event.clipboardData?.getData('text') ?? '';
 
     this.ref.nativeElement.value = this.formatDate(pastedText);
     this.ref.nativeElement.dispatchEvent(new Event('input'));
@@ -32,11 +33,19 @@ export class DateInputDirective implements OnInit {
   }
 
   private formatDate(value: string): string {
-    return this.indexesToInsert.reduce((acc, index) => {
-      if (value.length >= index && acc.at(index) !== '/') {
+    let formattedDate = this.indexesToInsert.reduce((acc, index) => {
+      if (value.length >= index && acc.at(index) !== '/' && acc.at(index - 1) !== '/' && acc.at(index + 1) !== '/') {
         return acc.slice(0, index) + '/' + acc.slice(index);
       }
       return acc;
     }, value);
+
+    formattedDate = formattedDate.replace(/\/{2,}/g, '/');
+
+    if (formattedDate.split('/').length > 3) {
+      return formattedDate.split('/')[0] + '/' + formattedDate.split('/')[1] + '/' + formattedDate.split('/').slice(2).join('');
+    }
+
+    return formattedDate.replace(this.dateRegex, '');
   }
 }

--- a/src/app/shared/directives/digit-only.directive.ts
+++ b/src/app/shared/directives/digit-only.directive.ts
@@ -1,18 +1,13 @@
-import { Directive, ElementRef, HostListener } from '@angular/core';
+import { Directive, HostListener } from '@angular/core';
 
 @Directive({
   selector: '[appDigitOnly]'
 })
 export class DigitOnlyDirective {
-  constructor(private el: ElementRef) {}
-
-  @HostListener('input', ['$event'])
+  @HostListener('beforeinput', ['$event'])
   public onInputChange(event: InputEvent): void {
-    const initValue = this.el.nativeElement.value;
-
-    this.el.nativeElement.value = initValue.replace(/[^0-9]*/g, '');
-    if (initValue !== this.el.nativeElement.value) {
-      event.stopPropagation();
+    if (event.data && /[^0-9./]/.test(event.data)) {
+      event.preventDefault();
     }
   }
 }

--- a/src/app/shell/personal-cabinet/provider/create-position/position-form/create-position-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-position/position-form/create-position-form.component.html
@@ -139,6 +139,7 @@
       formControlName="tariff"
       class="step-input"
       type="number"
+      appDigitOnly
       placeholder="{{ 'FORMS.PLACEHOLDERS.ENTER_TARIFF' | translate }}" />
   </mat-form-field>
   <app-validation-hint


### PR DESCRIPTION
#2906 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Input for the tariff field in the create-position form now restricts entries to digits, dots, and slashes for improved data consistency.

- **Bug Fixes**
  - Date input fields now handle pasted text and formatting more accurately, reducing issues with extra slashes and invalid trailing characters.
  - Improved handling of digit-only fields to prevent invalid characters from being entered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->