### PR TITLE
techAdmin & moderator profile

### DIFF
--- a/src/app/shared/services/admin/admin.service.ts
+++ b/src/app/shared/services/admin/admin.service.ts
@@ -9,6 +9,7 @@ import { MinistryAdmin, MinistryAdminParameters } from 'shared/models/ministry-a
 import { Provider, ProviderBlock, ProviderParameters } from 'shared/models/provider.model';
 import { PaginationParameters } from 'shared/models/query-parameters.model';
 import { SearchResponse } from 'shared/models/search.model';
+import { TechAdmin } from 'shared/models/tech-admin.model';
 import { WorkshopDraft, WorkshopFilterAdministration } from 'shared/models/workshop.model';
 
 @Injectable({
@@ -18,6 +19,10 @@ export class AdminService {
   private readonly baseApiUrl = '/api/v1/Admin';
 
   constructor(private http: HttpClient) {}
+
+  public getAdminProfile(): Observable<TechAdmin> {
+    return this.http.get<TechAdmin>(`${this.baseApiUrl}/Profile`);
+  }
 
   public getAllMinistryAdmins(parameters: MinistryAdminParameters): Observable<SearchResponse<MinistryAdmin[]>> {
     const options = { params: this.setMinistryAdminParams(parameters) };

--- a/src/app/shared/services/user/user-profile.service.spec.ts
+++ b/src/app/shared/services/user/user-profile.service.spec.ts
@@ -7,6 +7,7 @@ import { EmployeeService } from '../employee/employee.service';
 import { MinistryAdminService } from '../ministry-admin/ministry-admin.service';
 import { RegionAdminService } from '../region-admin/region-admin.service';
 import { AreaAdminService } from '../area-admin/area-admin.service';
+import { AdminService } from '../admin/admin.service';
 import { UserProfileService } from './user-profile.service';
 
 describe('UserProfileService', () => {
@@ -31,6 +32,9 @@ describe('UserProfileService', () => {
   const areaAdminServiceMock = {
     getAdminProfile: jest.fn().mockReturnValue(of({ profile: 'area admin profile' }))
   };
+  const adminServiceMock = {
+    getAdminProfile: jest.fn().mockReturnValue(of({ profile: 'admin profile' }))
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -41,7 +45,8 @@ describe('UserProfileService', () => {
         { provide: EmployeeService, useValue: employeeServiceMock },
         { provide: MinistryAdminService, useValue: ministryAdminServiceMock },
         { provide: RegionAdminService, useValue: regionAdminServiceMock },
-        { provide: AreaAdminService, useValue: areaAdminServiceMock }
+        { provide: AreaAdminService, useValue: areaAdminServiceMock },
+        { provide: AdminService, useValue: adminServiceMock }
       ]
     });
     service = TestBed.inject(UserProfileService);
@@ -141,13 +146,31 @@ describe('UserProfileService', () => {
       });
     });
 
+    it('should return admin profile observable for Role.techAdmin', (done) => {
+      const obs = service.getProfileObservableByRole(Role.techAdmin, '123');
+      expect(obs).not.toBeNull();
+      obs.subscribe((data) => {
+        expect(data.profile).toBe('admin profile');
+        done();
+      });
+    });
+
+    it('should return admin profile observable for Role.moderator', (done) => {
+      const obs = service.getProfileObservableByRole(Role.moderator, '123');
+      expect(obs).not.toBeNull();
+      obs.subscribe((data) => {
+        expect(data.profile).toBe('admin profile');
+        done();
+      });
+    });
+
     // For roles that return new Observable<any>() instances:
-    it('should return a new Observable for Role.all, Role.unauthorized, Role.techAdmin, and Role.moderator', () => {
-      const rolesToTest = [Role.all, Role.unauthorized, Role.techAdmin, Role.moderator];
+    it('should return a new Observable for Role.all, Role.unauthorized', () => {
+      const rolesToTest = [Role.all, Role.unauthorized];
       rolesToTest.forEach((role) => {
         const obs = service.getProfileObservableByRole(role, '123');
         // Check that we got something truthy; these observables likely don’t emit data.
-        expect(obs).toBeTruthy();
+        expect(obs).toBeNull();
       });
     });
   });

--- a/src/app/shared/services/user/user-profile.service.ts
+++ b/src/app/shared/services/user/user-profile.service.ts
@@ -13,6 +13,7 @@ import { EmployeeService } from '../employee/employee.service';
 import { MinistryAdminService } from '../ministry-admin/ministry-admin.service';
 import { RegionAdminService } from '../region-admin/region-admin.service';
 import { AreaAdminService } from '../area-admin/area-admin.service';
+import { AdminService } from '../admin/admin.service';
 
 @Injectable({ providedIn: 'root' })
 export class UserProfileService {
@@ -22,7 +23,8 @@ export class UserProfileService {
     private employeeService: EmployeeService,
     private ministryAdminService: MinistryAdminService,
     private regionAdminService: RegionAdminService,
-    private areaAdminService: AreaAdminService
+    private areaAdminService: AreaAdminService,
+    private adminService: AdminService
   ) {}
 
   /**
@@ -66,10 +68,10 @@ export class UserProfileService {
       [Role.ministryAdmin]: this.ministryAdminService.getAdminProfile(),
       [Role.regionAdmin]: this.regionAdminService.getAdminProfile(),
       [Role.areaAdmin]: this.areaAdminService.getAdminProfile(),
-      [Role.all]: new Observable<any>(),
-      [Role.unauthorized]: new Observable<any>(),
-      [Role.techAdmin]: new Observable<any>(),
-      [Role.moderator]: new Observable<any>()
+      [Role.all]: null,
+      [Role.unauthorized]: null,
+      [Role.techAdmin]: this.adminService.getAdminProfile(),
+      [Role.moderator]: this.adminService.getAdminProfile()
     };
 
     return roleServiceMap[role] || null;

--- a/src/app/shared/utils/admin.utils.ts
+++ b/src/app/shared/utils/admin.utils.ts
@@ -31,7 +31,7 @@ export class AdminFactory {
 }
 
 export function isRoleAdmin(role: string): boolean {
-  return [Role.techAdmin, Role.ministryAdmin, Role.regionAdmin, Role.areaAdmin].includes(role as Role);
+  return [Role.techAdmin, Role.ministryAdmin, Role.regionAdmin, Role.areaAdmin, Role.moderator].includes(role as Role);
 }
 
 export function canManageInstitution(role: string): boolean {

--- a/src/app/shell/main/main.component.ts
+++ b/src/app/shell/main/main.component.ts
@@ -141,7 +141,7 @@ export class MainComponent implements OnInit, OnDestroy {
         .subscribe(() => this.getMainPageData());
 
       return;
-    } else if (role !== Role.unauthorized) {
+    } else if (role === Role.provider) {
       this.store.dispatch(new GetUnfinishedWorkshop());
     }
     this.getMainPageData();


### PR DESCRIPTION
- added profile fetching for tech admin and moderator
- added moderator role as admin role
- fixed restore workshop creation, made it only for providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced profile retrieval for technical admins and moderators, allowing their profiles to be accessed similarly to other roles.

- **Bug Fixes**
  - Adjusted main page data loading to only fetch unfinished workshops for provider roles.
  - Updated admin role checks to include moderators as admins.

- **Refactor**
  - Improved handling of unauthorized and generic roles by returning null instead of empty observables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->