### PR TITLE
Zhylka/#3027 remove the 'Rating' from workshop details

### DIFF
--- a/src/app/shell/details/workshop-details/workshop-details.component.html
+++ b/src/app/shell/details/workshop-details/workshop-details.component.html
@@ -88,7 +88,7 @@
 
       <div class="flex flex-row">
         <div class="flex flex-col">
-          <span class="icon-text">
+          <span *ngIf="!workshop.workshopDraftId" class="icon-text">
             <mat-icon class="icon">star</mat-icon>
             {{ workshop.rating }}&nbsp;
             <span class="rating-number">({{ workshop.numberOfRatings }})</span>
@@ -144,7 +144,7 @@
         <ng-container [ngSwitch]="tab.alias">
           <app-workshop-about *ngSwitchCase="'AboutWorkshop'" [workshop]="workshop"></app-workshop-about>
           <app-provider-about *ngSwitchCase="'AboutProvider'" [provider]="provider"></app-provider-about>
-          <app-workshop-teachers *ngSwitchCase="'AboutTeachers'" [teachers]="workshop.teachers"></app-workshop-teachers>
+          <app-workshop-teachers *ngSwitchCase="'Teachers'" [teachers]="workshop.teachers"></app-workshop-teachers>
           <app-all-provider-workshops *ngSwitchCase="'OtherWorkshops'" [providerParameters]="providerParameters"></app-all-provider-workshops>
           <app-reviews *ngSwitchCase="'Reviews'" [workshop]="workshop" [role]="role"></app-reviews>
           <app-achievements *ngSwitchCase="'Achievements'" [workshop]="workshop"></app-achievements>

--- a/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
@@ -168,9 +168,12 @@ describe('WorkshopDetailsComponent', () => {
 
       component.onTabChange(mockEvent as MatTabChangeEvent);
 
-      expect(mockRouter.navigate).toHaveBeenCalledWith([], {
-        queryParams: { tab: 'AboutProvider' }
-      });
+      expect(mockRouter.navigate).toHaveBeenCalledWith(
+        [],
+        expect.objectContaining({
+          queryParams: { tab: 'AboutProvider' }
+        })
+      );
     });
 
     it('should change tab according to initial query params', () => {

--- a/src/app/shell/details/workshop-details/workshop-details.component.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.ts
@@ -111,7 +111,8 @@ export class WorkshopDetailsComponent implements OnInit, OnDestroy {
   public onTabChange(event: MatTabChangeEvent): void {
     const alias = this.tabs[event.index]?.alias;
     this.router.navigate([], {
-      queryParams: { tab: alias }
+      queryParams: { tab: alias },
+      replaceUrl: true
     });
   }
 
@@ -208,7 +209,7 @@ export class WorkshopDetailsComponent implements OnInit, OnDestroy {
       {
         alias: 'Reviews',
         labelKey: this.workshopTitles.Reviews,
-        visible: this.role !== Role.unauthorized
+        visible: this.role !== Role.unauthorized && this.workshop instanceof Workshop
       },
       {
         alias: 'Achievements',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Reviews" tab is now only visible to authorized users and when the workshop is a published workshop, providing a more tailored user experience.

* **Bug Fixes**
  * The rating display is now hidden for workshop drafts, ensuring ratings are only shown for published workshops.

* **Other**
  * Improved tab navigation with URL replacement for smoother browsing.
  * Updated tab alias for the teachers section to "Teachers" for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->