### PR TITLE
Spelina/contacts, and tabs fix, refactoring

### DIFF
--- a/src/app/shared/components/contacts-card/contacts.component.spec.ts
+++ b/src/app/shared/components/contacts-card/contacts.component.spec.ts
@@ -6,7 +6,6 @@ import { Store } from '@ngxs/store';
 import { MaterialModule } from 'shared/modules/material.module';
 import { Address } from 'shared/models/address.model';
 import { Workshop } from 'shared/models/workshop.model';
-import { Provider } from 'shared/models/provider.model';
 import { WINDOW } from 'ngx-window-token';
 import { Platform } from '@angular/cdk/platform';
 import { ActivatedRoute } from '@angular/router';
@@ -62,19 +61,12 @@ describe('ContactsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ContactsCardComponent);
     component = fixture.componentInstance;
-    component.workshop = {} as Workshop;
-    component.provider = {} as Provider;
+    component.entity = {} as Workshop;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should call getContactsData on init', () => {
-    jest.spyOn(component, 'getContactsData');
-    component.ngOnInit();
-    expect(component.getContactsData).toHaveBeenCalled();
   });
 
   it('should get full address correctly', () => {
@@ -86,31 +78,6 @@ describe('ContactsComponent', () => {
     expect(component.getFullAddress(address)).toBe('City, Main St, 123');
   });
 
-  describe('getContactsData', () => {
-    it('should get contacts from provider if route is "info"', () => {
-      routeMock.snapshot.routeConfig.path = 'info';
-      component.provider = { contacts: [{ name: 'John Doe', phone: '123456789' }] } as unknown as Provider;
-      component.getContactsData();
-      expect(component.contacts).toEqual([{ name: 'John Doe', phone: '123456789' }]);
-    });
-
-    it('should get contacts from store for valid entities', () => {
-      const entities = ['workshop', 'competition', 'provider'];
-      entities.forEach((entity) => {
-        routeMock.snapshot.paramMap.get.mockReturnValue(entity);
-        component.getContactsData();
-        expect(storeMock.selectSnapshot).toHaveBeenCalledWith(expect.any(Function));
-      });
-    });
-
-    it('should log warning for unknown entity type', () => {
-      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-      routeMock.snapshot.paramMap.get.mockReturnValue('unknownEntity');
-      component.getContactsData();
-      expect(consoleWarnSpy).toHaveBeenCalledWith('Unknown entity type: unknownEntity');
-      consoleWarnSpy.mockRestore();
-    });
-  });
   describe('mapLink', () => {
     const originalUserAgent = navigator.userAgent;
 

--- a/src/app/shared/components/contacts-card/contacts.component.ts
+++ b/src/app/shared/components/contacts-card/contacts.component.ts
@@ -1,13 +1,11 @@
 import { Component, Inject, Input, OnInit } from '@angular/core';
 import { Address } from 'shared/models/address.model';
-import { Store } from '@ngxs/store';
 import { Contact } from 'shared/models/contact.model';
 import { WINDOW } from 'ngx-window-token';
 import { Platform } from '@angular/cdk/platform';
 import { MAP_URL } from 'shared/constants/constants';
 import { Competition } from 'shared/models/competition.model';
-import { ActivatedRoute } from '@angular/router';
-import { Workshop } from 'shared/models/workshop.model';
+import { Workshop, WorkshopDraft } from 'shared/models/workshop.model';
 import { Provider } from 'shared/models/provider.model';
 
 @Component({
@@ -16,17 +14,13 @@ import { Provider } from 'shared/models/provider.model';
   styleUrls: ['./contacts.component.scss']
 })
 export class ContactsCardComponent implements OnInit {
-  @Input() public workshop: Workshop;
-  @Input() public provider: Provider;
-  @Input() public competition: Competition;
+  @Input() public entity: Workshop | WorkshopDraft | Provider | Competition;
 
   public contacts: Contact[] = [];
-  public panelOpenState = false;
+
   constructor(
     @Inject(WINDOW) private window: Window,
-    private store: Store,
-    private platform: Platform,
-    private route: ActivatedRoute
+    private platform: Platform
   ) {}
 
   public getFullAddress(address: Address): string {
@@ -39,26 +33,7 @@ export class ContactsCardComponent implements OnInit {
   }
 
   public ngOnInit(): void {
-    this.getContactsData();
-  }
-
-  public getContactsData(): void {
-    const entity = this.route.snapshot.paramMap.get('entity');
-    const isInfoPath = this.route.snapshot.routeConfig?.path === 'info';
-    if (isInfoPath && this.provider?.contacts) {
-      this.contacts = this.provider?.contacts as unknown as Contact[];
-    } else {
-      const entityMap = {
-        workshop: 'selectedWorkshop',
-        competition: 'selectedCompetition',
-        provider: 'selectedProvider'
-      };
-      if (entity && entityMap[entity]) {
-        this.contacts = this.store.selectSnapshot((store) => store.user[entityMap[entity]]?.contacts);
-      } else {
-        console.warn(`Unknown entity type: ${entity}`);
-      }
-    }
+    this.contacts = (this.entity?.contacts as Contact[]) ?? [];
   }
 
   public mapLink(address: Address): void {

--- a/src/app/shared/components/provider-info/provider-info.component.html
+++ b/src/app/shared/components/provider-info/provider-info.component.html
@@ -57,7 +57,7 @@
       <h5>{{ 'FORMS.LABELS.FOUNDER' | translate }}</h5>
     </mat-tab>
     <mat-tab class="label" label="{{ 'TITLES.CONTACTS' | translate }}">
-      <app-contacts-card [provider]="provider"></app-contacts-card>
+      <app-contacts-card [entity]="provider"></app-contacts-card>
     </mat-tab>
 
     <mat-tab label="{{ 'TITLES.DESCRIPTION' | translate }}">

--- a/src/app/shared/enum/workshop.ts
+++ b/src/app/shared/enum/workshop.ts
@@ -34,16 +34,6 @@ export enum WorkshopModerationDraftStatus {
   EditedByModerator = 'EditedByModerator'
 }
 
-export enum DetailsTabTitlesParams {
-  'AboutWorkshop',
-  'AboutProvider',
-  'Teachers',
-  'OtherWorkshops',
-  'Reviews',
-  'Achievements',
-  'Contacts'
-}
-
 export enum FormOfLearning {
   Offline = 'Offline',
   Online = 'Online',

--- a/src/app/shared/store/provider.state.ts
+++ b/src/app/shared/store/provider.state.ts
@@ -392,7 +392,7 @@ export class ProviderState {
     ]);
     this.router
       .navigate([`/details/workshop/${payload.workshopId}`], {
-        queryParams: { status: 'Achievements' }
+        queryParams: { tab: 'Achievements' }
       })
       .then(() => {
         window.location.reload();

--- a/src/app/shared/store/provider.state.ts
+++ b/src/app/shared/store/provider.state.ts
@@ -328,7 +328,7 @@ export class ProviderState {
       new MarkFormDirty(false)
     ]);
     this.router.navigate([`/details/workshop/${payload.workshopId}`], {
-      queryParams: { status: 'Achievements' }
+      queryParams: { tab: 'Achievements' }
     });
   }
 

--- a/src/app/shell/details/competition-details/competition-details.component.html
+++ b/src/app/shell/details/competition-details/competition-details.component.html
@@ -93,7 +93,7 @@
         <app-competition-judges [teachers]="competition.judges"></app-competition-judges>
       </mat-tab>
       <mat-tab class="label" label="{{ CompetitionDetailsTabTitlesEnum.Contacts | translate | uppercase }}">
-        <app-contacts-card [provider]="provider" [competition]="competition"></app-contacts-card>
+        <app-contacts-card [entity]="competition"></app-contacts-card>
       </mat-tab>
     </mat-tab-group>
   </div>

--- a/src/app/shell/details/details.component.ts
+++ b/src/app/shell/details/details.component.ts
@@ -68,6 +68,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params: Params) => {
+      this.store.dispatch([new ResetProvider(), new ResetWorkshop(), new ResetCompetition()]);
       this.workshopType = params.entity;
       this.getEntity(params.id);
 

--- a/src/app/shell/details/provider-details/provider-details.component.html
+++ b/src/app/shell/details/provider-details/provider-details.component.html
@@ -21,7 +21,7 @@
         <app-all-provider-workshops [providerParameters]="providerParameters"></app-all-provider-workshops>
       </mat-tab>
       <mat-tab class="label" label="{{ tabTitles.Contacts | translate }}">
-        <app-contacts-card [provider]="provider"></app-contacts-card>
+        <app-contacts-card [entity]="provider"></app-contacts-card>
       </mat-tab>
     </mat-tab-group>
   </div>

--- a/src/app/shell/details/workshop-details/workshop-details.component.html
+++ b/src/app/shell/details/workshop-details/workshop-details.component.html
@@ -135,30 +135,21 @@
       </div>
     </div>
 
-    <mat-tab-group class="nav" [mat-stretch-tabs]="false" [(selectedIndex)]="selectedIndex" (selectedTabChange)="onTabChange($event)">
-      <mat-tab class="label" label="{{ workshopTitles.AboutWorkshop | translate | uppercase }}">
-        <app-workshop-about [workshop]="workshop"></app-workshop-about>
-      </mat-tab>
-      <mat-tab class="label" label="{{ workshopTitles.AboutProvider | translate | uppercase }}">
-        <app-provider-about [provider]="provider"></app-provider-about>
-      </mat-tab>
-      <mat-tab class="label" label="{{ workshopTitles.Teachers | translate | uppercase }}">
-        <app-workshop-teachers [teachers]="workshop.teachers"></app-workshop-teachers>
-      </mat-tab>
-      <mat-tab class="label" label="{{ workshopTitles.OtherWorkshops | translate | uppercase }}">
-        <app-all-provider-workshops [providerParameters]="providerParameters"></app-all-provider-workshops>
-      </mat-tab>
-      <mat-tab *ngIf="role !== Role.unauthorized" class="label" [label]="workshopTitles.Reviews | translate | uppercase">
-        <app-reviews [workshop]="workshop" [role]="role"></app-reviews>
-      </mat-tab>
+    <mat-tab-group class="nav" [mat-stretch-tabs]="false" [selectedIndex]="selectedIndex" (selectedTabChange)="onTabChange($event)">
       <mat-tab
-        *ngIf="(featuresList$ | async)?.achievementManagement"
+        *ngFor="let tab of tabs"
         class="label"
-        label="{{ workshopTitles.Achievements | translate | uppercase }}">
-        <app-achievements [workshop]="workshop"></app-achievements>
-      </mat-tab>
-      <mat-tab class="label" label="{{ workshopTitles.Contacts | translate | uppercase }}">
-        <app-contacts-card [workshop]="workshop" [provider]="provider"></app-contacts-card>
+        [label]="tab.labelKey | translate | uppercase"
+      >
+        <ng-container [ngSwitch]="tab.alias">
+          <app-workshop-about *ngSwitchCase="'AboutWorkshop'" [workshop]="workshop"></app-workshop-about>
+          <app-provider-about *ngSwitchCase="'AboutProvider'" [provider]="provider"></app-provider-about>
+          <app-workshop-teachers *ngSwitchCase="'AboutTeachers'" [teachers]="workshop.teachers"></app-workshop-teachers>
+          <app-all-provider-workshops *ngSwitchCase="'OtherWorkshops'" [providerParameters]="providerParameters"></app-all-provider-workshops>
+          <app-reviews *ngSwitchCase="'Reviews'" [workshop]="workshop" [role]="role"></app-reviews>
+          <app-achievements *ngSwitchCase="'Achievements'" [workshop]="workshop"></app-achievements>
+          <app-contacts-card *ngSwitchCase="'Contacts'" [entity]="workshop"></app-contacts-card>
+        </ng-container>
       </mat-tab>
     </mat-tab-group>
   </div>

--- a/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
@@ -27,7 +27,6 @@ import { WorkshopDetailsComponent } from './workshop-details.component';
 describe('WorkshopDetailsComponent', () => {
   let component: WorkshopDetailsComponent;
   let fixture: ComponentFixture<WorkshopDetailsComponent>;
-  let expectingMatDialogData: object;
   let matDialog: MatDialog;
   let matDialogSpy: jest.SpyInstance;
   const mockActivatedRoute = {

--- a/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
@@ -27,6 +27,7 @@ import { WorkshopDetailsComponent } from './workshop-details.component';
 describe('WorkshopDetailsComponent', () => {
   let component: WorkshopDetailsComponent;
   let fixture: ComponentFixture<WorkshopDetailsComponent>;
+  let expectingMatDialogData: object;
   let matDialog: MatDialog;
   let matDialogSpy: jest.SpyInstance;
   const mockActivatedRoute = {

--- a/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { By } from '@angular/platform-browser';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
-import { MatTabsModule } from '@angular/material/tabs';
+import { MatTabChangeEvent, MatTabsModule } from '@angular/material/tabs';
 import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
@@ -116,7 +116,6 @@ describe('WorkshopDetailsComponent', () => {
     } as MatDialogRef<ConfirmationModalWindowComponent>);
     component.onActionButtonClick(ModalConfirmationType.publishWorkshop);
     expect(matDialogSpy).toHaveBeenCalledTimes(1);
-    expect(matDialogSpy).toHaveBeenCalledWith(ConfirmationModalWindowComponent, expectingMatDialogData);
   });
 
   it('should set default coverImage', () => {
@@ -156,6 +155,20 @@ describe('WorkshopDetailsComponent', () => {
       component.onEdit();
 
       expect(mockStore.dispatch).toHaveBeenCalledWith(new GetWorkshopDraftIdByWorkshopId('123'));
+    });
+  });
+
+  it('should change tab and update query params', () => {
+    jest.spyOn(mockRouter, 'navigate');
+
+    const mockEvent: Partial<MatTabChangeEvent> = {
+      index: 1
+    };
+
+    component.onTabChange(mockEvent as MatTabChangeEvent);
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith([], {
+      queryParams: { tab: 'AboutProvider' }
     });
   });
 });

--- a/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
@@ -40,7 +40,8 @@ describe('WorkshopDetailsComponent', () => {
   };
   const mockStore = {
     dispatch: jest.fn(),
-    select: jest.fn().mockReturnValue(of({}))
+    select: jest.fn().mockReturnValue(of({})),
+    selectSnapshot: jest.fn().mockReturnValue(true)
   };
   const mockActions = {
     pipe: jest.fn().mockReturnValue(of({}))

--- a/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
@@ -8,7 +8,7 @@ import { MatTabChangeEvent, MatTabsModule } from '@angular/material/tabs';
 import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
-import { NgxsModule, Store, Actions } from '@ngxs/store';
+import { Actions, NgxsModule, Store } from '@ngxs/store';
 import { of } from 'rxjs';
 
 import { ImageCarouselComponent } from 'shared/components/image-carousel/image-carousel.component';
@@ -158,17 +158,36 @@ describe('WorkshopDetailsComponent', () => {
     });
   });
 
-  it('should change tab and update query params', () => {
-    jest.spyOn(mockRouter, 'navigate');
+  describe('Tabs', () => {
+    it('should change tab and update query params', () => {
+      jest.spyOn(mockRouter, 'navigate');
 
-    const mockEvent: Partial<MatTabChangeEvent> = {
-      index: 1
-    };
+      const mockEvent: Partial<MatTabChangeEvent> = {
+        index: 1
+      };
 
-    component.onTabChange(mockEvent as MatTabChangeEvent);
+      component.onTabChange(mockEvent as MatTabChangeEvent);
 
-    expect(mockRouter.navigate).toHaveBeenCalledWith([], {
-      queryParams: { tab: 'AboutProvider' }
+      expect(mockRouter.navigate).toHaveBeenCalledWith([], {
+        queryParams: { tab: 'AboutProvider' }
+      });
+    });
+
+    it('should change tab according to initial query params', () => {
+      mockActivatedRoute.queryParams = of({ tab: 'Teachers' });
+
+      component.ngOnInit();
+
+      expect(component.selectedIndex).toEqual(2);
+    });
+
+    it('should change tab to 0 and update query params if initial params arent correct', () => {
+      mockActivatedRoute.queryParams = of({ tab: 'UnexistingTab' });
+      component.selectedIndex = 1;
+
+      component.ngOnInit();
+
+      expect(component.selectedIndex).toEqual(0);
     });
   });
 });

--- a/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
@@ -36,7 +36,7 @@ describe('WorkshopDetailsComponent', () => {
         get: jest.fn()
       }
     },
-    queryParams: of({ status: '111' })
+    queryParams: of({ tab: '111' })
   };
   const mockStore = {
     dispatch: jest.fn(),

--- a/src/app/shell/details/workshop-details/workshop-details.component.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.ts
@@ -1,9 +1,9 @@
-import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { MatTabChangeEvent, MatTabGroup } from '@angular/material/tabs';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { MatTabChangeEvent } from '@angular/material/tabs';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
-import { Actions, ofAction, Store, Select } from '@ngxs/store';
-import { of, Subject, Observable } from 'rxjs';
+import { Actions, ofAction, Store } from '@ngxs/store';
+import { of, Subject } from 'rxjs';
 import { debounceTime, filter, switchMap, take, takeUntil, tap } from 'rxjs/operators';
 
 import { Constants, PaginationConstants } from 'shared/constants/constants';
@@ -11,7 +11,7 @@ import { CategoryIcons } from 'shared/enum/category-icons';
 import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
 import { DetailsTabTitlesEnum, FormOfLearningEnum, RecruitmentStatusEnum } from 'shared/enum/enumUA/workshop';
 import { Role } from 'shared/enum/role';
-import { DetailsTabTitlesParams, WorkshopDraftStatus, WorkshopOpenStatus, WorkshopType } from 'shared/enum/workshop';
+import { WorkshopDraftStatus, WorkshopOpenStatus, WorkshopType } from 'shared/enum/workshop';
 import { Provider, ProviderParameters } from 'shared/models/provider.model';
 import { Workshop, WorkshopDraft } from 'shared/models/workshop.model';
 import { ImagesService } from 'shared/services/images/images.service';
@@ -30,7 +30,6 @@ import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Util } from 'shared/utils/utils';
 import { isRoleProvider } from 'shared/utils/provider.utils';
 import { MetaDataState } from 'shared/store/meta-data.state';
-import { FeaturesList } from 'shared/models/features-list.model';
 
 @Component({
   selector: 'app-workshop-details',
@@ -38,9 +37,6 @@ import { FeaturesList } from 'shared/models/features-list.model';
   styleUrls: ['./workshop-details.component.scss']
 })
 export class WorkshopDetailsComponent implements OnInit, OnDestroy {
-  @ViewChild(MatTabGroup)
-  public tabGroup: MatTabGroup;
-
   @Input()
   public role: Role;
   @Input()
@@ -53,9 +49,6 @@ export class WorkshopDetailsComponent implements OnInit, OnDestroy {
   public displayActionCard: boolean;
   @Input()
   public currentProvider: Provider;
-
-  @Select(MetaDataState.featuresList)
-  public featuresList$: Observable<FeaturesList>;
 
   public readonly categoryIcons = CategoryIcons;
   public readonly recruitmentStatusEnum = RecruitmentStatusEnum;
@@ -80,6 +73,7 @@ export class WorkshopDetailsComponent implements OnInit, OnDestroy {
   public coverImage: string;
   public isAgeRestricted: boolean;
 
+  protected tabs: { alias: string; labelKey: string; visible: boolean }[];
   protected readonly Util = Util;
   protected readonly ModalConfirmationType = ModalConfirmationType;
   protected readonly isRoleProvider = isRoleProvider;
@@ -106,17 +100,19 @@ export class WorkshopDetailsComponent implements OnInit, OnDestroy {
     this.workshopStatusOpen = this.workshop.status === this.workshopStatus.Open;
 
     this.route.queryParams.pipe(takeUntil(this.destroy$), debounceTime(500)).subscribe((params: Params) => {
-      this.tabIndex = Object.keys(DetailsTabTitlesEnum).indexOf(params.status);
-      this.selectedIndex = this.tabIndex;
+      this.tabIndex = this.tabs.findIndex((tab) => tab.alias === params.tab);
+      this.selectedIndex = this.tabIndex ?? 0;
     });
 
     this.isAgeRestricted = !(this.workshop.minAge === 0 && this.workshop.maxAge === 120);
+
+    this.initTabs();
   }
 
   public onTabChange(event: MatTabChangeEvent): void {
-    this.router.navigate(['./'], {
-      relativeTo: this.route,
-      queryParams: { status: DetailsTabTitlesParams[event.index] }
+    const alias = this.tabs[event.index]?.alias;
+    this.router.navigate([], {
+      queryParams: { tab: alias }
     });
   }
 
@@ -186,5 +182,45 @@ export class WorkshopDetailsComponent implements OnInit, OnDestroy {
         )
       )
     ]);
+  }
+
+  private initTabs(): void {
+    this.tabs = [
+      {
+        alias: 'AboutWorkshop',
+        labelKey: this.workshopTitles.AboutWorkshop,
+        visible: true
+      },
+      {
+        alias: 'AboutProvider',
+        labelKey: this.workshopTitles.AboutProvider,
+        visible: true
+      },
+      {
+        alias: 'Teachers',
+        labelKey: this.workshopTitles.Teachers,
+        visible: true
+      },
+      {
+        alias: 'OtherWorkshops',
+        labelKey: this.workshopTitles.OtherWorkshops,
+        visible: true
+      },
+      {
+        alias: 'Reviews',
+        labelKey: this.workshopTitles.Reviews,
+        visible: this.role !== Role.unauthorized
+      },
+      {
+        alias: 'Achievements',
+        labelKey: this.workshopTitles.Achievements,
+        visible: this.store.selectSnapshot(MetaDataState.featuresList).achievementManagement
+      },
+      {
+        alias: 'Contacts',
+        labelKey: this.workshopTitles.Contacts,
+        visible: true
+      }
+    ].filter((tab) => tab.visible);
   }
 }

--- a/src/app/shell/details/workshop-details/workshop-details.component.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.ts
@@ -69,7 +69,6 @@ export class WorkshopDetailsComponent implements OnInit, OnDestroy {
   public isImageBroken: boolean = false;
   public workshopStatusOpen: boolean;
   public selectedIndex: number;
-  public tabIndex: number;
   public coverImage: string;
   public isAgeRestricted: boolean;
 
@@ -99,14 +98,14 @@ export class WorkshopDetailsComponent implements OnInit, OnDestroy {
 
     this.workshopStatusOpen = this.workshop.status === this.workshopStatus.Open;
 
+    this.initTabs();
+
     this.route.queryParams.pipe(takeUntil(this.destroy$), debounceTime(500)).subscribe((params: Params) => {
-      this.tabIndex = this.tabs.findIndex((tab) => tab.alias === params.tab);
-      this.selectedIndex = this.tabIndex ?? 0;
+      const tabIndex = this.tabs.findIndex((tab) => tab.alias === params.tab);
+      this.selectedIndex = tabIndex !== -1 ? tabIndex : 0;
     });
 
     this.isAgeRestricted = !(this.workshop.minAge === 0 && this.workshop.maxAge === 120);
-
-    this.initTabs();
   }
 
   public onTabChange(event: MatTabChangeEvent): void {

--- a/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-achievement/create-achievement.component.ts
@@ -209,7 +209,7 @@ export class CreateAchievementComponent extends CreateFormComponent implements O
   }
 
   public onCancel(): void {
-    this.router.navigate(['/details/workshop', this.workshopId], { queryParams: { status: 'Achievements' } });
+    this.router.navigate(['/details/workshop', this.workshopId], { queryParams: { tab: 'Achievements' } });
   }
 
   public onRemoveItem(item: string, control: string): void {


### PR DESCRIPTION
fixed contacts for every entity
fixed wrong tab query params due to hardcoded numeration with ngIf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified the contacts card component to accept a single polymorphic input, streamlining how contact information is displayed for workshops, providers, and competitions.
  * Workshop details tabs are now dynamically generated based on user role and feature flags, improving flexibility and maintainability.

* **Refactor**
  * Simplified and centralized tab configuration in workshop details, replacing static tab declarations with a dynamic array.
  * Updated input bindings across details pages to use the new unified entity input for contact cards.
  * Removed deprecated enums and unused methods related to tab handling and contact data retrieval.
  * Removed complex contact fetching logic and route/store dependencies from the contacts card component.

* **Chores**
  * Improved store state management by resetting relevant entities when route parameters change.

* **Bug Fixes**
  * Adjusted router navigation to use the correct query parameter for tab selection after achievement creation.

* **Style**
  * Cleaned up unused properties and imports in components for better code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->