### PR TITLE
Smyk / 2993 Entering only spaces in the text field

### DIFF
--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
@@ -114,7 +114,8 @@ export class CreateDescriptionFormComponent implements OnInit, OnDestroy, AfterV
       ]),
       enrollmentProcedureDescription: new FormControl('', [
         Validators.minLength(ValidationConstants.INPUT_LENGTH_1),
-        Validators.maxLength(ValidationConstants.INPUT_LENGTH_2000)
+        Validators.maxLength(ValidationConstants.INPUT_LENGTH_2000),
+        Validators.pattern(MUST_CONTAIN_LETTERS)
       ]),
       coverage: new FormControl(this.Coverage.School),
       institutionHierarchyId: new FormControl('', Validators.required),


### PR DESCRIPTION
#2993 
Added "MUST_CONTAIN_LETTERS" validator to enrolment procedure description field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new validation rule requiring the enrollment procedure description to contain letters.

- **Bug Fixes**
  - Improved form validation to ensure descriptions meet updated content requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->