### PR TITLE
Spelina/[user config edit] disabled lastName, middleName, firstName fields

### DIFF
--- a/src/app/shell/personal-cabinet/shared-cabinet/user-config/user-config-edit/user-config-edit.component.ts
+++ b/src/app/shell/personal-cabinet/shared-cabinet/user-config/user-config-edit/user-config-edit.component.ts
@@ -83,6 +83,9 @@ export class UserConfigEditComponent extends CreateFormComponent implements OnIn
 
   public setEditMode(): void {
     this.userEditFormGroup.patchValue(this.user, { emitEvent: false });
+    this.userEditFormGroup.get('lastName').disable();
+    this.userEditFormGroup.get('firstName').disable();
+    this.userEditFormGroup.get('middleName').disable();
     this.addNavPath();
   }
 


### PR DESCRIPTION
#2937 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Made last name, first name, and middle name fields read-only in the user configuration edit form. Other fields remain editable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->