### PR TITLE
Spelina/[create position] digit only directive for the rate input

### DIFF
--- a/src/app/shell/personal-cabinet/provider/create-position/position-form/create-position-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-position/position-form/create-position-form.component.html
@@ -123,6 +123,7 @@
       formControlName="rate"
       class="step-input"
       type="number"
+      appDigitOnly
       placeholder="{{ 'FORMS.PLACEHOLDERS.ENTER_RATE' | translate }}" />
   </mat-form-field>
   <app-validation-hint


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the "rate" input field in the create-position form now accepts only numeric values, consistent with other numeric fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->