### PR TITLE
Spelina/provider competition drafts

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -83,7 +83,7 @@ registerLocaleData(localeUk);
       disabled: environment.production
     }),
     NgxsLoggerPluginModule.forRoot({
-      disabled: true
+      disabled: environment.production
     }),
     ShellModule,
     RegistrationModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -83,7 +83,7 @@ registerLocaleData(localeUk);
       disabled: environment.production
     }),
     NgxsLoggerPluginModule.forRoot({
-      disabled: environment.production
+      disabled: true
     }),
     ShellModule,
     RegistrationModule,

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -144,14 +144,14 @@
         {{ 'ENUM.NAV_BAR_NAME.MY_WORKSHOPS' | translate }}
       </button>
     </a>
-    <a *ngIf="isRoleProvider(user.role)" [routerLink]="'./personal-cabinet/provider/drafts'">
-      <button mat-menu-item>
-        {{ 'ENUM.NAV_BAR_NAME.MY_DRAFTS' | translate }}
-      </button>
-    </a>
     <a *ngIf="isRoleProvider(user.role)" [routerLink]="'./personal-cabinet/provider/competitions'">
       <button mat-menu-item>
         {{ 'ENUM.NAV_BAR_NAME.MY_COMPETITIONS' | translate }}
+      </button>
+    </a>
+    <a *ngIf="isRoleProvider(user.role)" [routerLink]="'./personal-cabinet/provider/drafts'">
+      <button mat-menu-item>
+        {{ 'ENUM.NAV_BAR_NAME.MY_DRAFTS' | translate }}
       </button>
     </a>
     <a [routerLink]="'./personal-cabinet/' + user.role + '/applications'">

--- a/src/app/shared/base-components/create-contacts/create-contacts.component.spec.ts
+++ b/src/app/shared/base-components/create-contacts/create-contacts.component.spec.ts
@@ -97,7 +97,7 @@ describe('CreateContactsComponent', () => {
 
   it('should delete a form field', () => {
     const formArray = new FormArray([new FormControl('test1'), new FormControl('test2')]);
-    const deleteFormFieldSpy = jest.spyOn(component, 'deleteFormField');
+    const deleteFormFieldSpy = jest.spyOn(component as any, 'deleteFormField');
 
     (component as any).deleteFormField(formArray, 0);
 
@@ -247,6 +247,7 @@ class MockMapComponent {
   @Input() addressFormGroup: FormGroup;
   @Input() settelmentFormGroup: FormGroup;
 }
+
 @Component({
   selector: 'app-create-address-form',
   template: ''

--- a/src/app/shared/components/competition-card/competition-card.component.html
+++ b/src/app/shared/components/competition-card/competition-card.component.html
@@ -60,7 +60,7 @@
 <ng-template #WorkshopStatusClosed>
   <div class="flex justify-between">
     <div class="chip-color-close">
-      {{ recruitmentStatusEnum.RecruitmentStoped | translate }}
+      {{ RecruitmentStatusEnum.RecruitmentStoped | translate }}
     </div>
   </div>
 </ng-template>

--- a/src/app/shared/components/competition-card/competition-card.component.html
+++ b/src/app/shared/components/competition-card/competition-card.component.html
@@ -25,8 +25,8 @@
             matTooltip="{{ 'MORE_DETAILS' | translate }}"
             [matTooltipPosition]="Constants.MAT_TOOL_TIP_POSITION_ABOVE"
             [routerLink]="[
-              competitionData.id ? '/details/competition' : '/details/draft',
-              competitionData.id ? competitionData.id : competitionData.workshopDraftId
+              competitionData.id ? '/details/competition' : '/details/competition-draft',
+              competitionData.id ? competitionData.id : competitionData.competitiveEventDraftId
             ]">
             <mat-icon class="icon_launch">launch</mat-icon>
           </a>

--- a/src/app/shared/components/competition-card/competition-card.component.html
+++ b/src/app/shared/components/competition-card/competition-card.component.html
@@ -41,7 +41,12 @@
       </mat-card-content>
 
       <mat-card-footer *ngIf="!isCreateForm" class="card-footer">
-        <a class="more-details" [routerLink]="['/details/competition', competitionData.id]">
+        <a
+          class="more-details"
+          [routerLink]="[
+            competitionData.id ? '/details/workshop' : '/details/draft',
+            competitionData.id ? competitionData.id : competitionData.workshopDraftId
+          ]">
           <span class="card_link">
             {{ 'MORE_DETAILS' | translate }}
           </span>

--- a/src/app/shared/components/competition-card/competition-card.component.html
+++ b/src/app/shared/components/competition-card/competition-card.component.html
@@ -57,6 +57,14 @@
   </div>
 </mat-card>
 
+<ng-template #WorkshopStatusClosed>
+  <div class="flex justify-between">
+    <div class="chip-color-close">
+      {{ recruitmentStatusEnum.RecruitmentStoped | translate }}
+    </div>
+  </div>
+</ng-template>
+
 <ng-template #ProviderActions>
   <div *ngIf="isCabinet" class="flex flex-row justify-end items-start actions">
     <div
@@ -89,9 +97,9 @@
   <ng-container *ngIf="!!!competitionData.draftStatus; else ProviderDraftView">
     <ng-container
       *ngIf="
-      competitionData.state === CompetitionStatus.Open || competitionData.availableSeats === Constants.UNLIMITED_SEATS;
-      else WorkshopStatusClosed
-    ">
+        competitionData.state === CompetitionStatus.Open || competitionData.availableSeats === Constants.UNLIMITED_SEATS;
+        else WorkshopStatusClosed
+      ">
       <div class="flex justify-between">
         <div class="chip-color-open">
           {{ RecruitmentStatusEnum.RecruitmentOngoing | translate }}
@@ -110,19 +118,18 @@
     <div class="provider-content flex justify-between items-center">
       <p class="card_text"><i class="fas fa-user card_icon"></i> {{ 'TOTAL_PARTICIPANTS' | translate }}:</p>
       <span class="card_text card_text_blue">
-      {{ competitionData.numberOfOccupiedSeats }}
+        {{ competitionData.numberOfOccupiedSeats }}
         <ng-container *ngIf="competitionData.numberOfSeats !== Constants.UNLIMITED_SEATS">
-        / {{ competitionData.numberOfSeats }}
-      </ng-container>
-    </span>
+          / {{ competitionData.numberOfSeats }}
+        </ng-container>
+      </span>
     </div>
     <div class="provider-content flex justify-between items-center">
       <p class="card_text"><i class="fas fa-user-clock card_icon"></i> {{ 'AWAITING_CONFIRMATION' | translate }}:</p>
       <span class="card_text card_text_blue"> {{ competitionData.amountOfPendingApplications }}</span>
     </div>
     <div class="provider-content flex justify-between items-center">
-      <p class="card_text"><i
-        class="fas fa-solid fa-envelope card_icon"></i> {{ 'ENUM.NAV_BAR_NAME.MESSAGES' | translate }}:</p>
+      <p class="card_text"><i class="fas fa-solid fa-envelope card_icon"></i> {{ 'ENUM.NAV_BAR_NAME.MESSAGES' | translate }}:</p>
       <span class="card_text card_text_blue"> {{ competitionData.unreadMessages }}</span>
     </div>
   </ng-container>

--- a/src/app/shared/components/competition-card/competition-card.component.html
+++ b/src/app/shared/components/competition-card/competition-card.component.html
@@ -24,16 +24,16 @@
             *ngIf="isCabinet"
             matTooltip="{{ 'MORE_DETAILS' | translate }}"
             [matTooltipPosition]="Constants.MAT_TOOL_TIP_POSITION_ABOVE"
-            [routerLink]="['/details/competition', competitionData.id]">
+            [routerLink]="[
+              competitionData.id ? '/details/competition' : '/details/draft',
+              competitionData.id ? competitionData.id : competitionData.workshopDraftId
+            ]">
             <mat-icon class="icon_launch">launch</mat-icon>
           </a>
           <div class="workshop-title-container">
             <span [matTooltip]="competitionData.title" showTooltipIfTruncated>{{ competitionData.title }}</span>
           </div>
         </mat-card-title>
-        <ng-container *ngFor="let id of competitionData.directionIds">
-          <img class="img" mat-card-image [src]="CategoryIcons[id]" />
-        </ng-container>
       </mat-card-header>
 
       <mat-card-content class="flex flex-col justify-between">
@@ -81,42 +81,93 @@
 </ng-template>
 
 <ng-template #ProviderCompetitionView>
-  <ng-container
-    *ngIf="
+  <ng-container *ngIf="!!!competitionData.draftStatus; else ProviderDraftView">
+    <ng-container
+      *ngIf="
       competitionData.state === CompetitionStatus.Open || competitionData.availableSeats === Constants.UNLIMITED_SEATS;
       else WorkshopStatusClosed
     ">
-    <div class="flex justify-between">
-      <div class="chip-color-open">
-        {{ RecruitmentStatusEnum.RecruitmentOngoing | translate }}
+      <div class="flex justify-between">
+        <div class="chip-color-open">
+          {{ RecruitmentStatusEnum.RecruitmentOngoing | translate }}
+        </div>
+        <a
+          *ngIf="canChangeWorkshopStatus"
+          class="more-details"
+          (click)="onChangeWorkshopStatus(CompetitionStatus.Closed, ModalConfirmationType.closeSet)">
+          <span class="card_link">{{ RecruitmentStatusEnum.Stop | translate }}</span>
+        </a>
       </div>
-      <a
-        *ngIf="canChangeWorkshopStatus"
-        class="more-details"
-        (click)="onChangeWorkshopStatus(CompetitionStatus.Closed, ModalConfirmationType.closeSet)">
-        <span class="card_link">{{ RecruitmentStatusEnum.Stop | translate }}</span>
-      </a>
+    </ng-container>
+    <div *ngIf="competitionData.competitiveSelection" class="provider-content flex justify-between items-center">
+      <p class="card_text"><i class="fas fa-user card_icon"></i> {{ 'COMPETITIVE_SELECTION' | translate }}</p>
     </div>
-  </ng-container>
-  <div *ngIf="competitionData.competitiveSelection" class="provider-content flex justify-between items-center">
-    <p class="card_text"><i class="fas fa-user card_icon"></i> {{ 'COMPETITIVE_SELECTION' | translate }}</p>
-  </div>
-  <div class="provider-content flex justify-between items-center">
-    <p class="card_text"><i class="fas fa-user card_icon"></i> {{ 'TOTAL_PARTICIPANTS' | translate }}:</p>
-    <span class="card_text card_text_blue">
+    <div class="provider-content flex justify-between items-center">
+      <p class="card_text"><i class="fas fa-user card_icon"></i> {{ 'TOTAL_PARTICIPANTS' | translate }}:</p>
+      <span class="card_text card_text_blue">
       {{ competitionData.numberOfOccupiedSeats }}
-      <ng-container *ngIf="competitionData.numberOfSeats !== Constants.UNLIMITED_SEATS">
+        <ng-container *ngIf="competitionData.numberOfSeats !== Constants.UNLIMITED_SEATS">
         / {{ competitionData.numberOfSeats }}
       </ng-container>
     </span>
+    </div>
+    <div class="provider-content flex justify-between items-center">
+      <p class="card_text"><i class="fas fa-user-clock card_icon"></i> {{ 'AWAITING_CONFIRMATION' | translate }}:</p>
+      <span class="card_text card_text_blue"> {{ competitionData.amountOfPendingApplications }}</span>
+    </div>
+    <div class="provider-content flex justify-between items-center">
+      <p class="card_text"><i
+        class="fas fa-solid fa-envelope card_icon"></i> {{ 'ENUM.NAV_BAR_NAME.MESSAGES' | translate }}:</p>
+      <span class="card_text card_text_blue"> {{ competitionData.unreadMessages }}</span>
+    </div>
+  </ng-container>
+</ng-template>
+
+<ng-template #ProviderDraftView>
+  <div class="flex justify-between">
+    <ng-container [ngSwitch]="competitionData.draftStatus">
+      <div *ngSwitchCase="workshopDraftStatus.Draft" class="chip-color-draft">
+        {{ draftStatusEnum.Draft | translate }}
+      </div>
+      <div *ngSwitchCase="workshopDraftStatus.PendingModeration" class="chip-color-pending">
+        {{ draftStatusEnum.PendingModeration | translate }}
+      </div>
+      <div *ngSwitchCase="workshopDraftStatus.Rejected" class="chip-color-rejected">
+        {{ draftStatusEnum.Rejected | translate }}
+      </div>
+      <div *ngSwitchCase="workshopDraftStatus.EditedByModerator" class="chip-color-edited">
+        {{ draftStatusEnum.EditedByModerator | translate }}
+      </div>
+    </ng-container>
+    <a
+      *ngIf="competitionData.draftStatus !== workshopDraftStatus.PendingModeration"
+      class="more-details"
+      (click)="onSendForModeration(competitionData.competitiveEventDraftId, ModalConfirmationType.draftSet)">
+      <span class="card_link">{{ 'BUTTONS.PUBLISH' | translate }}</span>
+    </a>
   </div>
-  <div class="provider-content flex justify-between items-center">
-    <p class="card_text"><i class="fas fa-user-clock card_icon"></i> {{ 'AWAITING_CONFIRMATION' | translate }}:</p>
-    <span class="card_text card_text_blue"> {{ competitionData.amountOfPendingApplications }}</span>
-  </div>
-  <div class="provider-content flex justify-between items-center">
-    <p class="card_text"><i class="fas fa-solid fa-envelope card_icon"></i> {{ 'ENUM.NAV_BAR_NAME.MESSAGES' | translate }}:</p>
-    <span class="card_text card_text_blue"> {{ competitionData.unreadMessages }}</span>
+  <div class="flex flex-col flex-grow">
+    <ng-container [ngSwitch]="competitionData.draftStatus">
+      <div *ngSwitchCase="workshopDraftStatus.Draft" class="text-center admin-response">
+        {{ 'DRAFT_CARD_HINT.PUBLISH' | translate }}
+      </div>
+      <div *ngSwitchCase="workshopDraftStatus.PendingModeration" class="text-center admin-response">
+        {{ 'DRAFT_CARD_HINT.PENDING_MODERATION' | translate }}
+      </div>
+      <div *ngSwitchCase="workshopDraftStatus.EditedByModerator" class="text-center admin-response">
+        {{ 'DRAFT_CARD_HINT.EDITED_BY_MODERATOR' | translate }}
+      </div>
+      <div *ngSwitchCase="workshopDraftStatus.Rejected">
+        <div class="flex flex-row justify-start">
+          <div class="admin-response flex items-center">{{ 'MODERATOR_MESSAGE' | translate }}</div>
+        </div>
+        <div class="rejection-message">
+          <div class="rejection-message-wrapper" [matTooltip]="competitionData.rejectionMessage">
+            {{ competitionData.rejectionMessage }}
+          </div>
+        </div>
+      </div>
+    </ng-container>
   </div>
 </ng-template>
 

--- a/src/app/shared/components/competition-card/competition-card.component.html
+++ b/src/app/shared/components/competition-card/competition-card.component.html
@@ -44,8 +44,8 @@
         <a
           class="more-details"
           [routerLink]="[
-            competitionData.id ? '/details/workshop' : '/details/draft',
-            competitionData.id ? competitionData.id : competitionData.workshopDraftId
+            competitionData.id ? '/details/competition' : '/details/competition-draft',
+            competitionData.id ? competitionData.id : competitionData.competitiveEventDraftId
           ]">
           <span class="card_link">
             {{ 'MORE_DETAILS' | translate }}

--- a/src/app/shared/components/competition-card/competition-card.component.spec.ts
+++ b/src/app/shared/components/competition-card/competition-card.component.spec.ts
@@ -84,7 +84,7 @@ describe('CompetitionCardComponent', () => {
       } as CompetitionDraftCard;
       jest.spyOn(mockRouter, 'navigate');
       component.onEdit();
-      expect(mockRouter.navigate).toHaveBeenCalledWith(['create/competition/draft', '111']);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/create/competition/draft', '111']);
     });
 
     it('should dispatch check for competitiveEventDraftId if DraftId is not provided', () => {

--- a/src/app/shared/components/competition-card/competition-card.component.spec.ts
+++ b/src/app/shared/components/competition-card/competition-card.component.spec.ts
@@ -1,23 +1,27 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { ENTER } from '@angular/cdk/keycodes';
 import { StsConfigLoader } from 'angular-auth-oidc-client';
 import { NgxsModule, Store } from '@ngxs/store';
 import { TranslateModule } from '@ngx-translate/core';
-import { Router } from '@angular/router';
 import { of } from 'rxjs';
 
 import { Role } from 'shared/enum/role';
 import { CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
 import { CompetitionStatus, FormOfLearning } from 'shared/enum/competition';
 import { RegistrationState } from 'shared/store/registration.state';
-import { GetCompetitionDraftIdByCompetitionId } from 'shared/store/provider.actions';
+import { CompetitionDraftSendForModeration, GetCompetitionDraftIdByCompetitionId } from 'shared/store/provider.actions';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { CompetitionCardComponent } from './competition-card.component';
 
 describe('CompetitionCardComponent', () => {
   let component: CompetitionCardComponent;
   let fixture: ComponentFixture<CompetitionCardComponent>;
   let storeMock: any;
+  let matDialog: MatDialog;
 
   beforeEach(() => {
     storeMock = {
@@ -27,9 +31,16 @@ describe('CompetitionCardComponent', () => {
 
     TestBed.configureTestingModule({
       providers: [{ provide: Store, useValue: storeMock }, StsConfigLoader],
-      declarations: [CompetitionCardComponent],
-      imports: [NgxsModule.forRoot([RegistrationState], { developmentMode: true }), HttpClientTestingModule, TranslateModule.forRoot()]
+      declarations: [CompetitionCardComponent, ConfirmationModalWindowComponent],
+      imports: [
+        NgxsModule.forRoot([RegistrationState], { developmentMode: true }),
+        HttpClientTestingModule,
+        TranslateModule.forRoot(),
+        MatDialogModule
+      ]
     }).compileComponents();
+
+    matDialog = TestBed.inject(MatDialog);
 
     fixture = TestBed.createComponent(CompetitionCardComponent);
     component = fixture.componentInstance;
@@ -116,5 +127,19 @@ describe('CompetitionCardComponent', () => {
     expect(component.isImageBroken).toBeTruthy();
 
     expect(component.competitionData._meta).toEqual('assets/images/groupimages/workshop-img.png');
+  });
+
+  it('should open confirmation dialog and dispatch SendForModeration on confirm', () => {
+    component.competitionData = {
+      competitiveEventDraftId: '123'
+    } as CompetitionDraftCard;
+
+    const matDialogSpy = jest.spyOn(matDialog, 'open').mockReturnValue({
+      afterClosed: () => of(true)
+    } as MatDialogRef<ConfirmationModalWindowComponent>);
+
+    component.onSendForModeration('123', ModalConfirmationType.draftSet);
+    expect(matDialogSpy).toHaveBeenCalled();
+    expect(storeMock.dispatch).toHaveBeenCalledWith(new CompetitionDraftSendForModeration('123'));
   });
 });

--- a/src/app/shared/components/competition-card/competition-card.component.spec.ts
+++ b/src/app/shared/components/competition-card/competition-card.component.spec.ts
@@ -4,17 +4,11 @@ import { ENTER } from '@angular/cdk/keycodes';
 import { StsConfigLoader } from 'angular-auth-oidc-client';
 import { NgxsModule, Store } from '@ngxs/store';
 import { TranslateModule } from '@ngx-translate/core';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ENTER } from '@angular/cdk/keycodes';
 import { Router } from '@angular/router';
-import { NgxsModule, Store } from '@ngxs/store';
-import { TranslateModule } from '@ngx-translate/core';
-import { StsConfigLoader } from 'angular-auth-oidc-client';
 import { of } from 'rxjs';
 
 import { Role } from 'shared/enum/role';
 import { CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
-import { CompetitionProviderViewCard } from 'shared/models/competition.model';
 import { CompetitionStatus, FormOfLearning } from 'shared/enum/competition';
 import { RegistrationState } from 'shared/store/registration.state';
 import { GetCompetitionDraftIdByCompetitionId } from 'shared/store/provider.actions';
@@ -83,19 +77,21 @@ describe('CompetitionCardComponent', () => {
   });
 
   describe('onEdit', () => {
-    it('should navigate directly if workshopDraftId provided', () => {
+    it('should navigate directly if DraftId provided', () => {
       const mockRouter = TestBed.inject(Router);
+      component.competitionData = {
+        competitiveEventDraftId: '111'
+      } as CompetitionDraftCard;
       jest.spyOn(mockRouter, 'navigate');
-      component.onEdit('111');
-      expect(storeMock.dispatch).not.toHaveBeenCalled();
+      component.onEdit();
       expect(mockRouter.navigate).toHaveBeenCalledWith(['create/competition/draft', '111']);
     });
 
-    it('should dispatch check for workshopDraftId if workshopDraftId is not provided', () => {
+    it('should dispatch check for competitiveEventDraftId if DraftId is not provided', () => {
       component.competitionData = {
         id: '111'
       } as CompetitionDraftCard;
-      component.onEdit(undefined);
+      component.onEdit();
       expect(storeMock.dispatch).toHaveBeenCalledWith(new GetCompetitionDraftIdByCompetitionId('111'));
     });
   });
@@ -108,7 +104,7 @@ describe('CompetitionCardComponent', () => {
     jest.spyOn(component, 'onEdit');
     jest.spyOn(component, 'onDelete');
 
-    component.onEditKeydown(keyboardEvent, '111');
+    component.onEditKeydown(keyboardEvent);
     expect(component.onEdit).toHaveBeenCalled();
 
     component.onDeleteKeydown(keyboardEvent);

--- a/src/app/shared/components/competition-card/competition-card.component.spec.ts
+++ b/src/app/shared/components/competition-card/competition-card.component.spec.ts
@@ -4,12 +4,20 @@ import { ENTER } from '@angular/cdk/keycodes';
 import { StsConfigLoader } from 'angular-auth-oidc-client';
 import { NgxsModule, Store } from '@ngxs/store';
 import { TranslateModule } from '@ngx-translate/core';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ENTER } from '@angular/cdk/keycodes';
+import { Router } from '@angular/router';
+import { NgxsModule, Store } from '@ngxs/store';
+import { TranslateModule } from '@ngx-translate/core';
+import { StsConfigLoader } from 'angular-auth-oidc-client';
 import { of } from 'rxjs';
 
 import { Role } from 'shared/enum/role';
+import { CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
 import { CompetitionProviderViewCard } from 'shared/models/competition.model';
 import { CompetitionStatus, FormOfLearning } from 'shared/enum/competition';
 import { RegistrationState } from 'shared/store/registration.state';
+import { GetCompetitionDraftIdByCompetitionId } from 'shared/store/provider.actions';
 import { CompetitionCardComponent } from './competition-card.component';
 
 describe('CompetitionCardComponent', () => {
@@ -19,7 +27,8 @@ describe('CompetitionCardComponent', () => {
 
   beforeEach(() => {
     storeMock = {
-      select: jest.fn().mockReturnValue(of(Role.parent))
+      select: jest.fn().mockReturnValue(of(Role.parent)),
+      dispatch: jest.fn()
     };
 
     TestBed.configureTestingModule({
@@ -73,6 +82,24 @@ describe('CompetitionCardComponent', () => {
     expect(component.deleteCompetition.emit).toHaveBeenCalledWith(component.competitionData);
   });
 
+  describe('onEdit', () => {
+    it('should navigate directly if workshopDraftId provided', () => {
+      const mockRouter = TestBed.inject(Router);
+      jest.spyOn(mockRouter, 'navigate');
+      component.onEdit('111');
+      expect(storeMock.dispatch).not.toHaveBeenCalled();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['create/competition/draft', '111']);
+    });
+
+    it('should dispatch check for workshopDraftId if workshopDraftId is not provided', () => {
+      component.competitionData = {
+        id: '111'
+      } as CompetitionDraftCard;
+      component.onEdit(undefined);
+      expect(storeMock.dispatch).toHaveBeenCalledWith(new GetCompetitionDraftIdByCompetitionId('111'));
+    });
+  });
+
   it('keydown', () => {
     const keyboardEvent = new KeyboardEvent('keydown', {
       keyCode: ENTER
@@ -81,9 +108,17 @@ describe('CompetitionCardComponent', () => {
     jest.spyOn(component, 'onEdit');
     jest.spyOn(component, 'onDelete');
 
-    component.onEditKeydown(keyboardEvent);
+    component.onEditKeydown(keyboardEvent, '111');
     expect(component.onEdit).toHaveBeenCalled();
+
     component.onDeleteKeydown(keyboardEvent);
     expect(component.onDelete).toHaveBeenCalled();
+  });
+
+  it('coverImage error', () => {
+    component.onImageError();
+    expect(component.isImageBroken).toBeTruthy();
+
+    expect(component.competitionData._meta).toEqual('assets/images/groupimages/workshop-img.png');
   });
 });

--- a/src/app/shared/components/competition-card/competition-card.component.ts
+++ b/src/app/shared/components/competition-card/competition-card.component.ts
@@ -87,11 +87,10 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
       }
     });
 
-    dialogRef.afterClosed().subscribe((res: boolean) => {
-      if (res) {
-        this.store.dispatch(new CompetitionDraftSendForModeration(id));
-      }
-    });
+    dialogRef
+      .afterClosed()
+      .pipe(filter(Boolean))
+      .subscribe(() => this.store.dispatch(new CompetitionDraftSendForModeration(id)));
   }
 
   public onKeydown(event: KeyboardEvent, action: () => void): void {

--- a/src/app/shared/components/competition-card/competition-card.component.ts
+++ b/src/app/shared/components/competition-card/competition-card.component.ts
@@ -1,22 +1,21 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { ENTER, SPACE } from '@angular/cdk/keycodes';
 import { Select, Store } from '@ngxs/store';
 import { filter, Observable, Subject, takeUntil } from 'rxjs';
 import { Constants } from 'shared/constants/constants';
-import { CategoryIcons } from 'shared/enum/category-icons';
 import { CompetitionStatus } from 'shared/enum/competition';
 import { OwnershipTypesEnum } from 'shared/enum/enumUA/provider';
-import { FormOfLearningEnum, PayRateTypeEnum, RecruitmentStatusEnum } from 'shared/enum/enumUA/workshop';
+import { DraftStatusEnum, FormOfLearningEnum, PayRateTypeEnum, RecruitmentStatusEnum } from 'shared/enum/enumUA/workshop';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Role } from 'shared/enum/role';
-import {
-  CompetitionBaseCard,
-  CompetitionDraftCard,
-  CompetitionProviderViewCard
-} from 'shared/models/competition.model';
+import { CompetitionBaseCard, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
 import { RegistrationState } from 'shared/store/registration.state';
 import { ImagesService } from 'shared/services/images/images.service';
-import { ENTER, SPACE } from '@angular/cdk/keycodes';
-import { Router } from '@angular/router';
+import { WorkshopDraftStatus } from 'shared/enum/workshop';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { CompetitionDraftSendForModeration, GetCompetitionDraftIdByWorkshopId } from 'shared/store/provider.actions';
 
 @Component({
   selector: 'app-competition-card',
@@ -40,11 +39,12 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
   public readonly RecruitmentStatusEnum = RecruitmentStatusEnum;
   public readonly Role = Role;
   public readonly Constants = Constants;
-  public readonly CategoryIcons = CategoryIcons;
   public readonly PayRateTypeEnum = PayRateTypeEnum;
   public readonly FormOfLearningEnum = FormOfLearningEnum;
   public readonly CompetitionStatus = CompetitionStatus;
   public readonly ModalConfirmationType = ModalConfirmationType;
+  public readonly draftStatusEnum = DraftStatusEnum;
+  public readonly workshopDraftStatus = WorkshopDraftStatus;
   public competitionData: CompetitionProviderViewCard | CompetitionDraftCard;
 
   public role: Role;
@@ -52,6 +52,7 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
 
   constructor(
     private imageService: ImagesService,
+    private dialog: MatDialog,
     private router: Router,
     private store: Store
   ) {}
@@ -76,6 +77,21 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
   public onImageError(): void {
     this.isImageBroken = true;
     this.competitionData._meta = this.imageService.getDefaultCoverImage();
+  }
+
+  public onSendForModeration(id: string, type: ModalConfirmationType): void {
+    const dialogRef = this.dialog.open(ConfirmationModalWindowComponent, {
+      width: Constants.MODAL_SMALL,
+      data: {
+        type: type
+      }
+    });
+
+    dialogRef.afterClosed().subscribe((res: boolean) => {
+      if (res) {
+        this.store.dispatch(new CompetitionDraftSendForModeration(id));
+      }
+    });
   }
 
   public onKeydown(event: KeyboardEvent, action: () => void): void {

--- a/src/app/shared/components/competition-card/competition-card.component.ts
+++ b/src/app/shared/components/competition-card/competition-card.component.ts
@@ -15,7 +15,7 @@ import { RegistrationState } from 'shared/store/registration.state';
 import { ImagesService } from 'shared/services/images/images.service';
 import { WorkshopDraftStatus } from 'shared/enum/workshop';
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
-import { CompetitionDraftSendForModeration, GetCompetitionDraftIdByWorkshopId } from 'shared/store/provider.actions';
+import { CompetitionDraftSendForModeration, GetCompetitionDraftIdByCompetitionId } from 'shared/store/provider.actions';
 
 @Component({
   selector: 'app-competition-card',
@@ -111,6 +111,14 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
 
   public onDeleteKeydown(event: KeyboardEvent): void {
     this.onKeydown(event, () => this.onDelete());
+  }
+
+  public onEdit(competitiveEventDraftId: string | undefined): void {
+    if (competitiveEventDraftId) {
+      this.router.navigate(['create/competition/draft', competitiveEventDraftId]);
+    } else {
+      this.store.dispatch(new GetCompetitionDraftIdByCompetitionId(this.competitionData?.id));
+    }
   }
 
   public onDelete(): void {

--- a/src/app/shared/components/competition-card/competition-card.component.ts
+++ b/src/app/shared/components/competition-card/competition-card.component.ts
@@ -4,9 +4,9 @@ import { MatDialog } from '@angular/material/dialog';
 import { ENTER, SPACE } from '@angular/cdk/keycodes';
 import { Select, Store } from '@ngxs/store';
 import { filter, Observable, Subject, takeUntil } from 'rxjs';
+
 import { Constants } from 'shared/constants/constants';
 import { CompetitionStatus } from 'shared/enum/competition';
-import { OwnershipTypesEnum } from 'shared/enum/enumUA/provider';
 import { DraftStatusEnum, FormOfLearningEnum, PayRateTypeEnum, RecruitmentStatusEnum } from 'shared/enum/enumUA/workshop';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Role } from 'shared/enum/role';
@@ -35,7 +35,6 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
 
   public isImageBroken = false;
 
-  public readonly OwnershipTypeEnum = OwnershipTypesEnum;
   public readonly RecruitmentStatusEnum = RecruitmentStatusEnum;
   public readonly Role = Role;
   public readonly Constants = Constants;
@@ -104,17 +103,14 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
     this.onKeydown(event, () => this.onEdit());
   }
 
-  public onEdit(): void {
-    this.router.navigate(['/create-competition', this.competitionData.id]);
-  }
-
   public onDeleteKeydown(event: KeyboardEvent): void {
     this.onKeydown(event, () => this.onDelete());
   }
 
-  public onEdit(competitiveEventDraftId: string | undefined): void {
-    if (competitiveEventDraftId) {
-      this.router.navigate(['create/competition/draft', competitiveEventDraftId]);
+  public onEdit(): void {
+    const draftId = (this.competitionData as CompetitionDraftCard)?.competitiveEventDraftId;
+    if (draftId) {
+      this.router.navigate(['create/competition/draft', draftId]);
     } else {
       this.store.dispatch(new GetCompetitionDraftIdByCompetitionId(this.competitionData?.id));
     }
@@ -123,6 +119,4 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
   public onDelete(): void {
     this.deleteCompetition.emit(this.competitionData);
   }
-
-  protected readonly recruitmentStatusEnum = RecruitmentStatusEnum;
 }

--- a/src/app/shared/components/competition-card/competition-card.component.ts
+++ b/src/app/shared/components/competition-card/competition-card.component.ts
@@ -123,4 +123,6 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
   public onDelete(): void {
     this.deleteCompetition.emit(this.competitionData);
   }
+
+  protected readonly recruitmentStatusEnum = RecruitmentStatusEnum;
 }

--- a/src/app/shared/components/competition-card/competition-card.component.ts
+++ b/src/app/shared/components/competition-card/competition-card.component.ts
@@ -8,7 +8,11 @@ import { OwnershipTypesEnum } from 'shared/enum/enumUA/provider';
 import { FormOfLearningEnum, PayRateTypeEnum, RecruitmentStatusEnum } from 'shared/enum/enumUA/workshop';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Role } from 'shared/enum/role';
-import { CompetitionBaseCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
+import {
+  CompetitionBaseCard,
+  CompetitionDraftCard,
+  CompetitionProviderViewCard
+} from 'shared/models/competition.model';
 import { RegistrationState } from 'shared/store/registration.state';
 import { ImagesService } from 'shared/services/images/images.service';
 import { ENTER, SPACE } from '@angular/cdk/keycodes';
@@ -41,7 +45,7 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
   public readonly FormOfLearningEnum = FormOfLearningEnum;
   public readonly CompetitionStatus = CompetitionStatus;
   public readonly ModalConfirmationType = ModalConfirmationType;
-  public competitionData: CompetitionProviderViewCard;
+  public competitionData: CompetitionProviderViewCard | CompetitionDraftCard;
 
   public role: Role;
   public destroy$: Subject<boolean> = new Subject<boolean>();
@@ -52,15 +56,11 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
     private store: Store
   ) {}
 
-  @Input() public set competition(competition: CompetitionProviderViewCard) {
+  @Input() public set competition(competition: CompetitionProviderViewCard | CompetitionDraftCard) {
     this.competitionData = competition;
   }
 
   public ngOnInit(): void {
-    // this code is a stub, so when the logic appears on the backend, it will need to be removed
-    this.competitionData.amountOfPendingApplications = 0;
-    this.competitionData.unreadMessages = 0;
-
     this.Role$.pipe(takeUntil(this.destroy$))
       .pipe(filter((role: Role) => role === Role.parent))
       .subscribe((role: Role) => {

--- a/src/app/shared/components/competition-card/competition-card.component.ts
+++ b/src/app/shared/components/competition-card/competition-card.component.ts
@@ -110,7 +110,7 @@ export class CompetitionCardComponent implements OnInit, OnDestroy {
   public onEdit(): void {
     const draftId = (this.competitionData as CompetitionDraftCard)?.competitiveEventDraftId;
     if (draftId) {
-      this.router.navigate(['create/competition/draft', draftId]);
+      this.router.navigate(['/create/competition/draft', draftId]);
     } else {
       this.store.dispatch(new GetCompetitionDraftIdByCompetitionId(this.competitionData?.id));
     }

--- a/src/app/shared/components/image-form-control/image-form-control.component.ts
+++ b/src/app/shared/components/image-form-control/image-form-control.component.ts
@@ -102,7 +102,7 @@ export class ImageFormControlComponent implements OnInit, ControlValueAccessor, 
           data: { type: deleteImageType }
         })
         .afterClosed()
-        .pipe(first(), filter(Boolean))
+        .pipe(filter(Boolean))
         .subscribe(() => this.removeImage(img));
     } else {
       this.removeImage(img);
@@ -111,11 +111,14 @@ export class ImageFormControlComponent implements OnInit, ControlValueAccessor, 
 
   public activateEditMode(): void {
     this.editMode = true;
-    if (this.imageIdsFormControl?.value?.length) {
-      this.imageIdsFormControl.value.forEach((imageId) => {
-        this.decodedImages.push(new DecodedImage(environment.storageUrl + imageId, null));
-      });
+    if (!this.imageIdsFormControl.value) {
+      return;
     }
+
+    const images = Array.isArray(this.imageIdsFormControl.value) ? this.imageIdsFormControl.value : [this.imageIdsFormControl.value];
+    images.forEach((imageId: string) => {
+      this.decodedImages.push(new DecodedImage(environment.storageUrl + imageId, null));
+    });
   }
 
   public markAsTouched(): void {

--- a/src/app/shared/components/provider-status-banner/provider-status-banner.component.ts
+++ b/src/app/shared/components/provider-status-banner/provider-status-banner.component.ts
@@ -65,7 +65,7 @@ export class ProviderStatusBannerComponent implements OnInit, OnDestroy {
   }
 
   public continueDraft(): void {
-    this.router.navigate(['/create', 'unfinished']);
+    this.router.navigate(['/create/workshop', 'unfinished']);
   }
 
   public cancelDraft(): void {

--- a/src/app/shared/components/workshop-card/workshop-card.component.html
+++ b/src/app/shared/components/workshop-card/workshop-card.component.html
@@ -44,7 +44,7 @@
         <a
           class="more-details"
           [routerLink]="[
-            workshopData.id ? '/details/workshop' : '/details/draft',
+            workshopData.id ? '/details/workshop' : '/details/workshop-draft',
             workshopData.id ? workshopData.id : workshopData.workshopDraftId
           ]">
           <span class="card_link">

--- a/src/app/shared/components/workshop-card/workshop-card.component.scss
+++ b/src/app/shared/components/workshop-card/workshop-card.component.scss
@@ -119,32 +119,6 @@
   }
 }
 
-.admin-response {
-  padding: 10px 0;
-  font-size: 13px;
-  font-weight: bold;
-  font-family: Innerspace, sans-serif;
-}
-
-.rejection-message {
-  background: #ff000077;
-
-  box-sizing: border-box;
-  padding: 10px;
-  border-radius: 4px;
-
-  &-wrapper {
-    font-family: Innerspace, sans-serif;
-    font-size: 13px;
-    font-weight: 700;
-
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 4;
-    -webkit-box-orient: vertical;
-  }
-}
-
 ::ng-deep .mat-mdc-card-header .mat-mdc-card-title {
   height: 30px !important;
 }

--- a/src/app/shared/components/workshop-card/workshop-card.component.spec.ts
+++ b/src/app/shared/components/workshop-card/workshop-card.component.spec.ts
@@ -90,7 +90,7 @@ describe('WorkshopCardComponent', () => {
       } as WorkshopDraftCard;
       component.onEdit();
       expect(mockStore.dispatch).not.toHaveBeenCalled();
-      expect(mockRouter.navigate).toHaveBeenCalledWith(['create/draft', '111']);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['create/workshop/draft', '111']);
     });
 
     it('should dispatch check for workshopDraftId if workshopDraftId is not provided', () => {

--- a/src/app/shared/components/workshop-card/workshop-card.component.ts
+++ b/src/app/shared/components/workshop-card/workshop-card.component.ts
@@ -141,7 +141,7 @@ export class WorkshopCardComponent implements OnInit, OnDestroy {
   public onEdit(): void {
     const draftId = (this.workshopData as WorkshopDraftCard)?.workshopDraftId;
     if (draftId) {
-      this.router.navigate(['create/draft', draftId]);
+      this.router.navigate(['create/workshop/draft', draftId]);
     } else {
       this.store.dispatch(new GetWorkshopDraftIdByWorkshopId(this.workshopData?.id));
     }

--- a/src/app/shared/components/workshop-card/workshop-card.component.ts
+++ b/src/app/shared/components/workshop-card/workshop-card.component.ts
@@ -23,7 +23,7 @@ import { WorkshopBaseCard, WorkshopDraft, WorkshopDraftCard, WorkshopProviderVie
 import { ImagesService } from 'shared/services/images/images.service';
 import { ShowMessageBar } from 'shared/store/app.actions';
 import { CreateFavoriteWorkshop, DeleteFavoriteWorkshop } from 'shared/store/parent.actions';
-import { DraftSendForModeration, GetWorkshopDraftIdByWorkshopId, UpdateWorkshopStatus } from 'shared/store/provider.actions';
+import { GetWorkshopDraftIdByWorkshopId, UpdateWorkshopStatus, WorkshopDraftSendForModeration } from 'shared/store/provider.actions';
 import { RegistrationState } from 'shared/store/registration.state';
 import { MetaDataState } from 'shared/store/meta-data.state';
 import { FeaturesList } from 'shared/models/features-list.model';
@@ -224,7 +224,7 @@ export class WorkshopCardComponent implements OnInit, OnDestroy {
 
     dialogRef.afterClosed().subscribe((res: boolean) => {
       if (res) {
-        this.store.dispatch(new DraftSendForModeration(id));
+        this.store.dispatch(new WorkshopDraftSendForModeration(id));
       }
     });
   }

--- a/src/app/shared/directives/stepper/stepper.directive.ts
+++ b/src/app/shared/directives/stepper/stepper.directive.ts
@@ -47,7 +47,7 @@ export class StepperDirective {
     if (!this.stepElement) {
       return;
     }
-    console.log(this.form)
+
     this.form.markAllAsTouched();
     this.form.updateValueAndValidity();
 

--- a/src/app/shared/directives/stepper/stepper.directive.ts
+++ b/src/app/shared/directives/stepper/stepper.directive.ts
@@ -47,7 +47,7 @@ export class StepperDirective {
     if (!this.stepElement) {
       return;
     }
-
+    console.log(this.form)
     this.form.markAllAsTouched();
     this.form.updateValueAndValidity();
 

--- a/src/app/shared/enum/workshop.ts
+++ b/src/app/shared/enum/workshop.ts
@@ -1,7 +1,9 @@
 export enum WorkshopType {
   Workshop = 'workshop',
-  Draft = 'draft',
-  Competition = 'competition'
+  WorkshopDraft = 'workshop-draft',
+  Competition = 'competition',
+  CompetitionDraft = 'competition-draft',
+  Draft = 'draft'
 }
 
 export enum PayRateType {

--- a/src/app/shared/models/competition.model.ts
+++ b/src/app/shared/models/competition.model.ts
@@ -2,6 +2,7 @@ import { CompetitionCoverage, CompetitionStatus, FormOfLearning } from 'shared/e
 import { Address } from 'shared/models/address.model';
 import { Judge } from 'shared/models/judge.model';
 import { Provider } from 'shared/models/provider.model';
+import { WorkshopDraftStatus } from 'shared/enum/workshop';
 import { PaginationParameters } from './query-parameters.model';
 import { SectionItem } from './section-item.model';
 import { Contacts } from './workshop.model';
@@ -214,4 +215,11 @@ export interface Description {
   price?: number;
   benefitsOptionsDesc?: string;
   competitiveEventDescriptionItems?: CompetitiveDescriptionItem[];
+}
+
+export interface CompetitionDraftCard extends CompetitionBaseCard {
+  competitiveEventDraftId: string;
+  draftStatus: WorkshopDraftStatus;
+  rejectionMessage?: string;
+  coverImageId?: string;
 }

--- a/src/app/shared/models/competition.model.ts
+++ b/src/app/shared/models/competition.model.ts
@@ -148,7 +148,7 @@ export class Competition extends CompetitionBase {
   }
 }
 
-export class CompetitionDraft {
+export class CompetitionDraft extends Competition {
   competitiveEventDraftId: string;
   draftStatus: WorkshopDraftStatus;
   rejectionMessage?: string;

--- a/src/app/shared/models/competition.model.ts
+++ b/src/app/shared/models/competition.model.ts
@@ -139,7 +139,23 @@ export class Competition extends CompetitionBase {
     if (required.coverImage) {
       this.coverImage = required.coverImage;
     }
+    if (description.imageIds) {
+      this.imageIds = description.imageIds;
+    }
+    if (description.imageFiles) {
+      this.imageFiles = description.imageFiles;
+    }
   }
+}
+
+export class CompetitionDraft {
+  competitiveEventDraftId: string;
+  draftStatus: WorkshopDraftStatus;
+  rejectionMessage?: string;
+  competitiveEventDetails: Competition;
+  providerEdrpou: string;
+  directorFullName: string;
+  directorPosition: string;
 }
 
 export interface CompetitionRequired {
@@ -215,6 +231,8 @@ export interface Description {
   price?: number;
   benefitsOptionsDesc?: string;
   competitiveEventDescriptionItems?: CompetitiveDescriptionItem[];
+  imageIds?: string[];
+  imageFiles?: File[];
 }
 
 export interface CompetitionDraftCard extends CompetitionBaseCard {

--- a/src/app/shared/models/provider.model.ts
+++ b/src/app/shared/models/provider.model.ts
@@ -22,7 +22,6 @@ export abstract class ProviderBase {
   coverImage?: File;
   imageIds?: string[];
   imageFiles?: File[];
-  userId: string; // TODO: Remove as soon as it will be removed from the backend
   contacts: Contacts[];
   institutionStatusId?: number;
   institutionId?: string;
@@ -35,7 +34,6 @@ export abstract class ProviderBase {
     this.shortTitle = info.shortTitle;
     this.edrpou = info.edrpou;
     this.typeId = info.typeId;
-    this.userId = user.id;
     this.contacts = contacts;
     this.institutionId = info.institution.id;
     this.institution = info.institution;

--- a/src/app/shared/services/competitions/user-competition.service.spec.ts
+++ b/src/app/shared/services/competitions/user-competition.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { Store } from '@ngxs/store';
 
-import { Competition, CompetitionDraft, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
+import { Competition, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
 import { FeaturesList } from 'shared/models/features-list.model';
 import { SearchResponse } from 'shared/models/search.model';
 import { UserCompetitionService } from './user-competition.service';

--- a/src/app/shared/services/competitions/user-competition.service.spec.ts
+++ b/src/app/shared/services/competitions/user-competition.service.spec.ts
@@ -134,7 +134,7 @@ describe('UserCompetitionService', () => {
       const draftId = '111';
 
       service.updateDraft(draftId, mockCompetition).subscribe((data) => {
-        expect(data).toContain(mockCompetition);
+        expect(data).toMatchObject(mockCompetition);
       });
 
       const req = httpMock.expectOne('/api/v2/competitions-drafts/111');

--- a/src/app/shared/services/competitions/user-competition.service.spec.ts
+++ b/src/app/shared/services/competitions/user-competition.service.spec.ts
@@ -151,5 +151,19 @@ describe('UserCompetitionService', () => {
       expect(req.request.method).toBe('DELETE');
       req.flush(null);
     });
+
+    it('should send draft for moderation', (done) => {
+      service.sendDraftForModeration('123').subscribe({
+        next: (res) => {
+          expect(res).toBeFalsy();
+          done();
+        },
+        error: done.fail
+      });
+
+      const req = httpMock.expectOne('/api/v2/competitions-drafts/123/send-for-moderation');
+      expect(req.request.method).toBe('PUT');
+      req.flush(null);
+    });
   });
 });

--- a/src/app/shared/services/competitions/user-competition.service.spec.ts
+++ b/src/app/shared/services/competitions/user-competition.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { Store } from '@ngxs/store';
 
-import { Competition, CompetitionProviderViewCard } from 'shared/models/competition.model';
+import { Competition, CompetitionDraft, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
 import { FeaturesList } from 'shared/models/features-list.model';
 import { SearchResponse } from 'shared/models/search.model';
 import { UserCompetitionService } from './user-competition.service';
@@ -86,7 +86,7 @@ describe('UserCompetitionService', () => {
     req.flush(mockCompetition);
   });
 
-  it('should archivate competition by ID', () => {
+  it('should archive competition by ID', () => {
     service.archiveCompetitionById('123').subscribe((response) => {
       expect(response).toBeNull();
     });
@@ -110,5 +110,46 @@ describe('UserCompetitionService', () => {
     expect(formData.has('imageFiles')).toBeTruthy();
     expect(formData.has('coverImage')).toBeTruthy();
     expect(formData.has('judges')).toBeTruthy();
+  });
+
+  describe('drafts', () => {
+    it('should get provider view competitions drafts', () => {
+      const mockResponse: SearchResponse<CompetitionDraftCard[]> = {
+        entities: [{ competitiveEventDraftId: 'draft1' } as CompetitionDraftCard],
+        totalAmount: 1
+      };
+
+      service.getProviderViewCompetitionDrafts({ from: 0, size: 10, providerId: 'provider1' }).subscribe((data) => {
+        expect(data).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne('/api/v2/provider/provider1/competitions-drafts?From=0&Size=10');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockResponse);
+    });
+
+    it('should update competition draft', () => {
+      storeMock.selectSnapshot.mockReturnValue({ images: false } as FeaturesList);
+      const mockCompetition: Competition = { id: '123' } as Competition;
+      const draftId = '111';
+
+      service.updateDraft(draftId, mockCompetition).subscribe((data) => {
+        expect(data).toContain(mockCompetition);
+      });
+
+      const req = httpMock.expectOne('/api/v2/competitions-drafts/111');
+      expect(req.request.method).toBe('PUT');
+      req.flush(mockCompetition);
+    });
+
+    it('should delete competition draft by ID', () => {
+      service.deleteCompetitionDraft('123').subscribe((response) => {
+        expect(response).toBeNull();
+      });
+
+      const req = httpMock.expectOne('/api/v2/competitions-drafts/123');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
   });
 });

--- a/src/app/shared/services/competitions/user-competition.service.spec.ts
+++ b/src/app/shared/services/competitions/user-competition.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { Store } from '@ngxs/store';
+
 import { Competition, CompetitionProviderViewCard } from 'shared/models/competition.model';
 import { FeaturesList } from 'shared/models/features-list.model';
 import { SearchResponse } from 'shared/models/search.model';
@@ -60,15 +61,14 @@ describe('UserCompetitionService', () => {
     req.flush(mockResponse);
   });
 
-  it('should create competition using v1', () => {
-    storeMock.selectSnapshot.mockReturnValue({ images: false } as FeaturesList);
+  it('should create competition', () => {
     const mockCompetition: Competition = { id: '123' } as Competition;
 
     service.createCompetition(mockCompetition).subscribe((data) => {
       expect(data).toEqual(mockCompetition);
     });
 
-    const req = httpMock.expectOne('/api/v1/CompetitiveEvent');
+    const req = httpMock.expectOne('/api/v2/competitions-drafts');
     expect(req.request.method).toBe('POST');
     req.flush(mockCompetition);
   });

--- a/src/app/shared/services/competitions/user-competition.service.ts
+++ b/src/app/shared/services/competitions/user-competition.service.ts
@@ -85,6 +85,10 @@ export class UserCompetitionService {
     return this.http.put<Competition>(`/api/v2/competitions-drafts/${draftId}`, formData);
   }
 
+  public deleteCompetitionDraft(id: string): Observable<void> {
+    return this.http.delete<void>(`/api/v2/competitions-drafts/${id}`);
+  }
+
   /**
    * This method create competition
    * @param competition Competition

--- a/src/app/shared/services/competitions/user-competition.service.ts
+++ b/src/app/shared/services/competitions/user-competition.service.ts
@@ -2,7 +2,13 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
-import { Competition, CompetitionCardParameters, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
+import {
+  Competition,
+  CompetitionCardParameters,
+  CompetitionDraft,
+  CompetitionDraftCard,
+  CompetitionProviderViewCard
+} from 'shared/models/competition.model';
 import { FeaturesList } from 'shared/models/features-list.model';
 import { SearchResponse } from 'shared/models/search.model';
 import { MetaDataState } from 'shared/store/meta-data.state';
@@ -24,6 +30,10 @@ export class UserCompetitionService {
    */
   public getCompetitionById(id: string): Observable<Competition> {
     return this.http.get<Competition>(`/api/v1/CompetitiveEvent/${id}`);
+  }
+
+  public getCompetitionDraftById(id: string): Observable<CompetitionDraft> {
+    return this.http.get<CompetitionDraft>(`/api/v2/competitions-drafts/${id}`);
   }
 
   /**

--- a/src/app/shared/services/competitions/user-competition.service.ts
+++ b/src/app/shared/services/competitions/user-competition.service.ts
@@ -2,11 +2,10 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
-import { Competition, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
+import { Competition, CompetitionCardParameters, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
 import { FeaturesList } from 'shared/models/features-list.model';
 import { SearchResponse } from 'shared/models/search.model';
 import { MetaDataState } from 'shared/store/meta-data.state';
-import { CompetitionCardParameters } from 'shared/models/competition.model';
 
 @Injectable({
   providedIn: 'root'
@@ -67,6 +66,11 @@ export class UserCompetitionService {
     return this.http.put<void>(`/api/v2/competitions-drafts/${id}/send-for-moderation`, {});
   }
 
+  public updateDraft(draftId: string, draft: Competition): Observable<Competition> {
+    const formData = this.createFormData(draft, draftId);
+    return this.http.put<Competition>(`/api/v2/competitions-drafts/${draftId}`, formData);
+  }
+
   /**
    * This method create competition
    * @param competition Competition
@@ -83,15 +87,10 @@ export class UserCompetitionService {
    * This method update competition
    * @param competition Competition
    */
-  /**
-   / * This method creates a competition.
-   * todo: Update logic to use `createCompetitionV2` when the new version is available.
-   */
+
   public updateCompetition(competition: Competition): Observable<Competition> {
     this.isImagesFeature = this.store.selectSnapshot<FeaturesList>(MetaDataState.featuresList).images;
-    // this code return when v2 for competition will be
-    // return this.isImagesFeature ? this.updateCompetitionV2(competition) : this.updateCompetitionV1(competition);
-    return this.updateCompetitionV1(competition);
+    return this.isImagesFeature ? this.updateCompetitionV2(competition) : this.updateCompetitionV1(competition);
   }
 
   public updateCompetitionV1(competition: Competition): Observable<Competition> {
@@ -107,24 +106,27 @@ export class UserCompetitionService {
     return this.http.delete<void>(`/api/v2/CompetitiveEvent/Delete/${id}`);
   }
 
-  private createFormData(competition: Competition): FormData {
+  private createFormData(competition: Competition, draftId?: string): FormData {
+    const preKey = draftId ? 'CompetitiveEventV2Dto.' : '';
     const formData = new FormData();
     const formNames = ['contacts', 'competitiveEventDescriptionItems', 'judges', 'subDirectionIds'];
     const imageFiles = ['imageFiles', 'coverImage'];
 
-    console.log(competition)
-
     Object.keys(competition).forEach((key: string) => {
       if (competition[key]) {
         if (imageFiles.includes(key)) {
-          competition[key].forEach((file: File) => formData.append(key, file));
+          competition[key].forEach((file: File) => formData.append(`${preKey}${key}`, file));
         } else if (formNames.includes(key)) {
-          formData.append(key, JSON.stringify(competition[key]));
+          formData.append(`${preKey}${key}`, JSON.stringify(competition[key]));
         } else {
-          formData.append(key, competition[key]);
+          formData.append(`${preKey}${key}`, competition[key]);
         }
       }
     });
+
+    if (draftId) {
+      formData.append('id', draftId);
+    }
 
     return formData;
   }

--- a/src/app/shared/services/competitions/user-competition.service.ts
+++ b/src/app/shared/services/competitions/user-competition.service.ts
@@ -63,28 +63,20 @@ export class UserCompetitionService {
     );
   }
 
+  public sendDraftForModeration(id: string): Observable<void> {
+    return this.http.put<void>(`/api/v2/competitions-drafts/${id}/send-for-moderation`, {});
+  }
+
   /**
    * This method create competition
    * @param competition Competition
    */
-  /**
-   / * This method creates a competition.
-   * todo: Update logic to use `createCompetitionV2` when the new version is available.
-   */
   public createCompetition(competition: Competition): Observable<Competition> {
-    this.isImagesFeature = this.store.selectSnapshot<FeaturesList>(MetaDataState.featuresList).images;
-    // this code return when v2 for competition will be
-    // return this.isImagesFeature ? this.createCompetitionV2(competition) : this.createCompetitionV1(competition);
-    return this.createCompetitionV1(competition);
-  }
-
-  public createCompetitionV1(competition: Competition): Observable<Competition> {
-    return this.http.post<Competition>('/api/v1/CompetitiveEvent', competition);
+    return this.createCompetitionV2(competition);
   }
 
   public createCompetitionV2(competition: Competition): Observable<Competition> {
-    const formData = this.createFormData(competition);
-    return this.http.post<Competition>('/api/v2/CompetitiveEvent', formData);
+    return this.http.post<Competition>('/api/v2/competitions-drafts', this.createFormData(competition));
   }
 
   /**
@@ -117,8 +109,10 @@ export class UserCompetitionService {
 
   private createFormData(competition: Competition): FormData {
     const formData = new FormData();
-    const formNames = ['contacts', 'competitiveEventDescriptionItems', 'judges'];
+    const formNames = ['contacts', 'competitiveEventDescriptionItems', 'judges', 'subDirectionIds'];
     const imageFiles = ['imageFiles', 'coverImage'];
+
+    console.log(competition)
 
     Object.keys(competition).forEach((key: string) => {
       if (competition[key]) {

--- a/src/app/shared/services/competitions/user-competition.service.ts
+++ b/src/app/shared/services/competitions/user-competition.service.ts
@@ -93,12 +93,12 @@ export class UserCompetitionService {
    * This method create competition
    * @param competition Competition
    */
-  public createCompetition(competition: Competition): Observable<Competition> {
+  public createCompetition(competition: Competition): Observable<CompetitionDraft> {
     return this.createCompetitionV2(competition);
   }
 
-  public createCompetitionV2(competition: Competition): Observable<Competition> {
-    return this.http.post<Competition>('/api/v2/competitions-drafts', this.createFormData(competition));
+  public createCompetitionV2(competition: Competition): Observable<CompetitionDraft> {
+    return this.http.post<CompetitionDraft>('/api/v2/competitions-drafts', this.createFormData(competition));
   }
 
   /**

--- a/src/app/shared/services/competitions/user-competition.service.ts
+++ b/src/app/shared/services/competitions/user-competition.service.ts
@@ -80,9 +80,9 @@ export class UserCompetitionService {
     return this.http.put<void>(`/api/v2/competitions-drafts/${id}/send-for-moderation`, {});
   }
 
-  public updateDraft(draftId: string, draft: Competition): Observable<Competition> {
+  public updateDraft(draftId: string, draft: Competition): Observable<CompetitionDraft> {
     const formData = this.createFormData(draft, draftId);
-    return this.http.put<Competition>(`/api/v2/competitions-drafts/${draftId}`, formData);
+    return this.http.put<CompetitionDraft>(`/api/v2/competitions-drafts/${draftId}`, formData);
   }
 
   public deleteCompetitionDraft(id: string): Observable<void> {

--- a/src/app/shared/services/competitions/user-competition.service.ts
+++ b/src/app/shared/services/competitions/user-competition.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
-import { Competition, CompetitionProviderViewCard } from 'shared/models/competition.model';
+import { Competition, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
 import { FeaturesList } from 'shared/models/features-list.model';
 import { SearchResponse } from 'shared/models/search.model';
 import { MetaDataState } from 'shared/store/meta-data.state';
@@ -38,6 +38,25 @@ export class UserCompetitionService {
       .set('Size', competitionCardParameters.size.toString());
     return this.http.get<SearchResponse<CompetitionProviderViewCard[]>>(
       `/api/v1/provider/${competitionCardParameters?.providerId}/competitiveevents`,
+      {
+        params
+      }
+    );
+  }
+
+  /**
+   * This method get related competition drafts for provider personal cabinet
+   */
+  // eslint-disable-next-line max-len
+  public getProviderViewCompetitionDrafts(
+    competitionCardParameters: CompetitionCardParameters
+  ): Observable<SearchResponse<CompetitionDraftCard[]>> {
+    const params = new HttpParams()
+      .set('From', competitionCardParameters.from.toString())
+      .set('Size', competitionCardParameters.size.toString());
+
+    return this.http.get<SearchResponse<CompetitionDraftCard[]>>(
+      `/api/v2/provider/${competitionCardParameters.providerId}/competitions-drafts`,
       {
         params
       }

--- a/src/app/shared/services/competitions/user-competition.service.ts
+++ b/src/app/shared/services/competitions/user-competition.service.ts
@@ -36,6 +36,10 @@ export class UserCompetitionService {
     return this.http.get<CompetitionDraft>(`/api/v2/competitions-drafts/${id}`);
   }
 
+  public getCompetitionDraftIdByCompetitionId(competitionId: string): Observable<string> {
+    return this.http.get<string>(`/api/v2/competitions-drafts/event/${competitionId}/draft-id`);
+  }
+
   /**
    * This method get related competitions for provider personal cabinet
    */

--- a/src/app/shared/services/competitions/user-competition.service.ts
+++ b/src/app/shared/services/competitions/user-competition.service.ts
@@ -131,7 +131,7 @@ export class UserCompetitionService {
     const imageFiles = ['imageFiles', 'coverImage'];
 
     Object.keys(competition).forEach((key: string) => {
-      if (competition[key]) {
+      if (competition[key] !== null && competition[key] !== undefined) {
         if (imageFiles.includes(key)) {
           competition[key].forEach((file: File) => formData.append(`${preKey}${key}`, file));
         } else if (formNames.includes(key)) {

--- a/src/app/shared/services/workshops/user-workshop/user-workshop.service.spec.ts
+++ b/src/app/shared/services/workshops/user-workshop/user-workshop.service.spec.ts
@@ -121,7 +121,7 @@ describe('UserWorkshopService', () => {
     req.flush({} as WorkshopDraft);
   });
 
-  it('should get provider view draft cardss', (done) => {
+  it('should get provider view draft cards', (done) => {
     const workshopCardParameters = {
       from: 0,
       size: 10,

--- a/src/app/shared/store/provider.actions.ts
+++ b/src/app/shared/store/provider.actions.ts
@@ -19,6 +19,7 @@ import {
 } from 'shared/models/workshop.model';
 import { StudySubject, StudySubjectParameters } from 'shared/models/study-subject.model';
 import { Competition, CompetitionCardParameters, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
+import { WorkshopType } from 'shared/enum/workshop';
 
 export class GetAchievementById {
   static readonly type = '[provider] get achievement By Id';
@@ -146,12 +147,13 @@ export class GetWorkshopDraftIdByWorkshopId {
   constructor(public id: string) {}
 }
 
-export class OnGetWorkshopDraftIdByWorkshopIdSuccess {
-  static readonly type = '[provider] get Workshop DraftId by Workshop Id Success';
+export class OnGetDraftIdByEntityIdSuccess {
+  static readonly type = '[provider] get DraftId by Entity Id Success';
 
   constructor(
     public draftId: string,
-    public workshopId: string
+    public entityId: string,
+    public entityType: WorkshopType
   ) {}
 }
 
@@ -887,7 +889,7 @@ export class DeleteCompetitionDraftById {
   ) {}
 }
 
-export class GetCompetitionDraftIdByWorkshopId {
+export class GetCompetitionDraftIdByCompetitionId {
   static readonly type = '[provider] get Competition Draft ID by Competition Id';
 
   constructor(public id: string) {}

--- a/src/app/shared/store/provider.actions.ts
+++ b/src/app/shared/store/provider.actions.ts
@@ -242,8 +242,8 @@ export class CreateWorkshopDraft {
   constructor(public payload: Workshop) {}
 }
 
-export class UpdateDraft {
-  static readonly type = '[provider] update Draft';
+export class UpdateWorkshopDraft {
+  static readonly type = '[provider] update Workshop Draft';
 
   constructor(
     public draftId: string,
@@ -254,7 +254,7 @@ export class UpdateDraft {
 export class OnUpdateDraftSuccess {
   static readonly type = '[provider] update Draft success';
 
-  constructor(public payload: Workshop) {}
+  constructor(public payload: Workshop | Competition) {}
 }
 
 export class DeleteWorkshopDraftById {
@@ -867,6 +867,15 @@ export class OnArchiveCompetitionFail {
   static readonly type = '[provider] archive Competition by id fail';
 
   constructor(public error: HttpErrorResponse) {}
+}
+
+export class UpdateCompetitionDraft {
+  static readonly type = '[provider] update Competition Draft';
+
+  constructor(
+    public draftId: string,
+    public payload: Competition
+  ) {}
 }
 
 export class DeleteCompetitionDraftById {

--- a/src/app/shared/store/provider.actions.ts
+++ b/src/app/shared/store/provider.actions.ts
@@ -164,7 +164,7 @@ export class WorkshopDraftSendForModeration {
 }
 
 export class CompetitionDraftSendForModeration {
-  static readonly type = '[provider] send Draft for Moderation';
+  static readonly type = '[provider] send Competition Draft for Moderation';
 
   constructor(public id: string) {}
 }

--- a/src/app/shared/store/provider.actions.ts
+++ b/src/app/shared/store/provider.actions.ts
@@ -155,7 +155,13 @@ export class OnGetWorkshopDraftIdByWorkshopIdSuccess {
   ) {}
 }
 
-export class DraftSendForModeration {
+export class WorkshopDraftSendForModeration {
+  static readonly type = '[provider] send Workshop Draft for Moderation';
+
+  constructor(public id: string) {}
+}
+
+export class CompetitionDraftSendForModeration {
   static readonly type = '[provider] send Draft for Moderation';
 
   constructor(public id: string) {}
@@ -870,4 +876,10 @@ export class DeleteCompetitionDraftById {
     public payload: CompetitionDraftCard,
     public parameters: CompetitionCardParameters
   ) {}
+}
+
+export class GetCompetitionDraftIdByWorkshopId {
+  static readonly type = '[provider] get Competition Draft ID by Competition Id';
+
+  constructor(public id: string) {}
 }

--- a/src/app/shared/store/provider.actions.ts
+++ b/src/app/shared/store/provider.actions.ts
@@ -18,7 +18,7 @@ import {
   UnfinishedWorkshopContacts
 } from 'shared/models/workshop.model';
 import { StudySubject, StudySubjectParameters } from 'shared/models/study-subject.model';
-import { Competition, CompetitionCardParameters } from 'shared/models/competition.model';
+import { Competition, CompetitionCardParameters, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
 
 export class GetAchievementById {
   static readonly type = '[provider] get achievement By Id';
@@ -105,13 +105,19 @@ export class GetProviderViewWorkshops {
 }
 
 export class GetProviderViewWorkshopDrafts {
-  static readonly type = '[provider] get Workshops Drafts for provider cabinet';
+  static readonly type = '[provider] get Workshop Drafts for provider cabinet';
 
   constructor(public workshopCardParameters: WorkshopCardParameters) {}
 }
 
 export class GetProviderViewCompetitions {
   static readonly type = '[provider] get Competitions for provider cabinet';
+
+  constructor(public competitionCardParameters: CompetitionCardParameters) {}
+}
+
+export class GetProviderViewCompetitionDrafts {
+  static readonly type = '[provider] get Competition Drafts for provider cabinet';
 
   constructor(public competitionCardParameters: CompetitionCardParameters) {}
 }
@@ -855,4 +861,13 @@ export class OnArchiveCompetitionFail {
   static readonly type = '[provider] archive Competition by id fail';
 
   constructor(public error: HttpErrorResponse) {}
+}
+
+export class DeleteCompetitionDraftById {
+  static readonly type = '[provider] delete Competition draft';
+
+  constructor(
+    public payload: CompetitionDraftCard,
+    public parameters: CompetitionCardParameters
+  ) {}
 }

--- a/src/app/shared/store/provider.actions.ts
+++ b/src/app/shared/store/provider.actions.ts
@@ -260,7 +260,7 @@ export class OnUpdateDraftSuccess {
 }
 
 export class DeleteWorkshopDraftById {
-  static readonly type = '[provider] delete Draft';
+  static readonly type = '[provider] delete Workshop Draft';
 
   constructor(
     public payload: WorkshopDraftCard,
@@ -268,7 +268,7 @@ export class DeleteWorkshopDraftById {
   ) {}
 }
 
-export class OnDeleteDraftSuccess {
+export class OnDeleteWorkshopDraftSuccess {
   static readonly type = '[provider] delete Draft success';
 
   constructor(public parameters: WorkshopCardParameters) {}
@@ -887,6 +887,12 @@ export class DeleteCompetitionDraftById {
     public payload: CompetitionDraftCard,
     public parameters: CompetitionCardParameters
   ) {}
+}
+
+export class OnDeleteCompetitionDraftSuccess {
+  static readonly type = '[provider] delete Competition draft success';
+
+  constructor(public parameters: CompetitionCardParameters) {}
 }
 
 export class GetCompetitionDraftIdByCompetitionId {

--- a/src/app/shared/store/provider.state.ts
+++ b/src/app/shared/store/provider.state.ts
@@ -46,7 +46,9 @@ import { Position } from 'shared/models/position.model';
 import { workshopToDraftState } from 'shared/utils/provider.utils';
 import { StudySubject } from 'shared/models/study-subject.model';
 import { Competition, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
-import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import {
+  ConfirmationModalWindowComponent
+} from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { GetFilteredProviders } from './admin.actions';
 import { MarkFormDirty, ShowMessageBar } from './app.actions';
@@ -617,10 +619,10 @@ export class ProviderState {
     }
   }
 
-  @Action(providerActions.UpdateDraft)
+  @Action(providerActions.UpdateWorkshopDraft)
   updateDraft(
     { dispatch }: StateContext<ProviderStateModel>,
-    { draftId, payload }: providerActions.UpdateDraft
+    { draftId, payload }: providerActions.UpdateWorkshopDraft
   ): Observable<WorkshopDraft | void> {
     return this.userWorkshopService.updateDraft(draftId, payload).pipe(
       tap((res: WorkshopDraft) => dispatch(new providerActions.OnUpdateDraftSuccess(res))),
@@ -1311,6 +1313,17 @@ export class ProviderState {
   @Action(providerActions.OnArchiveCompetitionFail)
   archiveCompetitionByIdFail({ dispatch }: StateContext<ProviderStateModel>): void {
     dispatch(new ShowMessageBar({ message: SnackbarText.error, type: 'error' }));
+  }
+
+  @Action(providerActions.UpdateCompetitionDraft)
+  updateCompetitionDraft(
+    { dispatch }: StateContext<ProviderStateModel>,
+    { draftId, payload }: providerActions.UpdateCompetitionDraft
+  ): Observable<Competition | void> {
+    return this.userCompetitionService.updateDraft(draftId, payload).pipe(
+      tap((res: Competition) => dispatch(new providerActions.OnUpdateDraftSuccess(res))),
+      catchError((error: HttpErrorResponse) => dispatch(new providerActions.OnUpdateWorkshopFail(error)))
+    );
   }
 
   @Action(providerActions.CompetitionDraftSendForModeration)

--- a/src/app/shared/store/provider.state.ts
+++ b/src/app/shared/store/provider.state.ts
@@ -45,7 +45,7 @@ import { Util } from 'shared/utils/utils';
 import { Position } from 'shared/models/position.model';
 import { workshopToDraftState } from 'shared/utils/provider.utils';
 import { StudySubject } from 'shared/models/study-subject.model';
-import { Competition, CompetitionProviderViewCard } from 'shared/models/competition.model';
+import { Competition, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { GetFilteredProviders } from './admin.actions';
@@ -69,7 +69,8 @@ export interface ProviderStateModel {
   providerWorkshops: SearchResponse<WorkshopProviderViewCard[]>;
   providerCompetition: SearchResponse<CompetitionProviderViewCard[]>;
   officialEmployees: SearchResponse<OfficialEmployee[]>;
-  providerDrafts: SearchResponse<WorkshopDraftCard[]>;
+  providerWorkshopDrafts: SearchResponse<WorkshopDraftCard[]>;
+  providerCompetitionDrafts: SearchResponse<CompetitionDraftCard[]>;
   selectedEmployee: Employee;
   blockedParent: BlockedParent;
   truncatedItems: TruncatedItem[];
@@ -93,7 +94,8 @@ export interface ProviderStateModel {
     providerWorkshops: null,
     providerCompetition: null,
     officialEmployees: null,
-    providerDrafts: null,
+    providerWorkshopDrafts: null,
+    providerCompetitionDrafts: null,
     selectedEmployee: null,
     blockedParent: null,
     truncatedItems: null,
@@ -149,8 +151,13 @@ export class ProviderState {
   }
 
   @Selector()
-  static providerDrafts(state: ProviderStateModel): SearchResponse<WorkshopDraftCard[]> {
-    return state.providerDrafts;
+  static providerWorkshopDrafts(state: ProviderStateModel): SearchResponse<WorkshopDraftCard[]> {
+    return state.providerWorkshopDrafts;
+  }
+
+  @Selector()
+  static providerCompetitionDrafts(state: ProviderStateModel): SearchResponse<CompetitionDraftCard[]> {
+    return state.providerCompetitionDrafts;
   }
 
   @Selector()
@@ -449,8 +456,8 @@ export class ProviderState {
     return this.userWorkshopService
       .getProviderViewWorkshopDrafts(workshopCardParameters)
       .pipe(
-        tap((providerDrafts: SearchResponse<WorkshopDraftCard[]>) =>
-          patchState({ providerDrafts: providerDrafts ?? EMPTY_RESULT, isLoading: false })
+        tap((providerWorkshopDrafts: SearchResponse<WorkshopDraftCard[]>) =>
+          patchState({ providerWorkshopDrafts: providerWorkshopDrafts ?? EMPTY_RESULT, isLoading: false })
         )
       );
   }
@@ -466,6 +473,21 @@ export class ProviderState {
       .pipe(
         tap((providerCompetitions: SearchResponse<CompetitionProviderViewCard[]>) =>
           patchState({ providerCompetition: providerCompetitions ?? EMPTY_RESULT, isLoading: false })
+        )
+      );
+  }
+
+  @Action(providerActions.GetProviderViewCompetitionDrafts)
+  getProviderViewCompetitionDrafts(
+    { patchState }: StateContext<ProviderStateModel>,
+    { competitionCardParameters }: providerActions.GetProviderViewCompetitionDrafts
+  ): Observable<SearchResponse<CompetitionDraftCard[]>> {
+    patchState({ isLoading: true });
+    return this.userCompetitionService
+      .getProviderViewCompetitionDrafts(competitionCardParameters)
+      .pipe(
+        tap((providerCompetitionDrafts: SearchResponse<CompetitionDraftCard[]>) =>
+          patchState({ providerCompetitionDrafts: providerCompetitionDrafts ?? EMPTY_RESULT, isLoading: false })
         )
       );
   }

--- a/src/app/shared/store/provider.state.ts
+++ b/src/app/shared/store/provider.state.ts
@@ -639,18 +639,21 @@ export class ProviderState {
   }
 
   @Action(providerActions.DeleteWorkshopDraftById)
-  deleteDraft(
+  deleteWorkshopDraft(
     { dispatch }: StateContext<ProviderStateModel>,
     { payload, parameters }: providerActions.DeleteWorkshopDraftById
   ): Observable<void> {
     return this.userWorkshopService.deleteWorkshopDraft(payload.workshopDraftId).pipe(
-      tap(() => dispatch(new providerActions.OnDeleteDraftSuccess(parameters))),
+      tap(() => dispatch(new providerActions.OnDeleteWorkshopDraftSuccess(parameters))),
       catchError((error: HttpErrorResponse) => dispatch(new providerActions.OnDeleteDraftFail(error)))
     );
   }
 
-  @Action(providerActions.OnDeleteDraftSuccess)
-  onDeleteDraftSuccess({ dispatch }: StateContext<ProviderStateModel>, { parameters }: providerActions.OnDeleteDraftSuccess): void {
+  @Action(providerActions.OnDeleteWorkshopDraftSuccess)
+  onDeleteWorkshopDraftSuccess(
+    { dispatch }: StateContext<ProviderStateModel>,
+    { parameters }: providerActions.OnDeleteWorkshopDraftSuccess
+  ): void {
     dispatch([
       new ShowMessageBar({
         message: SnackbarText.deleteDraft,
@@ -1325,6 +1328,31 @@ export class ProviderState {
       tap((res: Competition) => dispatch(new providerActions.OnUpdateDraftSuccess(res))),
       catchError((error: HttpErrorResponse) => dispatch(new providerActions.OnUpdateWorkshopFail(error)))
     );
+  }
+
+  @Action(providerActions.DeleteCompetitionDraftById)
+  deleteCompetitionDraft(
+    { dispatch }: StateContext<ProviderStateModel>,
+    { payload, parameters }: providerActions.DeleteCompetitionDraftById
+  ): Observable<void> {
+    return this.userCompetitionService.deleteCompetitionDraft(payload.competitiveEventDraftId).pipe(
+      tap(() => dispatch(new providerActions.OnDeleteCompetitionDraftSuccess(parameters))),
+      catchError((error: HttpErrorResponse) => dispatch(new providerActions.OnDeleteDraftFail(error)))
+    );
+  }
+
+  @Action(providerActions.OnDeleteCompetitionDraftSuccess)
+  onDeleteCompetitionDraftSuccess(
+    { dispatch }: StateContext<ProviderStateModel>,
+    { parameters }: providerActions.OnDeleteCompetitionDraftSuccess
+  ): void {
+    dispatch([
+      new ShowMessageBar({
+        message: SnackbarText.deleteDraft,
+        type: 'success'
+      }),
+      new providerActions.GetProviderViewCompetitionDrafts(parameters)
+    ]);
   }
 
   @Action(providerActions.CompetitionDraftSendForModeration)

--- a/src/app/shared/store/provider.state.ts
+++ b/src/app/shared/store/provider.state.ts
@@ -1326,7 +1326,7 @@ export class ProviderState {
   ): Observable<Competition | void> {
     return this.userCompetitionService.updateDraft(draftId, payload).pipe(
       tap((res: Competition) => dispatch(new providerActions.OnUpdateDraftSuccess(res))),
-      catchError((error: HttpErrorResponse) => dispatch(new providerActions.OnUpdateWorkshopFail(error)))
+      catchError((error: HttpErrorResponse) => dispatch(new providerActions.OnUpdateCompetitionFail(error)))
     );
   }
 
@@ -1370,7 +1370,7 @@ export class ProviderState {
   @Action(providerActions.GetCompetitionDraftIdByCompetitionId)
   getCompetitionDraftIdByCompetitionId(
     { patchState, dispatch }: StateContext<ProviderStateModel>,
-    { id }: providerActions.GetWorkshopDraftIdByWorkshopId
+    { id }: providerActions.GetCompetitionDraftIdByCompetitionId
   ): Observable<string> {
     patchState({ isLoading: true });
     return this.userCompetitionService.getCompetitionDraftIdByCompetitionId(id).pipe(

--- a/src/app/shared/store/provider.state.ts
+++ b/src/app/shared/store/provider.state.ts
@@ -46,14 +46,17 @@ import { Position } from 'shared/models/position.model';
 import { workshopToDraftState } from 'shared/utils/provider.utils';
 import { StudySubject } from 'shared/models/study-subject.model';
 import { Competition, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
-import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import {
+  ConfirmationModalWindowComponent
+} from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { WorkshopType } from 'shared/enum/workshop';
 import { GetFilteredProviders } from './admin.actions';
 import { MarkFormDirty, ShowMessageBar } from './app.actions';
 import * as providerActions from './provider.actions';
 import {
   GetProviderViewCompetitions,
-  OnGetWorkshopDraftIdByWorkshopIdSuccess,
+  OnGetDraftIdByEntityIdSuccess,
   OnSaveWorkshopStep,
   OnSaveWorkshopStepFail,
   OnSaveWorkshopStepSuccess
@@ -578,7 +581,7 @@ export class ProviderState {
     patchState({ isLoading: true });
     return this.userWorkshopService.getWorkshopDraftIdByWorkshopId(id).pipe(
       take(1),
-      tap((draftId: string) => dispatch(new OnGetWorkshopDraftIdByWorkshopIdSuccess(draftId, id))),
+      tap((draftId: string) => dispatch(new OnGetDraftIdByEntityIdSuccess(draftId, id, WorkshopType.Workshop))),
       catchError(() => {
         dispatch(new ShowMessageBar({ message: SnackbarText.error, type: 'error' }));
         return EMPTY;
@@ -587,13 +590,13 @@ export class ProviderState {
     );
   }
 
-  @Action(providerActions.OnGetWorkshopDraftIdByWorkshopIdSuccess)
-  onGetWorkshopDraftIdByWorkshopIdSuccess(
+  @Action(providerActions.OnGetDraftIdByEntityIdSuccess)
+  onGetDraftIdByEntityIdSuccess(
     { dispatch }: StateContext<ProviderStateModel>,
-    { draftId, workshopId }: providerActions.OnGetWorkshopDraftIdByWorkshopIdSuccess
+    { draftId, entityId, entityType }: providerActions.OnGetDraftIdByEntityIdSuccess
   ): void {
     if (!draftId) {
-      this.router.navigate(['/create/workshop', workshopId]);
+      this.router.navigate(['create', entityType, entityId]);
     } else {
       this.matDialog
         .open(ConfirmationModalWindowComponent, {
@@ -605,7 +608,7 @@ export class ProviderState {
         .afterClosed()
         .pipe(filter(Boolean))
         .subscribe(() => {
-          this.router.navigate(['/create/draft', draftId]).then(() => {
+          this.router.navigate(['create', entityType, draftId]).then(() => {
             dispatch(
               new ShowMessageBar({
                 type: 'warningBlue',
@@ -1333,6 +1336,23 @@ export class ProviderState {
     return this.userCompetitionService.sendDraftForModeration(id).pipe(
       tap(() => dispatch(new providerActions.OnDraftSendForModerationSuccess())),
       catchError((error: HttpErrorResponse) => dispatch(new providerActions.OnDraftSendForModerationFail(error)))
+    );
+  }
+
+  @Action(providerActions.GetCompetitionDraftIdByCompetitionId)
+  getCompetitionDraftIdByCompetitionId(
+    { patchState, dispatch }: StateContext<ProviderStateModel>,
+    { id }: providerActions.GetWorkshopDraftIdByWorkshopId
+  ): Observable<string> {
+    patchState({ isLoading: true });
+    return this.userCompetitionService.getCompetitionDraftIdByCompetitionId(id).pipe(
+      take(1),
+      tap((draftId: string) => dispatch(new OnGetDraftIdByEntityIdSuccess(draftId, id, WorkshopType.Competition))),
+      catchError(() => {
+        dispatch(new ShowMessageBar({ message: SnackbarText.error, type: 'error' }));
+        return EMPTY;
+      }),
+      finalize(() => patchState({ isLoading: false }))
     );
   }
 

--- a/src/app/shared/store/provider.state.ts
+++ b/src/app/shared/store/provider.state.ts
@@ -282,10 +282,10 @@ export class ProviderState {
       .pipe(tap((truncatedItems: TruncatedItem[]) => patchState({ truncatedItems, isLoading: false })));
   }
 
-  @Action(providerActions.DraftSendForModeration)
+  @Action(providerActions.WorkshopDraftSendForModeration)
   sendDraftForModeration(
     { dispatch, patchState }: StateContext<ProviderStateModel>,
-    { id }: providerActions.DraftSendForModeration
+    { id }: providerActions.WorkshopDraftSendForModeration
   ): Observable<void> {
     patchState({ isLoading: true });
     return this.userWorkshopService.sendDraftForModeration(id).pipe(
@@ -1311,6 +1311,18 @@ export class ProviderState {
   @Action(providerActions.OnArchiveCompetitionFail)
   archiveCompetitionByIdFail({ dispatch }: StateContext<ProviderStateModel>): void {
     dispatch(new ShowMessageBar({ message: SnackbarText.error, type: 'error' }));
+  }
+
+  @Action(providerActions.CompetitionDraftSendForModeration)
+  sendCompetitionDraftForModeration(
+    { dispatch, patchState }: StateContext<ProviderStateModel>,
+    { id }: providerActions.CompetitionDraftSendForModeration
+  ): Observable<void> {
+    patchState({ isLoading: true });
+    return this.userCompetitionService.sendDraftForModeration(id).pipe(
+      tap(() => dispatch(new providerActions.OnDraftSendForModerationSuccess())),
+      catchError((error: HttpErrorResponse) => dispatch(new providerActions.OnDraftSendForModerationFail(error)))
+    );
   }
 
   @Action(OnSaveWorkshopStep)

--- a/src/app/shared/store/provider.state.ts
+++ b/src/app/shared/store/provider.state.ts
@@ -46,9 +46,7 @@ import { Position } from 'shared/models/position.model';
 import { workshopToDraftState } from 'shared/utils/provider.utils';
 import { StudySubject } from 'shared/models/study-subject.model';
 import { Competition, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
-import {
-  ConfirmationModalWindowComponent
-} from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { WorkshopType } from 'shared/enum/workshop';
 import { GetFilteredProviders } from './admin.actions';

--- a/src/app/shared/store/provider.state.ts
+++ b/src/app/shared/store/provider.state.ts
@@ -46,9 +46,7 @@ import { Position } from 'shared/models/position.model';
 import { workshopToDraftState } from 'shared/utils/provider.utils';
 import { StudySubject } from 'shared/models/study-subject.model';
 import { Competition, CompetitionDraftCard, CompetitionProviderViewCard } from 'shared/models/competition.model';
-import {
-  ConfirmationModalWindowComponent
-} from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { GetFilteredProviders } from './admin.actions';
 import { MarkFormDirty, ShowMessageBar } from './app.actions';

--- a/src/app/shared/store/shared-user.actions.ts
+++ b/src/app/shared/store/shared-user.actions.ts
@@ -1,82 +1,97 @@
 import { HttpErrorResponse } from '@angular/common/http';
 
 import { EditDraft, Workshop, WorkshopDraft } from 'shared/models/workshop.model';
+import { CompetitionDraft } from 'shared/models/competition.model';
 import { Application, ApplicationFilterParameters, ApplicationUpdate } from '../models/application.model';
 import { ProviderParameters } from '../models/provider.model';
-import { CompetitionDraft } from 'shared/models/competition.model';
 
 export class GetWorkshopsByProviderId {
   static readonly type = '[user] get Workshops By Provider Id';
+
   constructor(public providerParameters: ProviderParameters) {}
 }
 
 export class GetWorkshopById {
   static readonly type = '[user] get Workshop By Workshop Id';
+
   constructor(public payload: string) {}
 }
 
 export class OnGetWorkshopByIdSuccess {
   static readonly type = '[user] get Workshop By Workshop Id success';
+
   constructor(public workshop: Workshop) {}
 }
 
 export class OnGetWorkshopByIdFail {
   static readonly type = '[user] get Workshop By Workshop Id fail';
+
   constructor(public payload: HttpErrorResponse) {}
 }
 
 export class GetWorkshopDraftById {
   static readonly type = '[user] get Workshop Draft By Draft Id';
+
   constructor(public payload: string) {}
 }
 
 export class OnGetWorkshopDraftByIdSuccess {
   static readonly type = '[user] get Workshop Draft By Draft Id success';
+
   constructor(public payload: WorkshopDraft) {}
 }
 
 export class OnGetCompetitionDraftByIdSuccess {
   static readonly type = '[user] get Competition Draft By Draft Id success';
+
   constructor(public payload: CompetitionDraft) {}
 }
 
 export class OnGetDraftByIdFail {
   static readonly type = '[user] get Draft By Draft Id fail';
+
   constructor(public payload: HttpErrorResponse) {}
 }
 
 export class GetCompetitionById {
   static readonly type = '[user] get Competition By Competition Id';
+
   constructor(public payload: string) {}
 }
 
 export class GetCompetitionDraftById {
-  static readonly type = '[user] get Competition Draft By Competition Id';
+  static readonly type = '[user] get Competition Draft By Id';
+
   constructor(public payload: string) {}
 }
 
 export class GetAllApplications {
   static readonly type = '[admin] Get All Applications';
+
   constructor(public params: ApplicationFilterParameters) {}
 }
 
 export class OnGetCompetitionByIdFail {
   static readonly type = '[user] get Competition by Competition Id fail';
+
   constructor(public payload: HttpErrorResponse) {}
 }
 
 export class GetProviderById {
   static readonly type = '[user] get Provider By Provider Id';
+
   constructor(public payload: string) {}
 }
 
 export class OnGetProviderByIdFail {
   static readonly type = '[user] get Provider By Id fail';
+
   constructor(public payload: HttpErrorResponse) {}
 }
 
 export class GetApplicationsByPropertyId {
   static readonly type = '[user] get Applications By Property Id';
+
   constructor(
     public id: string,
     public parameters: ApplicationFilterParameters
@@ -85,46 +100,55 @@ export class GetApplicationsByPropertyId {
 
 export class GetApplicationsByStatus {
   static readonly type = '[user] get Applications By Status';
+
   constructor(public payload: number) {}
 }
 
 export class UpdateApplication {
   static readonly type = '[user] update Application';
+
   constructor(public payload: ApplicationUpdate) {}
 }
 
 export class OnUpdateApplicationFail {
   static readonly type = '[user] update Application fail';
+
   constructor(public payload: HttpErrorResponse) {}
 }
 
 export class OnUpdateApplicationSuccess {
   static readonly type = '[user] update Application success';
+
   constructor(public payload: Application) {}
 }
 
 export class GetFilteredChildren {
   static readonly type = '[user] get Filtered Children';
+
   constructor() {}
 }
 
 export class ResetProvider {
   static readonly type = '[user] clear Provider';
+
   constructor() {}
 }
 
 export class ResetWorkshop {
   static readonly type = '[user] clear Workshop';
+
   constructor() {}
 }
 
 export class ResetCompetition {
   static readonly type = '[user] clear Competition';
+
   constructor() {}
 }
 
 export class DeleteWorkshopDraftCoverImage {
   static readonly type = '[user] Delete Workshop Draft Cover Image';
+
   constructor(public draftId: string) {}
 }
 
@@ -134,11 +158,13 @@ export class DeleteWorkshopDraftCoverImageSuccess {
 
 export class DeleteWorkshopDraftCoverImageFail {
   static readonly type = '[user] Delete Workshop Draft Cover Image Fail';
+
   constructor(public error: HttpErrorResponse) {}
 }
 
 export class DeleteWorkshopDraftImage {
   static readonly type = '[user] Delete Workshop Draft Image';
+
   constructor(
     public draftId: string,
     public imageId: string
@@ -151,11 +177,13 @@ export class DeleteWorkshopDraftImageSuccess {
 
 export class DeleteWorkshopDraftImageFail {
   static readonly type = '[user] Delete Workshop Draft Image Fail';
+
   constructor(public error: HttpErrorResponse) {}
 }
 
 export class EditWorkshopDraftByModerator {
   static readonly type = '[user] Edit Workshop Draft By Moderator';
+
   constructor(
     public formData: EditDraft,
     public draftId: string
@@ -168,5 +196,6 @@ export class EditWorkshopDraftByModeratorSuccess {
 
 export class EditWorkshopDraftByModeratorFail {
   static readonly type = '[user] Edit Workshop Draft By Moderator Fail';
+
   constructor(public error: HttpErrorResponse) {}
 }

--- a/src/app/shared/store/shared-user.actions.ts
+++ b/src/app/shared/store/shared-user.actions.ts
@@ -3,6 +3,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { EditDraft, Workshop, WorkshopDraft } from 'shared/models/workshop.model';
 import { Application, ApplicationFilterParameters, ApplicationUpdate } from '../models/application.model';
 import { ProviderParameters } from '../models/provider.model';
+import { CompetitionDraft } from 'shared/models/competition.model';
 
 export class GetWorkshopsByProviderId {
   static readonly type = '[user] get Workshops By Provider Id';
@@ -34,13 +35,23 @@ export class OnGetWorkshopDraftByIdSuccess {
   constructor(public payload: WorkshopDraft) {}
 }
 
-export class OnGetWorkshopDraftByIdFail {
-  static readonly type = '[user] get Workshop Draft By Draft Id fail';
+export class OnGetCompetitionDraftByIdSuccess {
+  static readonly type = '[user] get Competition Draft By Draft Id success';
+  constructor(public payload: CompetitionDraft) {}
+}
+
+export class OnGetDraftByIdFail {
+  static readonly type = '[user] get Draft By Draft Id fail';
   constructor(public payload: HttpErrorResponse) {}
 }
 
 export class GetCompetitionById {
   static readonly type = '[user] get Competition By Competition Id';
+  constructor(public payload: string) {}
+}
+
+export class GetCompetitionDraftById {
+  static readonly type = '[user] get Competition Draft By Competition Id';
   constructor(public payload: string) {}
 }
 

--- a/src/app/shared/store/shared-user.state.ts
+++ b/src/app/shared/store/shared-user.state.ts
@@ -184,7 +184,7 @@ export class SharedUserState {
   @Action(GetCompetitionDraftById)
   getCompetitionDraftById(
     { patchState, dispatch }: StateContext<SharedUserStateModel>,
-    { payload }: GetCompetitionById
+    { payload }: GetCompetitionDraftById
   ): Observable<CompetitionDraft | void> {
     patchState({ isLoading: true });
     return this.userCompetitionService.getCompetitionDraftById(payload).pipe(

--- a/src/app/shared/store/shared-user.state.ts
+++ b/src/app/shared/store/shared-user.state.ts
@@ -8,7 +8,7 @@ import { EMPTY_RESULT } from 'shared/constants/constants';
 import { messageStatus, showHttpErrorMessage, SnackbarText } from 'shared/enum/enumUA/message-bar';
 import { ApplicationStatuses } from 'shared/enum/statuses';
 import { Application } from 'shared/models/application.model';
-import { Competition } from 'shared/models/competition.model';
+import { Competition, CompetitionDraft } from 'shared/models/competition.model';
 import { Provider } from 'shared/models/provider.model';
 import { SearchResponse } from 'shared/models/search.model';
 import { Workshop, WorkshopCard, WorkshopDraft, WorkshopDraftCard } from 'shared/models/workshop.model';
@@ -34,15 +34,17 @@ import {
   GetAllApplications,
   GetApplicationsByPropertyId,
   GetCompetitionById,
+  GetCompetitionDraftById,
   GetProviderById,
   GetWorkshopById,
   GetWorkshopDraftById,
   GetWorkshopsByProviderId,
   OnGetCompetitionByIdFail,
+  OnGetCompetitionDraftByIdSuccess,
+  OnGetDraftByIdFail,
   OnGetProviderByIdFail,
   OnGetWorkshopByIdFail,
   OnGetWorkshopByIdSuccess,
-  OnGetWorkshopDraftByIdFail,
   OnGetWorkshopDraftByIdSuccess,
   OnUpdateApplicationFail,
   OnUpdateApplicationSuccess,
@@ -58,7 +60,7 @@ export interface SharedUserStateModel {
   selectedWorkshop: Workshop | WorkshopDraft;
   selectedProvider: Provider;
   applicationCards: SearchResponse<Application[]>;
-  selectedCompetition: Competition;
+  selectedCompetition: Competition | CompetitionDraft;
 }
 
 @State<SharedUserStateModel>({
@@ -105,7 +107,7 @@ export class SharedUserState {
   }
 
   @Selector()
-  static selectedCompetition(state: SharedUserStateModel): Competition {
+  static selectedCompetition(state: SharedUserStateModel): Competition | CompetitionDraft {
     return state.selectedCompetition;
   }
 
@@ -147,7 +149,7 @@ export class SharedUserState {
     patchState({ isLoading: true });
     return this.userWorkshopService.getWorkshopDraftById(payload).pipe(
       tap((workshop: WorkshopDraft) => dispatch(new OnGetWorkshopDraftByIdSuccess(workshop))),
-      catchError((error: HttpErrorResponse) => dispatch(new OnGetWorkshopDraftByIdFail(error)))
+      catchError((error: HttpErrorResponse) => dispatch(new OnGetDraftByIdFail(error)))
     );
   }
 
@@ -156,9 +158,9 @@ export class SharedUserState {
     patchState({ selectedWorkshop: payload, isLoading: false });
   }
 
-  @Action(OnGetWorkshopDraftByIdFail)
-  onGetWorkshopDraftByIdFail({ dispatch, patchState }: StateContext<SharedUserStateModel>, { payload }: OnGetWorkshopDraftByIdFail): void {
-    patchState({ selectedWorkshop: null, isLoading: false });
+  @Action(OnGetDraftByIdFail)
+  onGetDraftByIdFail({ dispatch, patchState }: StateContext<SharedUserStateModel>, { payload }: OnGetDraftByIdFail): void {
+    patchState({ selectedWorkshop: null, selectedCompetition: null, isLoading: false });
     dispatch(
       new ShowMessageBar({
         message: SnackbarText.deletedDraft,
@@ -177,6 +179,26 @@ export class SharedUserState {
       tap((competition: Competition) => patchState({ selectedCompetition: competition, isLoading: false })),
       catchError((error: HttpErrorResponse) => dispatch(new OnGetCompetitionByIdFail(error)))
     );
+  }
+
+  @Action(GetCompetitionDraftById)
+  getCompetitionDraftById(
+    { patchState, dispatch }: StateContext<SharedUserStateModel>,
+    { payload }: GetCompetitionById
+  ): Observable<CompetitionDraft | void> {
+    patchState({ isLoading: true });
+    return this.userCompetitionService.getCompetitionDraftById(payload).pipe(
+      tap((competition: CompetitionDraft) => dispatch(new OnGetCompetitionDraftByIdSuccess(competition))),
+      catchError((error: HttpErrorResponse) => dispatch(new OnGetDraftByIdFail(error)))
+    );
+  }
+
+  @Action(OnGetCompetitionDraftByIdSuccess)
+  onGetCompetitionDraftByIdSuccess(
+    { patchState }: StateContext<SharedUserStateModel>,
+    { payload }: OnGetCompetitionDraftByIdSuccess
+  ): void {
+    patchState({ selectedCompetition: payload, isLoading: false });
   }
 
   @Action(GetAllApplications)
@@ -237,7 +259,6 @@ export class SharedUserState {
     { id, parameters }: GetApplicationsByPropertyId
   ): Observable<SearchResponse<Application[]>> {
     patchState({ isLoading: true });
-
     return this.applicationService
       .getApplicationsByPropertyId(id, parameters)
       .pipe(

--- a/src/app/shared/styles/components/cards.scss
+++ b/src/app/shared/styles/components/cards.scss
@@ -250,3 +250,31 @@
 .mat-mdc-card-content:last-child {
   padding-bottom: 0;
 }
+
+.admin-response {
+  padding: 10px 0;
+  font-size: 13px;
+  font-weight: bold;
+  font-family: Innerspace, sans-serif;
+}
+
+.rejection-message {
+  background: #ff000077;
+
+  box-sizing: border-box;
+  padding: 10px;
+  border-radius: 4px;
+
+  &-wrapper {
+    font-family: Innerspace, sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+  }
+}
+
+

--- a/src/app/shared/styles/components/drafts.scss
+++ b/src/app/shared/styles/components/drafts.scss
@@ -1,0 +1,45 @@
+.btn-cancel {
+  background-color: transparent;
+  border: 1px solid var(--specific-text-color) !important;
+  color: var(--specific-text-color) !important;
+}
+
+.btn-publish {
+  background-color: var(--specific-bg-button) !important;
+  color: var(--light-text-button) !important;
+}
+
+.error-message {
+  color: red;
+  height: 40px;
+  width: 40px;
+  font-size: 40px;
+
+  &:hover {
+    color: darkred;
+  }
+}
+
+.reject {
+  &-block {
+    height: 34px;
+    background-color: transparent;
+    border-radius: 20px;
+    padding: 0 30px;
+    transition:
+      background-color 0.3s ease,
+      color 0.3s ease;
+
+    &-moderator-message {
+      font-family: Innerspace, sans-serif;
+      font-weight: bold;
+      font-size: 13px;
+      color: var(--specific-light-text-color);
+      user-select: none;
+    }
+  }
+
+  &-block:hover {
+    background-color: #ece8e8;
+  }
+}

--- a/src/app/shared/styles/components/navigation-tabs.scss
+++ b/src/app/shared/styles/components/navigation-tabs.scss
@@ -1,4 +1,8 @@
 :host ::ng-deep {
+  .mdc-tab {
+    height: 36px !important;
+  }
+
   .mat-mdc-tab-group:hover,
   .mat-mdc-tab-nav-bar:hover {
     --mat-tab-header-active-ripple-color: transparent;

--- a/src/app/shared/styles/components/side-menu-cards.scss
+++ b/src/app/shared/styles/components/side-menu-cards.scss
@@ -1,6 +1,7 @@
 .container {
   background: var(--bg-specific-light);
   box-shadow: 0px 6px 16px rgba(0, 0, 0, 0.08);
+  border-radius: 5px;
   padding: 24px;
   width: 300px;
   min-height: 206px;

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -17,7 +17,7 @@ import { PaginationElement } from 'shared/models/pagination-element.model';
 import { PaginationParameters } from 'shared/models/query-parameters.model';
 import { Person } from 'shared/models/user.model';
 import { AdminsTableData, OfficialEmployeeTableData, UsersTableData } from 'shared/models/users-table';
-import { Contacts, Workshop } from 'shared/models/workshop.model';
+import { Workshop } from 'shared/models/workshop.model';
 import { ValidationConstants } from 'shared/constants/validation';
 import { TIME_REGEX_REPLACE } from 'shared/constants/regex-constants';
 import { OfficialEmployee } from 'shared/models/official-employee.model';
@@ -52,8 +52,10 @@ export class Util {
     });
   }
 
-  public static containsWorkshopDetails(workshop: object): workshop is { workshopDetails: Workshop } {
-    return !!workshop && 'workshopDetails' in workshop;
+  public static containsWorkshopOrCompetitionDetails(
+    entity: object
+  ): entity is { workshopDetails: Workshop } | { competitiveEventDetails: Competition } {
+    return !!entity && ('workshopDetails' in entity || 'competitiveEventDetails' in entity);
   }
 
   /**

--- a/src/app/shared/validators/array-length/array-length-validator.spec.ts
+++ b/src/app/shared/validators/array-length/array-length-validator.spec.ts
@@ -32,10 +32,4 @@ describe('ArrayLengthValidator', () => {
 
     expect(numbers.errors).toEqual({ minArrayLength: { requiredLength: 3, actualLength: 0 } });
   });
-
-  it('should return not array error if value is null', () => {
-    const numbers: FormControl = new FormControl(null, [minArrayLength(3), maxArrayLength(6)]);
-
-    expect(numbers.errors).toEqual({ notArray: true });
-  });
 });

--- a/src/app/shared/validators/array-length/array-length-validator.ts
+++ b/src/app/shared/validators/array-length/array-length-validator.ts
@@ -3,6 +3,11 @@ import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 export function minArrayLength(minLength: number): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     const value = control.value;
+
+    if (!value) {
+      return null;
+    }
+
     if (!Array.isArray(value)) {
       return { notArray: true };
     }
@@ -21,6 +26,11 @@ export function minArrayLength(minLength: number): ValidatorFn {
 export function maxArrayLength(maxLength: number): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     const value = control.value;
+
+    if (!value) {
+      return null;
+    }
+
     if (!Array.isArray(value)) {
       return { notArray: true };
     }

--- a/src/app/shell/details/competition-details/competition-details.component.html
+++ b/src/app/shell/details/competition-details/competition-details.component.html
@@ -136,6 +136,7 @@
 
     <mat-tab-group
       class="nav"
+      [dynamicHeight]="true"
       [mat-stretch-tabs]="false"
       [selectedIndex]="selectedIndex"
       (animationDone)="onAnimationDone()"

--- a/src/app/shell/details/competition-details/competition-details.component.html
+++ b/src/app/shell/details/competition-details/competition-details.component.html
@@ -14,17 +14,59 @@
       {{ 'BUTTONS.ARCHIVE' | translate }}
     </button>
     <div class="flex">
-      <a [routerLink]="['/create-competition', competition.id]" class="btn btn-cancel" mat-button>
-        {{ 'BUTTONS.EDIT' | translate }}
-      </a>
+      <span
+        [matTooltip]="
+          competition.draftStatus === WorkshopDraftStatus.PendingModeration
+            ? ('TOOLTIP.CANNOT_EDIT_WORKSHOP_PENDING_MODERATION' | translate)
+            : null
+        ">
+        <button
+          class="btn btn-cancel"
+          [class.btn-rejected]="competition.draftStatus === WorkshopDraftStatus.Rejected"
+          [disabled]="competition.draftStatus === WorkshopDraftStatus.PendingModeration"
+          mat-button
+          (click)="onEdit()">
+          {{ 'BUTTONS.EDIT' | translate }}
+        </button>
+      </span>
       <button
+        *ngIf="competition.competitiveEventDraftId"
         class="btn btn-publish"
-        [disabled]="competition.state !== CompetitionStatus.Draft"
-        (click)="onActionButtonClick(ModalType.publishCompetition)"
+        [disabled]="competition.draftStatus === WorkshopDraftStatus.PendingModeration"
+        (click)="onActionButtonClick(ModalConfirmationType.draftSet)"
         mat-button>
         {{ 'BUTTONS.PUBLISH' | translate }}
       </button>
     </div>
+  </div>
+
+  <div
+    *ngIf="competition.draftStatus === WorkshopDraftStatus.Draft || competition.draftStatus === WorkshopDraftStatus.PendingModeration"
+    class="draft-panel flex items-center"
+    [ngClass]="{
+      'draft-panel-draft': competition.draftStatus === WorkshopDraftStatus.Draft,
+      'draft-panel-pending': competition.draftStatus === WorkshopDraftStatus.PendingModeration
+    }">
+    <ng-container [ngSwitch]="competition.draftStatus">
+      <span *ngSwitchCase="WorkshopDraftStatus.Draft">
+        {{ 'ENUM.WORKSHOP_DRAFT.STATUS.DRAFT' | translate | uppercase }}
+      </span>
+      <span *ngSwitchCase="WorkshopDraftStatus.PendingModeration">
+        {{ 'ENUM.WORKSHOP_DRAFT.STATUS.PENDING' | translate | uppercase }}
+      </span>
+    </ng-container>
+  </div>
+  <div class="expansion-wrapper" *ngIf="competition.rejectionMessage">
+    <mat-expansion-panel expanded>
+      <mat-expansion-panel-header>
+        <mat-panel-title class="reject-block-moderator-message">
+          {{ 'MODERATOR_MESSAGE' | translate | uppercase }}
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+      <p>
+        {{ competition.rejectionMessage }}
+      </p>
+    </mat-expansion-panel>
   </div>
 
   <div class="details-wrapper">

--- a/src/app/shell/details/competition-details/competition-details.component.scss
+++ b/src/app/shell/details/competition-details/competition-details.component.scss
@@ -2,6 +2,7 @@
 @use 'details';
 @use 'workshop-status';
 @use 'buttons';
+@use 'drafts';
 
 .workshop-title {
   margin-bottom: 0;
@@ -22,17 +23,6 @@
 
 .details-link {
   margin-bottom: 1rem;
-}
-
-.btn-cancel {
-  background-color: transparent;
-  border: 1px solid var(--specific-text-color) !important;
-  color: var(--specific-text-color) !important;
-}
-
-.btn-publish {
-  background-color: var(--specific-bg-button) !important;
-  color: var(--light-text-button) !important;
 }
 
 .action-buttons-wrapper {

--- a/src/app/shell/details/competition-details/competition-details.component.spec.ts
+++ b/src/app/shell/details/competition-details/competition-details.component.spec.ts
@@ -16,12 +16,12 @@ import { ConfirmationModalWindowComponent } from 'shared/components/confirmation
 import { Role } from 'shared/enum/role';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Provider } from 'shared/models/provider.model';
-import { Competition } from 'shared/models/competition.model';
+import { Competition, CompetitionDraft } from 'shared/models/competition.model';
 import { Judge } from 'shared/models/judge.model';
 import { Constants } from 'shared/constants/constants';
 import { ImagesService } from 'shared/services/images/images.service';
 import { SubDirection } from 'shared/models/category.model';
-import { ArchiveCompetitionById } from 'shared/store/provider.actions';
+import { ArchiveCompetitionById, CompetitionDraftSendForModeration } from 'shared/store/provider.actions';
 import { CompetitionDetailsComponent } from './competition-details.component';
 
 describe('CompetitionDetailsComponent', () => {
@@ -101,17 +101,21 @@ describe('CompetitionDetailsComponent', () => {
       } as MatDialogRef<ConfirmationModalWindowComponent>);
     });
 
-    // it('should open confirmation dialog and dispatch SendForModeration on confirm', () => {
-    //   expectingMatDialogData = {
-    //     width: Constants.MODAL_SMALL,
-    //     data: {
-    //       type: ModalConfirmationType.draftSet
-    //     }
-    //   };
-    //   component.onActionButtonClick(ModalConfirmationType.draftSet);
-    //   expect(matDialogSpy).toHaveBeenCalledTimes(1);
-    //   expect(mockStore.dispatch).toHaveBeenCalledWith(new CompetitionDraftSendForModeration('123'));
-    // });
+    it('should open confirmation dialog and dispatch SendForModeration on confirm', () => {
+      component.competition = {
+        competitiveEventDraftId: '123'
+      } as CompetitionDraft;
+
+      expectingMatDialogData = {
+        width: Constants.MODAL_SMALL,
+        data: {
+          type: ModalConfirmationType.draftSet
+        }
+      };
+      component.onActionButtonClick(ModalConfirmationType.draftSet);
+      expect(matDialogSpy).toHaveBeenCalledTimes(1);
+      expect(mockStore.dispatch).toHaveBeenCalledWith(new CompetitionDraftSendForModeration('123'));
+    });
 
     it('should open confirmation dialog and dispatch ArchiveCompetition on confirm', () => {
       component.competition = {

--- a/src/app/shell/details/competition-details/competition-details.component.ts
+++ b/src/app/shell/details/competition-details/competition-details.component.ts
@@ -100,7 +100,6 @@ export class CompetitionDetailsComponent extends TabParamsComponent implements O
       .afterClosed()
       .pipe(
         filter(Boolean),
-        filter(Boolean),
         switchMap(() => {
           if (type === ModalConfirmationType.draftSet) {
             this.store.dispatch(new CompetitionDraftSendForModeration((this.competition as CompetitionDraft).competitiveEventDraftId));

--- a/src/app/shell/details/competition-details/competition-details.component.ts
+++ b/src/app/shell/details/competition-details/competition-details.component.ts
@@ -7,7 +7,7 @@ import { EMPTY, filter, Observable } from 'rxjs';
 import { switchMap, take, takeUntil, tap } from 'rxjs/operators';
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { Constants, PaginationConstants } from 'shared/constants/constants';
-import { CompetitionDetailsTabTitlesParams, CompetitionStatus } from 'shared/enum/competition';
+import { CompetitionStatus } from 'shared/enum/competition';
 import { CompetitionDetailsTabTitlesEnum } from 'shared/enum/enumUA/competition';
 import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
 import { FormOfLearningEnum, RecruitmentStatusEnum } from 'shared/enum/enumUA/workshop';

--- a/src/app/shell/details/competition-details/competition-details.component.ts
+++ b/src/app/shell/details/competition-details/competition-details.component.ts
@@ -31,6 +31,7 @@ import {
   GetCompetitionDraftIdByCompetitionId,
   OnArchiveCompetitionFail,
   OnArchiveCompetitionSuccess,
+  OnDeleteDraftFail,
   OnDraftSendForModerationSuccess
 } from 'shared/store/provider.actions';
 import { WorkshopDraftStatus, WorkshopType } from 'shared/enum/workshop';
@@ -110,7 +111,7 @@ export class CompetitionDetailsComponent extends TabParamsComponent implements O
             return this.actions$.pipe(
               ofAction(OnDraftSendForModerationSuccess),
               take(1),
-              takeUntil(this.actions$.pipe(ofAction(OnArchiveCompetitionFail))),
+              takeUntil(this.actions$.pipe(ofAction(OnDeleteDraftFail))),
               tap(() => this.store.dispatch(new GetCompetitionDraftById((this.competition as CompetitionDraft).competitiveEventDraftId)))
             );
           }

--- a/src/app/shell/details/competition-details/competition-details.component.ts
+++ b/src/app/shell/details/competition-details/competition-details.component.ts
@@ -5,6 +5,9 @@ import { Actions, ofAction, Select, Store } from '@ngxs/store';
 import { WINDOW } from 'ngx-window-token';
 import { EMPTY, filter, Observable } from 'rxjs';
 import { switchMap, take, takeUntil, tap } from 'rxjs/operators';
+import { filter, Observable, of } from 'rxjs';
+import { switchMap, take, tap } from 'rxjs/operators';
+
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { Constants, PaginationConstants } from 'shared/constants/constants';
 import { CompetitionStatus } from 'shared/enum/competition';

--- a/src/app/shell/details/competition-details/competition-details.component.ts
+++ b/src/app/shell/details/competition-details/competition-details.component.ts
@@ -5,26 +5,33 @@ import { Actions, ofAction, Select, Store } from '@ngxs/store';
 import { WINDOW } from 'ngx-window-token';
 import { EMPTY, filter, Observable } from 'rxjs';
 import { switchMap, take, takeUntil, tap } from 'rxjs/operators';
-
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { Constants, PaginationConstants } from 'shared/constants/constants';
-import { CompetitionStatus } from 'shared/enum/competition';
+import { CompetitionDetailsTabTitlesParams, CompetitionStatus } from 'shared/enum/competition';
 import { CompetitionDetailsTabTitlesEnum } from 'shared/enum/enumUA/competition';
 import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
 import { FormOfLearningEnum, RecruitmentStatusEnum } from 'shared/enum/enumUA/workshop';
 import { InfoMenuType } from 'shared/enum/info-menu-type';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Role } from 'shared/enum/role';
-import { Competition } from 'shared/models/competition.model';
+import { Competition, CompetitionDraft } from 'shared/models/competition.model';
+import { ImgPath } from 'shared/models/carousel.model';
 import { Provider, ProviderParameters } from 'shared/models/provider.model';
 import { ImagesService } from 'shared/services/images/images.service';
 import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
 import { AddNavPath } from 'shared/store/navigation.actions';
-import { GetCompetitionById, GetProviderById } from 'shared/store/shared-user.actions';
+import { GetCompetitionById, GetCompetitionDraftById, GetProviderById } from 'shared/store/shared-user.actions';
 import { GetSubDirections } from 'shared/store/meta-data.actions';
 import { MetaDataState } from 'shared/store/meta-data.state';
 import { SubDirection } from 'shared/models/category.model';
-import { ArchiveCompetitionById, OnArchiveCompetitionFail, OnArchiveCompetitionSuccess } from 'shared/store/provider.actions';
+import {
+  ArchiveCompetitionById,
+  CompetitionDraftSendForModeration,
+  GetCompetitionDraftIdByCompetitionId,
+  OnArchiveCompetitionFail,
+  OnArchiveCompetitionSuccess
+} from 'shared/store/provider.actions';
+import { WorkshopType } from 'shared/enum/workshop';
 import { TabParamsComponent } from '../details-tabs/tab-params.component';
 
 @Component({
@@ -33,7 +40,7 @@ import { TabParamsComponent } from '../details-tabs/tab-params.component';
   styleUrls: ['./competition-details.component.scss']
 })
 export class CompetitionDetailsComponent extends TabParamsComponent implements OnInit {
-  @Input() public competition: Competition;
+  @Input() public competition: Competition | CompetitionDraft;
   @Input() public provider: Provider;
   @Input() public role: Role;
   @Input() public isMobileScreen: boolean;
@@ -51,6 +58,7 @@ export class CompetitionDetailsComponent extends TabParamsComponent implements O
 
   public isImageBroken: boolean = false;
   public competitionStatusOpen: boolean;
+  public images: ImgPath[] = [];
   public coverImage: string;
   public competitionSubdirections: string[];
   public providerParameters: ProviderParameters = {
@@ -74,8 +82,8 @@ export class CompetitionDetailsComponent extends TabParamsComponent implements O
 
   public ngOnInit(): void {
     super.ngOnInit();
-    this.providerParameters.excludedCompetitionId = this.competition.id;
-    this.providerParameters.providerId = this.competition?.organizerOfTheEventId;
+    this.providerParameters.excludedCompetitionId = this.competition.id ? this.competition.id : '';
+    this.providerParameters.providerId = this.competition.organizerOfTheEventId;
     this.getCompetitionData();
     this.getSubDirections();
   }
@@ -84,7 +92,7 @@ export class CompetitionDetailsComponent extends TabParamsComponent implements O
     const dialogRef = this.dialog.open(ConfirmationModalWindowComponent, {
       width: Constants.MODAL_SMALL,
       data: {
-        type: type
+        type
       }
     });
 
@@ -92,18 +100,18 @@ export class CompetitionDetailsComponent extends TabParamsComponent implements O
       .afterClosed()
       .pipe(
         filter(Boolean),
+        filter(Boolean),
         switchMap(() => {
-          // TODO: uncomment once provider competition draft PR will be merged
-          // if (type === ModalConfirmationType.draftSet) {
-          //   this.store.dispatch(new CompetitionDraftSendForModeration((this.competition as CompetitionDraft).competitiveEventDraftId));
-          //
-          //   return this.actions$.pipe(
-          //     ofAction(OnCompetitionDraftSendForModerationSuccess),
-          //     take(1),
-          //     takeUntil(this.actions$.pipe(ofAction(OnArchiveCompetitionFail))),
-          //     tap(() => this.store.dispatch(new GetCompetitionDraftById((this.competition as CompetitionDraft).competitiveEventDraftId)))
-          //   );
-          // }
+          if (type === ModalConfirmationType.draftSet) {
+            this.store.dispatch(new CompetitionDraftSendForModeration((this.competition as CompetitionDraft).competitiveEventDraftId));
+
+            return this.actions$.pipe(
+              ofAction(OnCompetitionDraftSendForModerationSuccess),
+              take(1),
+              takeUntil(this.actions$.pipe(ofAction(OnArchiveCompetitionFail))),
+              tap(() => this.store.dispatch(new GetCompetitionDraftById((this.competition as CompetitionDraft).competitiveEventDraftId)))
+            );
+          }
 
           if (type === ModalConfirmationType.archiveCompetition) {
             this.store.dispatch(new ArchiveCompetitionById(this.competition.id));
@@ -119,6 +127,15 @@ export class CompetitionDetailsComponent extends TabParamsComponent implements O
         })
       )
       .subscribe();
+  }
+
+  public onEdit(): void {
+    const competitionId = this.route.snapshot.paramMap.get('id');
+    if (this.route.snapshot.paramMap.get('entity') === WorkshopType.CompetitionDraft) {
+      this.router.navigate(['/create/competition/draft', competitionId]);
+    } else {
+      this.store.dispatch(new GetCompetitionDraftIdByCompetitionId(competitionId));
+    }
   }
 
   public onImageError(): void {

--- a/src/app/shell/details/competition-details/competition-details.component.ts
+++ b/src/app/shell/details/competition-details/competition-details.component.ts
@@ -5,8 +5,6 @@ import { Actions, ofAction, Select, Store } from '@ngxs/store';
 import { WINDOW } from 'ngx-window-token';
 import { EMPTY, filter, Observable } from 'rxjs';
 import { switchMap, take, takeUntil, tap } from 'rxjs/operators';
-import { filter, Observable, of } from 'rxjs';
-import { switchMap, take, tap } from 'rxjs/operators';
 
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { Constants, PaginationConstants } from 'shared/constants/constants';
@@ -32,9 +30,10 @@ import {
   CompetitionDraftSendForModeration,
   GetCompetitionDraftIdByCompetitionId,
   OnArchiveCompetitionFail,
-  OnArchiveCompetitionSuccess
+  OnArchiveCompetitionSuccess,
+  OnDraftSendForModerationSuccess
 } from 'shared/store/provider.actions';
-import { WorkshopType } from 'shared/enum/workshop';
+import { WorkshopDraftStatus, WorkshopType } from 'shared/enum/workshop';
 import { TabParamsComponent } from '../details-tabs/tab-params.component';
 
 @Component({
@@ -58,6 +57,7 @@ export class CompetitionDetailsComponent extends TabParamsComponent implements O
   public readonly FormOfLearningEnum = FormOfLearningEnum;
   public readonly CompetitionDetailsTabTitlesEnum = CompetitionDetailsTabTitlesEnum;
   public readonly InfoMenuType = InfoMenuType;
+  public readonly WorkshopDraftStatus = WorkshopDraftStatus;
 
   public isImageBroken: boolean = false;
   public competitionStatusOpen: boolean;
@@ -108,7 +108,7 @@ export class CompetitionDetailsComponent extends TabParamsComponent implements O
             this.store.dispatch(new CompetitionDraftSendForModeration((this.competition as CompetitionDraft).competitiveEventDraftId));
 
             return this.actions$.pipe(
-              ofAction(OnCompetitionDraftSendForModerationSuccess),
+              ofAction(OnDraftSendForModerationSuccess),
               take(1),
               takeUntil(this.actions$.pipe(ofAction(OnArchiveCompetitionFail))),
               tap(() => this.store.dispatch(new GetCompetitionDraftById((this.competition as CompetitionDraft).competitiveEventDraftId)))

--- a/src/app/shell/details/details-tabs/achievements/achievements.component.ts
+++ b/src/app/shell/details/details-tabs/achievements/achievements.component.ts
@@ -60,7 +60,7 @@ export class AchievementsComponent implements OnInit, OnDestroy {
   public ngOnInit(): void {
     const provider = this.store.selectSnapshot<Provider>(RegistrationState.provider);
     this.isAllowedEdit = this.workshop.providerId === provider?.id;
-    this.achievementParameters.workshopId = Util.containsWorkshopDetails(this.workshop)
+    this.achievementParameters.workshopId = Util.containsWorkshopOrCompetitionDetails(this.workshop)
       ? this.workshop.workshopDetails.id
       : this.workshop.id;
     this.store.dispatch(new GetAchievementsType());

--- a/src/app/shell/details/details-tabs/reviews/reviews.component.ts
+++ b/src/app/shell/details/details-tabs/reviews/reviews.component.ts
@@ -77,7 +77,9 @@ export class ReviewsComponent implements OnInit, OnDestroy {
   ) {}
 
   public ngOnInit(): void {
-    this.rateParameters.entityId = Util.containsWorkshopDetails(this.workshop) ? this.workshop.workshopDetails.id : this.workshop.id;
+    this.rateParameters.entityId = Util.containsWorkshopOrCompetitionDetails(this.workshop)
+      ? this.workshop.workshopDetails.id
+      : this.workshop.id;
     this.getRates();
 
     this.getParentData();

--- a/src/app/shell/details/details.component.scss
+++ b/src/app/shell/details/details.component.scss
@@ -18,5 +18,6 @@
 }
 
 .workshop-page-wrap {
+  width: 100%;
   overflow: hidden;
 }

--- a/src/app/shell/details/details.component.ts
+++ b/src/app/shell/details/details.component.ts
@@ -103,7 +103,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
         this.competition = Util.containsWorkshopOrCompetitionDetails(competition)
           ? {
               draftStatus: competition.draftStatus,
-              rejectionMessage: competition.draftStatus,
+              rejectionMessage: competition.rejectionMessage,
               competitiveEventDraftId: competition.competitiveEventDraftId,
               ...competition.competitiveEventDetails
             }
@@ -113,7 +113,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * This method get Workshop or Provider by id;
+   * This method gets Entity by id;
    */
   private getEntity(id: string): void {
     switch (this.workshopType) {

--- a/src/app/shell/details/details.component.ts
+++ b/src/app/shell/details/details.component.ts
@@ -90,7 +90,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
       .subscribe(([isMobileScreen, role, workshop, provider, competition]) => {
         this.isMobileScreen = isMobileScreen;
         this.role = role;
-        this.workshop = Util.containsWorkshopDetails(workshop)
+        this.workshop = Util.containsWorkshopOrCompetitionDetails(workshop)
           ? {
               draftStatus: workshop.draftStatus,
               rejectionMessage: workshop.rejectionMessage,

--- a/src/app/shell/details/details.component.ts
+++ b/src/app/shell/details/details.component.ts
@@ -7,7 +7,7 @@ import { Select, Store } from '@ngxs/store';
 import { WINDOW } from 'ngx-window-token';
 
 import { Provider } from 'shared/models/provider.model';
-import { Competition } from 'shared/models/competition.model';
+import { Competition, CompetitionDraft } from 'shared/models/competition.model';
 import { Role } from 'shared/enum/role';
 import { Workshop, WorkshopDraft } from 'shared/models/workshop.model';
 import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
@@ -16,6 +16,7 @@ import { DeleteNavPath } from 'shared/store/navigation.actions';
 import { RegistrationState } from 'shared/store/registration.state';
 import {
   GetCompetitionById,
+  GetCompetitionDraftById,
   GetProviderById,
   GetWorkshopById,
   GetWorkshopDraftById,
@@ -42,14 +43,14 @@ export class DetailsComponent implements OnInit, OnDestroy {
   @Select(SharedUserState.selectedProvider)
   private provider$: Observable<Provider>;
   @Select(SharedUserState.selectedCompetition)
-  private competition$: Observable<Competition>;
+  private competition$: Observable<Competition | CompetitionDraft>;
   @Select(RegistrationState.role)
   private role$: Observable<Role>;
 
   public isMobileScreen: boolean;
   public workshop: Workshop | WorkshopDraft;
   public provider: Provider;
-  public competition: Competition;
+  public competition: Competition | CompetitionDraft;
   public role: Role;
 
   public displayActionCard: boolean;
@@ -99,7 +100,14 @@ export class DetailsComponent implements OnInit, OnDestroy {
             }
           : workshop;
         this.provider = provider;
-        this.competition = competition;
+        this.competition = Util.containsWorkshopOrCompetitionDetails(competition)
+          ? {
+              draftStatus: competition.draftStatus,
+              rejectionMessage: competition.draftStatus,
+              competitiveEventDraftId: competition.competitiveEventDraftId,
+              ...competition.competitiveEventDetails
+            }
+          : competition;
         this.displayActionCard = this.role === Role.parent || this.role === Role.unauthorized;
       });
   }
@@ -112,11 +120,14 @@ export class DetailsComponent implements OnInit, OnDestroy {
       case WorkshopType.Workshop:
         this.store.dispatch(new GetWorkshopById(id));
         break;
-      case WorkshopType.Draft:
+      case WorkshopType.WorkshopDraft:
         this.store.dispatch(new GetWorkshopDraftById(id));
         break;
       case WorkshopType.Competition:
         this.store.dispatch(new GetCompetitionById(id));
+        break;
+      case WorkshopType.CompetitionDraft:
+        this.store.dispatch(new GetCompetitionDraftById(id));
         break;
       default:
         this.store.dispatch(new GetProviderById(id));

--- a/src/app/shell/details/workshop-details/workshop-details.component.scss
+++ b/src/app/shell/details/workshop-details/workshop-details.component.scss
@@ -2,6 +2,7 @@
 @use 'details';
 @use 'workshop-status';
 @use 'buttons';
+@use 'drafts';
 
 .workshop-title {
   margin-bottom: 0;
@@ -9,28 +10,6 @@
 
 .icon {
   min-width: 24px;
-}
-
-.btn-cancel {
-  background-color: transparent;
-  border: 1px solid var(--specific-text-color) !important;
-  color: var(--specific-text-color) !important;
-}
-
-.btn-publish {
-  background-color: var(--specific-bg-button) !important;
-  color: var(--light-text-button) !important;
-}
-
-.error-message {
-  color: red;
-  height: 40px;
-  width: 40px;
-  font-size: 40px;
-
-  &:hover {
-    color: darkred;
-  }
 }
 
 .chip {
@@ -41,30 +20,6 @@
 
 .title {
   margin-right: 16px;
-}
-
-.reject {
-  &-block {
-    height: 34px;
-    background-color: transparent;
-    border-radius: 20px;
-    padding: 0 30px;
-    transition:
-      background-color 0.3s ease,
-      color 0.3s ease;
-
-    &-moderator-message {
-      font-family: Innerspace, sans-serif;
-      font-weight: bold;
-      font-size: 13px;
-      color: var(--specific-light-text-color);
-      user-select: none;
-    }
-  }
-
-  &-block:hover {
-    background-color: #ece8e8;
-  }
 }
 
 .details-link {

--- a/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
@@ -160,13 +160,13 @@ describe('WorkshopDetailsComponent', () => {
           return '123';
         }
         if (key === 'entity') {
-          return 'draft';
+          return 'workshop-draft';
         }
       });
 
       component.onEdit();
 
-      expect(mockRouter.navigate).toHaveBeenCalledWith(['/create/draft', '123']);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/create/workshop/draft', '123']);
     });
 
     it('should dispatch GetWorkshopDraftIdByWorkshopId if workshop', () => {

--- a/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.spec.ts
@@ -19,7 +19,7 @@ import { Workshop, WorkshopDraft } from 'shared/models/workshop.model';
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Constants } from 'shared/constants/constants';
-import { ArchiveWorkshopById, DraftSendForModeration, GetWorkshopDraftIdByWorkshopId } from 'shared/store/provider.actions';
+import { ArchiveWorkshopById, GetWorkshopDraftIdByWorkshopId, WorkshopDraftSendForModeration } from 'shared/store/provider.actions';
 import { ImagesService } from 'shared/services/images/images.service';
 import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
 import { WorkshopDetailsComponent } from './workshop-details.component';
@@ -124,7 +124,7 @@ describe('WorkshopDetailsComponent', () => {
       };
       component.onActionButtonClick(ModalConfirmationType.draftSet);
       expect(matDialogSpy).toHaveBeenCalledTimes(1);
-      expect(mockStore.dispatch).toHaveBeenCalledWith(new DraftSendForModeration('123'));
+      expect(mockStore.dispatch).toHaveBeenCalledWith(new WorkshopDraftSendForModeration('123'));
     });
 
     it('should open confirmation dialog and dispatch ArchiveWorkshop on confirm', () => {

--- a/src/app/shell/details/workshop-details/workshop-details.component.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.ts
@@ -19,13 +19,13 @@ import { NavigationBarService } from 'shared/services/navigation-bar/navigation-
 import { AddNavPath } from 'shared/store/navigation.actions';
 import {
   ArchiveWorkshopById,
-  WorkshopDraftSendForModeration,
   GetWorkshopDraftIdByWorkshopId,
   OnArchiveWorkshopFail,
   OnArchiveWorkshopSuccess,
   OnDraftSendForModerationFail,
   OnDraftSendForModerationSuccess,
-  ResetAchievements
+  ResetAchievements,
+  WorkshopDraftSendForModeration
 } from 'shared/store/provider.actions';
 import { GetProviderById, GetWorkshopById, GetWorkshopDraftById } from 'shared/store/shared-user.actions';
 import { InfoMenuType } from 'shared/enum/info-menu-type';
@@ -228,4 +228,3 @@ export class WorkshopDetailsComponent extends TabParamsComponent implements OnIn
     ].filter((tab) => tab.visible);
   }
 }
-

--- a/src/app/shell/details/workshop-details/workshop-details.component.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.ts
@@ -19,7 +19,7 @@ import { NavigationBarService } from 'shared/services/navigation-bar/navigation-
 import { AddNavPath } from 'shared/store/navigation.actions';
 import {
   ArchiveWorkshopById,
-  DraftSendForModeration,
+  WorkshopDraftSendForModeration,
   GetWorkshopDraftIdByWorkshopId,
   OnArchiveWorkshopFail,
   OnArchiveWorkshopSuccess,
@@ -96,7 +96,7 @@ export class WorkshopDetailsComponent extends TabParamsComponent implements OnIn
   public ngOnInit(): void {
     super.ngOnInit();
     this.providerParameters.excludedWorkshopId = this.workshop.id ? this.workshop.id : '';
-    this.providerParameters.providerId = Util.containsWorkshopDetails(this.workshop)
+    this.providerParameters.providerId = Util.containsWorkshopOrCompetitionDetails(this.workshop)
       ? this.workshop.workshopDetails.providerId
       : this.workshop.providerId;
     this.getWorkshopData();
@@ -130,7 +130,7 @@ export class WorkshopDetailsComponent extends TabParamsComponent implements OnIn
         filter(Boolean),
         switchMap(() => {
           if (type === ModalConfirmationType.draftSet) {
-            this.store.dispatch(new DraftSendForModeration((this.workshop as WorkshopDraft).workshopDraftId));
+            this.store.dispatch(new WorkshopDraftSendForModeration((this.workshop as WorkshopDraft).workshopDraftId));
 
             return this.actions$.pipe(
               ofAction(OnDraftSendForModerationSuccess),
@@ -163,6 +163,26 @@ export class WorkshopDetailsComponent extends TabParamsComponent implements OnIn
     } else {
       this.store.dispatch(new GetWorkshopDraftIdByWorkshopId(workshopId));
     }
+  }
+
+  private getWorkshopData(): void {
+    this.coverImage = this.imagesService.getCoverImage(this.workshop);
+    this.store.dispatch([
+      new GetProviderById(
+        Util.containsWorkshopOrCompetitionDetails(this.workshop) ? this.workshop.workshopDetails.providerId : this.workshop.providerId
+      ),
+      new AddNavPath(
+        this.navigationBarService.createNavPaths(
+          {
+            name: NavBarName.WorkshopResult,
+            path: '/result',
+            isActive: false,
+            disable: false
+          },
+          { name: this.workshop.title, isActive: false, disable: true }
+        )
+      )
+    ]);
   }
 
   protected initTabs(): void {
@@ -209,24 +229,5 @@ export class WorkshopDetailsComponent extends TabParamsComponent implements OnIn
       }
     ].filter((tab) => tab.visible);
   }
-
-  private getWorkshopData(): void {
-    this.coverImage = this.imagesService.getCoverImage(this.workshop);
-    this.store.dispatch([
-      new GetProviderById(
-        Util.containsWorkshopDetails(this.workshop) ? this.workshop.workshopDetails.providerId : this.workshop.providerId
-      ),
-      new AddNavPath(
-        this.navigationBarService.createNavPaths(
-          {
-            name: NavBarName.WorkshopResult,
-            path: '/result',
-            isActive: false,
-            disable: false
-          },
-          { name: this.workshop.title, isActive: false, disable: true }
-        )
-      )
-    ]);
-  }
 }
+

--- a/src/app/shell/details/workshop-details/workshop-details.component.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.ts
@@ -163,26 +163,6 @@ export class WorkshopDetailsComponent extends TabParamsComponent implements OnIn
     }
   }
 
-  private getWorkshopData(): void {
-    this.coverImage = this.imagesService.getCoverImage(this.workshop);
-    this.store.dispatch([
-      new GetProviderById(
-        Util.containsWorkshopOrCompetitionDetails(this.workshop) ? this.workshop.workshopDetails.providerId : this.workshop.providerId
-      ),
-      new AddNavPath(
-        this.navigationBarService.createNavPaths(
-          {
-            name: NavBarName.WorkshopResult,
-            path: '/result',
-            isActive: false,
-            disable: false
-          },
-          { name: this.workshop.title, isActive: false, disable: true }
-        )
-      )
-    ]);
-  }
-
   protected initTabs(): void {
     this.tabs = [
       {
@@ -226,5 +206,25 @@ export class WorkshopDetailsComponent extends TabParamsComponent implements OnIn
         visible: true
       }
     ].filter((tab) => tab.visible);
+  }
+
+  private getWorkshopData(): void {
+    this.coverImage = this.imagesService.getCoverImage(this.workshop);
+    this.store.dispatch([
+      new GetProviderById(
+        Util.containsWorkshopOrCompetitionDetails(this.workshop) ? this.workshop.workshopDetails.providerId : this.workshop.providerId
+      ),
+      new AddNavPath(
+        this.navigationBarService.createNavPaths(
+          {
+            name: NavBarName.WorkshopResult,
+            path: '/result',
+            isActive: false,
+            disable: false
+          },
+          { name: this.workshop.title, isActive: false, disable: true }
+        )
+      )
+    ]);
   }
 }

--- a/src/app/shell/details/workshop-details/workshop-details.component.ts
+++ b/src/app/shell/details/workshop-details/workshop-details.component.ts
@@ -96,9 +96,7 @@ export class WorkshopDetailsComponent extends TabParamsComponent implements OnIn
   public ngOnInit(): void {
     super.ngOnInit();
     this.providerParameters.excludedWorkshopId = this.workshop.id ? this.workshop.id : '';
-    this.providerParameters.providerId = Util.containsWorkshopOrCompetitionDetails(this.workshop)
-      ? this.workshop.workshopDetails.providerId
-      : this.workshop.providerId;
+    this.providerParameters.providerId = this.workshop.providerId;
     this.getWorkshopData();
 
     this.workshopStatusOpen = this.workshop.status === this.workshopStatus.Open;
@@ -158,8 +156,8 @@ export class WorkshopDetailsComponent extends TabParamsComponent implements OnIn
 
   public onEdit(): void {
     const workshopId = this.route.snapshot.paramMap.get('id');
-    if (this.route.snapshot.paramMap.get('entity') === WorkshopType.Draft) {
-      this.router.navigate(['/create/draft', workshopId]);
+    if (this.route.snapshot.paramMap.get('entity') === WorkshopType.WorkshopDraft) {
+      this.router.navigate(['/create/workshop/draft', workshopId]);
     } else {
       this.store.dispatch(new GetWorkshopDraftIdByWorkshopId(workshopId));
     }

--- a/src/app/shell/main/main.component.spec.ts
+++ b/src/app/shell/main/main.component.spec.ts
@@ -103,7 +103,7 @@ describe('MainComponent', () => {
     it('should continue draft and navigate to create/unfinished', () => {
       jest.spyOn(router, 'navigate');
       component.continueUnfinishedCreation();
-      expect(router.navigate).toHaveBeenCalledWith(['/create', 'unfinished']);
+      expect(router.navigate).toHaveBeenCalledWith(['/create/workshop', 'unfinished']);
     });
 
     it('should cancel draft and dispatch OnDeleteDraftWorkshop', () => {

--- a/src/app/shell/main/main.component.ts
+++ b/src/app/shell/main/main.component.ts
@@ -102,7 +102,7 @@ export class MainComponent implements OnInit, OnDestroy {
   }
 
   public continueUnfinishedCreation(): void {
-    this.router.navigate(['/create', 'unfinished']);
+    this.router.navigate(['/create/workshop', 'unfinished']);
   }
 
   public cancelUnfinishedCreation(): void {

--- a/src/app/shell/personal-cabinet/personal-cabinet.component.html
+++ b/src/app/shell/personal-cabinet/personal-cabinet.component.html
@@ -18,13 +18,13 @@
       </a>
     </ng-container>
     <ng-container *ngIf="isRoleProvider(userRole)">
-      <a mat-tab-link [routerLinkActive]="['active']" [routerLink]="'./provider/drafts'">
-        {{ 'ENUM.NAV_BAR_NAME.MY_DRAFTS' | translate | uppercase }}
+      <a mat-tab-link [routerLinkActive]="['active']" [routerLink]="'./provider/competitions'">
+        {{ 'ENUM.NAV_BAR_NAME.MY_COMPETITIONS' | translate | uppercase }}
       </a>
     </ng-container>
     <ng-container *ngIf="isRoleProvider(userRole)">
-      <a mat-tab-link [routerLinkActive]="['active']" [routerLink]="'./provider/competitions'">
-        {{ 'ENUM.NAV_BAR_NAME.MY_COMPETITIONS' | translate | uppercase }}
+      <a mat-tab-link [routerLinkActive]="['active']" [routerLink]="'./provider/drafts'">
+        {{ 'ENUM.NAV_BAR_NAME.MY_DRAFTS' | translate | uppercase }}
       </a>
     </ng-container>
     <ng-container *ngIf="!isRoleAdmin(userRole)">
@@ -33,7 +33,7 @@
           {{ 'ENUM.NAV_BAR_NAME.APPLICATIONS' | translate | uppercase }}
         </a>
       </span>
-    </ng-container>  
+    </ng-container>
     <ng-container *ngIf="!isRoleAdmin(userRole) && (featuresList$ | async)?.messagingFeature">
       <span [matBadge]="(unreadMessagesCount$ | async) || null" matBadgePosition="after">
         <a mat-tab-link [routerLinkActive]="['active']" [routerLink]="'./messages'">

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.spec.ts
@@ -69,7 +69,7 @@ describe('CreateCompetitionDescriptionFormComponent', () => {
           useValue: {
             snapshot: {
               paramMap: {
-                get: (key: string) => '123'
+                has: () => true
               }
             }
           }

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.spec.ts
@@ -3,6 +3,7 @@ import { Component, forwardRef, Input } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormControl, FormGroup, FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { NgxsModule, Store } from '@ngxs/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
@@ -62,6 +63,16 @@ describe('CreateCompetitionDescriptionFormComponent', () => {
           // eslint-disable-next-line @angular-eslint/no-forward-ref
           useExisting: forwardRef(() => ImageFormControlComponent),
           multi: true
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: (key: string) => '123'
+              }
+            }
+          }
         },
         Store
       ]

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
@@ -332,25 +332,27 @@ export class CreateCompetitionDescriptionFormComponent implements OnInit, OnDest
   }
 
   private listenToChanges(): void {
-    merge(
-      ...[
-        'imageFiles',
-        'description',
-        'disabilityOptionsDesc',
-        'additionalDescription',
-        'descriptionOfTheEnrollmentProcedure',
-        'competitiveEventDescriptionItems',
-        'benefitsOptionsDesc'
-      ].map(
-        (controlName) =>
-          this.DescriptionFormGroup.get(controlName)?.valueChanges.pipe(
-            throttleTime(5000, undefined, {
-              leading: true,
-              trailing: false
-            })
-          ) ?? of()
-      )
-    )
+    const fieldsToListen = [
+      'imageFiles',
+      'description',
+      'disabilityOptionsDesc',
+      'additionalDescription',
+      'descriptionOfTheEnrollmentProcedure',
+      'competitiveEventDescriptionItems',
+      'benefitsOptionsDesc'
+    ];
+
+    const mappedFields = fieldsToListen.map(
+      (controlName) =>
+        this.DescriptionFormGroup.get(controlName)?.valueChanges.pipe(
+          throttleTime(5000, undefined, {
+            leading: true,
+            trailing: false
+          })
+        ) ?? of()
+    );
+
+    merge(...mappedFields)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.store.dispatch(

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
@@ -98,10 +98,6 @@ export class CreateCompetitionDescriptionFormComponent implements OnInit, OnDest
 
     this.initializeFormControls();
     this.priceControlListener();
-
-    if (this.route.snapshot.paramMap.get('entity') === 'competition') {
-      this.listenToChanges();
-    }
   }
 
   public ngOnDestroy(): void {
@@ -202,6 +198,10 @@ export class CreateCompetitionDescriptionFormComponent implements OnInit, OnDest
         const value = subDirections.filter((subDirection) => this.competition.subDirectionIds.includes(subDirection.id));
         asyncScheduler.schedule(() => this.subDirectionControl.patchValue(value, { emitEvent: false }));
       });
+    }
+
+    if (!this.route.snapshot.paramMap.get('entity')) {
+      this.listenToChanges();
     }
   }
 

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { AbstractControl, FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Select, Store } from '@ngxs/store';
-import { asyncScheduler, merge, Observable, of, Subject, throttleTime } from 'rxjs';
+import { asyncScheduler, first, merge, Observable, of, Subject, throttleTime } from 'rxjs';
 import { distinctUntilChanged, filter, map, take, takeUntil } from 'rxjs/operators';
 
 import { MUST_CONTAIN_LETTERS } from 'shared/constants/regex-constants';
@@ -152,6 +152,16 @@ export class CreateCompetitionDescriptionFormComponent implements OnInit, OnDest
    */
   public activateEditMode(): void {
     this.DescriptionFormGroup.patchValue(this.competition, { emitEvent: false });
+
+    if (this.competition.imageIds) {
+      this.DescriptionFormGroup.get('imageFiles').removeValidators(Validators.required);
+      this.DescriptionFormGroup.get('imageIds')
+        .valueChanges.pipe(
+          filter((value) => !value),
+          first()
+        )
+        .subscribe(() => this.DescriptionFormGroup.get('imageFiles').addValidators(Validators.required));
+    }
 
     if (this.competition.directionSubDirectionIds?.length) {
       this.directionControl.patchValue(this.competition.directionSubDirectionIds[0].directionId);

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
@@ -200,7 +200,7 @@ export class CreateCompetitionDescriptionFormComponent implements OnInit, OnDest
       });
     }
 
-    if (!this.route.snapshot.paramMap.get('entity')) {
+    if (!this.route.snapshot.paramMap.has('entity')) {
       this.listenToChanges();
     }
   }

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { AbstractControl, FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Select, Store } from '@ngxs/store';
-import { asyncScheduler, Observable, Subject } from 'rxjs';
+import { asyncScheduler, merge, Observable, of, Subject, throttleTime } from 'rxjs';
 import { distinctUntilChanged, filter, map, take, takeUntil } from 'rxjs/operators';
 
 import { MUST_CONTAIN_LETTERS } from 'shared/constants/regex-constants';
@@ -18,6 +18,9 @@ import { CompetitionCoverage } from 'shared/enum/competition';
 import { CopperConfig } from 'shared/configs/copper.config';
 import { maxArrayLength, minArrayLength } from 'shared/validators/array-length/array-length-validator';
 import { Direction, SubDirection } from 'shared/models/category.model';
+import { ShowMessageBar } from 'shared/store/app.actions';
+import { ActivatedRoute } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-create-competition-description-form',
@@ -57,7 +60,9 @@ export class CreateCompetitionDescriptionFormComponent implements OnInit, OnDest
 
   constructor(
     private readonly formBuilder: FormBuilder,
-    private readonly store: Store
+    private readonly store: Store,
+    private readonly route: ActivatedRoute,
+    private readonly translateService: TranslateService
   ) {}
 
   public get directionControl(): FormControl {
@@ -93,6 +98,10 @@ export class CreateCompetitionDescriptionFormComponent implements OnInit, OnDest
 
     this.initializeFormControls();
     this.priceControlListener();
+
+    if (this.route.snapshot.paramMap.get('entity') === 'competition') {
+      this.listenToChanges();
+    }
   }
 
   public ngOnDestroy(): void {
@@ -320,5 +329,36 @@ export class CreateCompetitionDescriptionFormComponent implements OnInit, OnDest
       this.subDirectionControl.setErrors(null);
       this.store.dispatch(new GetSubDirections(directionId));
     });
+  }
+
+  private listenToChanges(): void {
+    merge(
+      ...[
+        'imageFiles',
+        'description',
+        'disabilityOptionsDesc',
+        'additionalDescription',
+        'descriptionOfTheEnrollmentProcedure',
+        'competitiveEventDescriptionItems',
+        'benefitsOptionsDesc'
+      ].map(
+        (controlName) =>
+          this.DescriptionFormGroup.get(controlName)?.valueChanges.pipe(
+            throttleTime(5000, undefined, {
+              leading: true,
+              trailing: false
+            })
+          ) ?? of()
+      )
+    )
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.store.dispatch(
+          new ShowMessageBar({
+            message: this.translateService.instant('SERVICE_MESSAGES.SNACK_BAR_TEXT.CHANGE_REQUIRES_MODERATION'),
+            type: 'warningYellow'
+          })
+        );
+      });
   }
 }

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { AbstractControl, FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { Select, Store } from '@ngxs/store';
-import { asyncScheduler, first, merge, Observable, of, Subject, throttleTime } from 'rxjs';
+import { asyncScheduler, merge, Observable, of, Subject, throttleTime } from 'rxjs';
 import { distinctUntilChanged, filter, map, take, takeUntil } from 'rxjs/operators';
 
 import { MUST_CONTAIN_LETTERS } from 'shared/constants/regex-constants';
@@ -148,16 +148,6 @@ export class CreateCompetitionDescriptionFormComponent implements OnInit, OnDest
    */
   public activateEditMode(): void {
     this.DescriptionFormGroup.patchValue(this.competition, { emitEvent: false });
-
-    if (this.competition.imageIds) {
-      this.DescriptionFormGroup.get('imageFiles').removeValidators(Validators.required);
-      this.DescriptionFormGroup.get('imageIds')
-        .valueChanges.pipe(
-          filter((value) => !value),
-          first()
-        )
-        .subscribe(() => this.DescriptionFormGroup.get('imageFiles').addValidators(Validators.required));
-    }
 
     if (this.competition.directionSubDirectionIds?.length) {
       this.directionControl.patchValue(this.competition.directionSubDirectionIds[0].directionId);

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.spec.ts
@@ -1,8 +1,9 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NgxsModule, Store } from '@ngxs/store';
-import { ActivatedRoute, Router } from '@angular/router';
 import { FormArray, FormControl, FormGroup } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { NgxsModule, Store } from '@ngxs/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
@@ -11,7 +12,10 @@ import { Provider } from 'shared/models/provider.model';
 import { InstitutionTypes, OwnershipTypes } from 'shared/enum/provider';
 import { LicenseStatuses, ProviderStatuses } from 'shared/enum/statuses';
 import { Institution } from 'shared/models/institution.model';
-import { Address } from 'shared/models/address.model';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { Competition } from 'shared/models/competition.model';
+import { WorkshopType } from 'shared/enum/workshop';
 import { CreateCompetitionComponent } from './create-competition.component';
 
 describe('CreateCompetitionComponent', () => {
@@ -21,7 +25,12 @@ describe('CreateCompetitionComponent', () => {
   let store: Store;
   let navigationBarService: NavigationBarService;
   let activatedRoute: ActivatedRoute;
-  let mockCompetitionId: string;
+
+  const matDialogMock = {
+    open: jest.fn().mockReturnValue({
+      afterClosed: () => of(true)
+    })
+  };
 
   const mockStore = {
     dispatch: jest.fn(),
@@ -31,7 +40,10 @@ describe('CreateCompetitionComponent', () => {
 
   const activatedRouteMock = {
     snapshot: {
-      paramMap: new Map([['id', '1']]) // Assuming an ID is present in the route
+      paramMap: new Map([
+        ['id', '1'],
+        ['entity', WorkshopType.Competition]
+      ])
     }
   };
 
@@ -41,15 +53,6 @@ describe('CreateCompetitionComponent', () => {
 
   const routerMock = {
     navigate: jest.fn()
-  };
-
-  const sampleAddress: Address = {
-    street: '123 Main St',
-    id: 0,
-    buildingNumber: '12',
-    latitude: 13,
-    longitude: 14,
-    catottgId: 2
   };
 
   const sampleInstitution: Institution = {
@@ -81,38 +84,34 @@ describe('CreateCompetitionComponent', () => {
   };
 
   const provider: Provider = {
+    id: '123',
     ownership: OwnershipTypes.Common,
     isBlocked: false,
     fullTitle: 'Sample Provider',
     shortTitle: 'SP',
-    email: 'provider@test.com',
     edrpou: '12345678',
-    director: 'John Doe',
-    directorDateOfBirth: '1990-01-01',
-    phoneNumber: '123-456-7890',
-    founder: 'Jane Doe',
     status: ProviderStatuses.Approved,
     licenseStatus: LicenseStatuses.Approved,
     userId: 'user-id',
-    legalAddress: sampleAddress,
     institution: sampleInstitution,
     institutionType: InstitutionTypes.Other,
     providerSectionItems: []
-  };
+  } as Provider;
 
-  mockStore.select.mockReturnValue(of(provider));
+  mockStore.selectSnapshot.mockReturnValue(of(provider));
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [CreateCompetitionComponent],
-      imports: [NgxsModule.forRoot([]), TranslateModule.forRoot()], // Mock any necessary modules
+      imports: [NgxsModule.forRoot([]), TranslateModule.forRoot(), MatDialogModule],
       providers: [
         { provide: Store, useValue: mockStore },
         { provide: Router, useValue: routerMock },
         { provide: ActivatedRoute, useValue: activatedRouteMock },
-        { provide: NavigationBarService, useValue: navigationBarServiceMock }
+        { provide: NavigationBarService, useValue: navigationBarServiceMock },
+        { provide: MatDialog, useValue: matDialogMock }
       ],
-      schemas: [NO_ERRORS_SCHEMA] // Ignore template errors in testing
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
 
     fixture = TestBed.createComponent(CreateCompetitionComponent);
@@ -121,7 +120,6 @@ describe('CreateCompetitionComponent', () => {
     router = TestBed.inject(Router);
     navigationBarService = TestBed.inject(NavigationBarService);
     activatedRoute = TestBed.inject(ActivatedRoute);
-    mockCompetitionId = '1';
 
     component.RequiredFormGroup = new FormGroup({
       title: new FormControl(required.title),
@@ -140,7 +138,12 @@ describe('CreateCompetitionComponent', () => {
       parentCompetitionControl: new FormControl(required.parentCompetition),
       numberOfSeats: new FormControl(required.numberOfSeats)
     });
-    component.DescriptionFormGroup = new FormGroup({});
+    component.DescriptionFormGroup = new FormGroup({
+      subDirectionIds: new FormControl([
+        { id: 1, title: 'sub1' },
+        { id: 2, title: 'sub2' }
+      ])
+    });
     component.JudgeFormArray = new FormArray([]);
     component.ContactsFormArray = new FormArray([]);
   });
@@ -166,9 +169,176 @@ describe('CreateCompetitionComponent', () => {
         ])
       });
 
-      const description = component.createDescription();
+      const description = (component as any).createDescription();
 
       expect(description.subDirectionIds).toEqual([1, 2]);
+    });
+  });
+
+  describe('shouldBeDraft', () => {
+    let anotherCompetition: Competition;
+
+    beforeEach(() => {
+      component.competition = {
+        title: 'Title',
+        shortTitle: 'Short',
+        coverImage: new File([''], 'filename.jpg', { type: 'image/jpeg' }),
+        imageFiles: [new File([''], 'filename1.jpg', { type: 'image/jpeg' }), new File([''], 'filename2.jpg', { type: 'image/jpeg' })],
+        descriptionOfTheEnrollmentProcedure: 'desc',
+        competitiveEventDescriptionItems: [
+          { sectionName: 'hel2', description: 'hel2' },
+          { sectionName: 'hel2', description: 'hel2' }
+        ],
+        additionalDescription: 'addesc',
+        description: 'desc',
+        subDirectionIds: [1, 2],
+        preferentialTermsOfParticipation: 'terms'
+      } as Competition;
+
+      anotherCompetition = {
+        title: 'Title',
+        shortTitle: 'Short',
+        coverImage: new File([''], 'filename.jpg', { type: 'image/jpeg' }),
+        imageFiles: [new File([''], 'filename1.jpg', { type: 'image/jpeg' }), new File([''], 'filename2.jpg', { type: 'image/jpeg' })],
+        descriptionOfTheEnrollmentProcedure: 'desc',
+        competitiveEventDescriptionItems: [
+          { sectionName: 'hel2', description: 'hel2' },
+          { sectionName: 'hel2', description: 'hel2' }
+        ],
+        additionalDescription: 'addesc',
+        description: 'desc',
+        subDirectionIds: [1, 2],
+        preferentialTermsOfParticipation: 'terms'
+      } as Competition;
+
+      jest.clearAllMocks();
+    });
+
+    it('should NOT be draft', () => {
+      expect((component as any).shouldBeDraft(anotherCompetition)).toBe(false);
+    });
+
+    it('should be draft if primitives changed', () => {
+      anotherCompetition.title = 'Another Title';
+
+      expect((component as any).shouldBeDraft(anotherCompetition)).toBe(true);
+    });
+
+    it('should be draft if coverImage changed', () => {
+      anotherCompetition.coverImage = new File([''], 'filename1.jpg', { type: 'image/png' });
+      expect((component as any).shouldBeDraft(anotherCompetition)).toBe(true);
+
+      anotherCompetition.coverImage = null;
+      expect((component as any).shouldBeDraft(anotherCompetition)).toBe(true);
+    });
+
+    it('should be draft if files changed', () => {
+      anotherCompetition.imageFiles = [
+        new File([''], 'filename1.jpg', { type: 'image/jpeg' }),
+        new File([''], 'filename3.jpg', { type: 'image/jpeg' })
+      ];
+      expect((component as any).shouldBeDraft(anotherCompetition)).toBe(true);
+
+      anotherCompetition.imageFiles = [
+        new File([''], 'filename1.jpg', { type: 'image/jpeg' }),
+        new File([''], 'filename2.jpg', { type: 'image/jpeg' }),
+        new File([''], 'filename3.jpg', { type: 'image/jpeg' })
+      ];
+      expect((component as any).shouldBeDraft(anotherCompetition)).toBe(true);
+    });
+
+    it('should be draft if description changed', () => {
+      anotherCompetition.description = 'test';
+      expect((component as any).shouldBeDraft(anotherCompetition)).toBe(true);
+    });
+
+    it('should be draft if additional description changed', () => {
+      anotherCompetition.additionalDescription = 'test';
+      expect((component as any).shouldBeDraft(anotherCompetition)).toBe(true);
+    });
+
+    describe('should be draft if competitiveEventDescriptionItems changed', () => {
+      afterEach(() => {
+        expect((component as any).shouldBeDraft(anotherCompetition)).toBe(true);
+      });
+
+      it('length changed', () => {
+        anotherCompetition.competitiveEventDescriptionItems = [
+          { sectionName: 'hel2', description: 'hel2' },
+          { sectionName: 'hel2', description: 'hel2' },
+          { sectionName: 'hel3', description: 'hel3' }
+        ];
+      });
+
+      it('sectionName changed', () => {
+        anotherCompetition.competitiveEventDescriptionItems = [
+          { sectionName: 'hel1', description: 'hel2' },
+          { sectionName: 'hel2', description: 'hel2' }
+        ];
+      });
+
+      it('description changed', () => {
+        anotherCompetition.competitiveEventDescriptionItems = [
+          { sectionName: 'hel2', description: 'hel3' },
+          { sectionName: 'hel2', description: 'hel2' }
+        ];
+      });
+
+      it('structure changed', () => {
+        anotherCompetition.competitiveEventDescriptionItems = [
+          { sectionName: 'hel2', description: 'hel3', competitiveEventId: '123' },
+          { sectionName: 'hel2', description: 'hel2' }
+        ];
+      });
+
+      it('partially null', () => {
+        anotherCompetition.competitiveEventDescriptionItems = [
+          { sectionName: null, description: 'hel3' },
+          { sectionName: 'hel2', description: 'hel2' }
+        ];
+      });
+
+      it('partially undefined', () => {
+        anotherCompetition.competitiveEventDescriptionItems = [
+          { sectionName: undefined, description: 'hel3' },
+          { sectionName: 'hel2', description: 'hel2' }
+        ];
+      });
+
+      it('fully null', () => {
+        anotherCompetition.competitiveEventDescriptionItems = [null, { sectionName: 'hel2', description: 'hel2' }];
+      });
+
+      it('fully undefined', () => {
+        anotherCompetition.competitiveEventDescriptionItems = [undefined, null];
+      });
+    });
+
+    it('should be draft matDialog', () => {
+      jest.spyOn(component as any, 'shouldBeDraft').mockReturnValue(true);
+
+      component.editMode = true;
+
+      component.onSubmit();
+
+      expect(matDialogMock.open).toHaveBeenCalledWith(
+        ConfirmationModalWindowComponent,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: ModalConfirmationType.draftEditSet
+          })
+        })
+      );
+    });
+
+    it('should NOT be draft matDialog', () => {
+      jest.spyOn(component as any, 'shouldBeDraft').mockReturnValue(false);
+
+      component.editMode = true;
+
+      component.onSubmit();
+
+      expect(matDialogMock.open).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
@@ -119,7 +119,7 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   public setEditMode(): void {
     const competitionId = this.route.snapshot.paramMap.get('param');
-    if (!this.route.snapshot.paramMap.get('entity')) {
+    if (!this.route.snapshot.paramMap.has('entity')) {
       this.store.dispatch(new GetCompetitionById(competitionId));
     } else {
       this.store.dispatch(new GetCompetitionDraftById(competitionId));

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
@@ -14,7 +14,12 @@ import { Provider } from 'shared/models/provider.model';
 import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
 import { AddNavPath } from 'shared/store/navigation.actions';
 import { RegistrationState } from 'shared/store/registration.state';
-import { GetCompetitionById, ResetCompetition } from 'shared/store/shared-user.actions';
+import {
+  GetCompetitionById, GetCompetitionDraftById,
+  GetWorkshopById,
+  GetWorkshopDraftById,
+  ResetCompetition
+} from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 import { Judge } from 'shared/models/judge.model';
 import { Constants } from 'shared/constants/constants';
@@ -123,9 +128,20 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   public setEditMode(): void {
     const competitionId = this.route.snapshot.paramMap.get('param');
-    this.store.dispatch(new GetCompetitionById(competitionId));
+    switch (this.route.snapshot.paramMap.get('entity')) {
+      case WorkshopType.Competition:
+        this.store.dispatch(new GetCompetitionById(competitionId));
+        break;
+      case WorkshopType.Draft:
+        this.store.dispatch(new GetCompetitionDraftById(competitionId));
+        break;
+      default:
+        this.editMode = false;
+        return;
+    }
     this.selectedCompetition$.pipe(filter(Boolean), takeUntil(this.destroy$)).subscribe((competition: Competition | CompetitionDraft) => {
       this.competition = Util.containsWorkshopOrCompetitionDetails(competition) ? competition.competitiveEventDetails : competition;
+      console.log(this.competition)
     });
   }
 

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
@@ -2,6 +2,7 @@ import { AfterContentChecked, ChangeDetectorRef, Component, OnDestroy, OnInit } 
 import { FormArray, FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
+import { MatDialog } from '@angular/material/dialog';
 import { Select, Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
@@ -17,12 +18,14 @@ import { GetCompetitionById, ResetCompetition } from 'shared/store/shared-user.a
 import { SharedUserState } from 'shared/store/shared-user.state';
 import { Judge } from 'shared/models/judge.model';
 import { Constants } from 'shared/constants/constants';
-import { CreateCompetition, UpdateCompetition } from 'shared/store/provider.actions';
+import { CreateCompetition, UpdateCompetition, UpdateCompetitionDraft } from 'shared/store/provider.actions';
 import { Contacts } from 'shared/models/workshop.model';
 import { SubDirection } from 'shared/models/category.model';
-import { CreateFormComponent } from '../../shared-cabinet/create-form/create-form.component';
 import { WorkshopType } from 'shared/enum/workshop';
 import { Util } from 'shared/utils/utils';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { CreateFormComponent } from '../../shared-cabinet/create-form/create-form.component';
 
 @Component({
   selector: 'app-create-competition',
@@ -59,7 +62,8 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
     protected route: ActivatedRoute,
     protected navigationBarService: NavigationBarService,
     private changeDetector: ChangeDetectorRef,
-    private router: Router
+    private router: Router,
+    private dialog: MatDialog
   ) {
     super(store, route, navigationBarService);
   }
@@ -140,7 +144,27 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
       if (this.editMode) {
         competition = new Competition(requiredInfo, descInfo, contacts, judges, provider, this.competition.id);
-        this.store.dispatch(new UpdateCompetition(competition));
+        if (this.route.snapshot.paramMap.get('entity') === WorkshopType.Competition) {
+          if (this.shouldBeDraft(competition)) {
+            this.dialog
+              .open(ConfirmationModalWindowComponent, {
+                width: Constants.MODAL_SMALL,
+                data: {
+                  type: ModalConfirmationType.draftEditSet
+                }
+              })
+              .afterClosed()
+              .pipe(filter(Boolean))
+              .subscribe(() => {
+                this.store.dispatch(new UpdateCompetition(competition));
+              });
+          } else {
+            this.store.dispatch(new UpdateCompetition(competition));
+          }
+        } else {
+          const draftId = this.route.snapshot.paramMap.get('param');
+          this.store.dispatch(new UpdateCompetitionDraft(draftId, competition));
+        }
       } else {
         competition = new Competition(requiredInfo, descInfo, contacts, judges, provider);
         this.store.dispatch(new CreateCompetition(competition));
@@ -226,5 +250,31 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   private createContacts(): Contacts[] {
     return this.ContactsFormArray?.controls.map((form: FormGroup) => new Contacts(form.value)) || [];
+  }
+
+  private shouldBeDraft(competition: Competition): boolean {
+    const fieldsToCheck = [
+      'title',
+      'shortTitle',
+      'coverImage',
+      'imageFiles',
+      'description',
+      'disabilityOptionsDesc',
+      'additionalDescription',
+      'descriptionOfTheEnrollmentProcedure',
+      'competitiveEventDescriptionItems',
+      'benefitsOptionsDesc'
+    ];
+
+    return fieldsToCheck.some((fieldName) => {
+      if (typeof competition[fieldName] === 'object' && typeof this.competition[fieldName] === 'object') {
+        return !Util.deepEqual(competition[fieldName], this.competition[fieldName]);
+      }
+
+      return (
+        competition[fieldName] !== this.competition[fieldName] &&
+        (!Util.isEmpty(competition[fieldName]) || !Util.isEmpty(this.competition[fieldName]))
+      );
+    });
   }
 }

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
@@ -8,7 +8,7 @@ import { filter, takeUntil } from 'rxjs/operators';
 
 import { NavBarName, PersonalCabinetTitle } from 'shared/enum/enumUA/navigation-bar';
 import { Role } from 'shared/enum/role';
-import { Competition, CompetitionRequired, Description } from 'shared/models/competition.model';
+import { Competition, CompetitionDraft, CompetitionRequired, Description } from 'shared/models/competition.model';
 import { Provider } from 'shared/models/provider.model';
 import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
 import { AddNavPath } from 'shared/store/navigation.actions';
@@ -21,6 +21,8 @@ import { CreateCompetition, UpdateCompetition } from 'shared/store/provider.acti
 import { Contacts } from 'shared/models/workshop.model';
 import { SubDirection } from 'shared/models/category.model';
 import { CreateFormComponent } from '../../shared-cabinet/create-form/create-form.component';
+import { WorkshopType } from 'shared/enum/workshop';
+import { Util } from 'shared/utils/utils';
 
 @Component({
   selector: 'app-create-competition',
@@ -50,6 +52,8 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   public readonly UNLIMITED_SEATS = Constants.UNLIMITED_SEATS;
 
+  private entity: string;
+
   constructor(
     protected store: Store,
     protected route: ActivatedRoute,
@@ -77,6 +81,8 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
     this.determineEditMode();
     this.determineRelease();
     this.addNavPath();
+
+    this.entity = this.route.snapshot.paramMap.get('entity') || WorkshopType.Competition;
 
     const id = Boolean(this.route.snapshot.paramMap.get('id'));
     const param = Boolean(this.route.snapshot.paramMap.get('param'));
@@ -114,8 +120,8 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
   public setEditMode(): void {
     const competitionId = this.route.snapshot.paramMap.get('param');
     this.store.dispatch(new GetCompetitionById(competitionId));
-    this.selectedCompetition$.pipe(filter(Boolean), takeUntil(this.destroy$)).subscribe((competition: Competition) => {
-      this.competition = competition;
+    this.selectedCompetition$.pipe(filter(Boolean), takeUntil(this.destroy$)).subscribe((competition: Competition | CompetitionDraft) => {
+      this.competition = Util.containsWorkshopOrCompetitionDetails(competition) ? competition.competitiveEventDetails : competition;
     });
   }
 

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
@@ -14,13 +14,7 @@ import { Provider } from 'shared/models/provider.model';
 import { NavigationBarService } from 'shared/services/navigation-bar/navigation-bar.service';
 import { AddNavPath } from 'shared/store/navigation.actions';
 import { RegistrationState } from 'shared/store/registration.state';
-import {
-  GetCompetitionById,
-  GetCompetitionDraftById,
-  GetWorkshopById,
-  GetWorkshopDraftById,
-  ResetCompetition
-} from 'shared/store/shared-user.actions';
+import { GetCompetitionById, GetCompetitionDraftById, ResetCompetition } from 'shared/store/shared-user.actions';
 import { SharedUserState } from 'shared/store/shared-user.state';
 import { Judge } from 'shared/models/judge.model';
 import { Constants } from 'shared/constants/constants';
@@ -61,8 +55,6 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   public readonly UNLIMITED_SEATS = Constants.UNLIMITED_SEATS;
 
-  private entity: string;
-
   constructor(
     protected store: Store,
     protected route: ActivatedRoute,
@@ -91,8 +83,6 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
     this.determineEditMode();
     this.determineRelease();
     this.addNavPath();
-
-    this.entity = this.route.snapshot.paramMap.get('entity') || WorkshopType.Competition;
 
     const id = Boolean(this.route.snapshot.paramMap.get('id'));
     const param = Boolean(this.route.snapshot.paramMap.get('param'));

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { MatDialog } from '@angular/material/dialog';
 import { Select, Store } from '@ngxs/store';
-import { Observable } from 'rxjs';
+import { first, Observable } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import { NavBarName, PersonalCabinetTitle } from 'shared/enum/enumUA/navigation-bar';
@@ -15,7 +15,8 @@ import { NavigationBarService } from 'shared/services/navigation-bar/navigation-
 import { AddNavPath } from 'shared/store/navigation.actions';
 import { RegistrationState } from 'shared/store/registration.state';
 import {
-  GetCompetitionById, GetCompetitionDraftById,
+  GetCompetitionById,
+  GetCompetitionDraftById,
   GetWorkshopById,
   GetWorkshopDraftById,
   ResetCompetition
@@ -128,18 +129,12 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
 
   public setEditMode(): void {
     const competitionId = this.route.snapshot.paramMap.get('param');
-    switch (this.route.snapshot.paramMap.get('entity')) {
-      case WorkshopType.Competition:
-        this.store.dispatch(new GetCompetitionById(competitionId));
-        break;
-      case WorkshopType.Draft:
-        this.store.dispatch(new GetCompetitionDraftById(competitionId));
-        break;
-      default:
-        this.editMode = false;
-        return;
+    if (!this.route.snapshot.paramMap.get('entity')) {
+      this.store.dispatch(new GetCompetitionById(competitionId));
+    } else {
+      this.store.dispatch(new GetCompetitionDraftById(competitionId));
     }
-    this.selectedCompetition$.pipe(filter(Boolean), takeUntil(this.destroy$)).subscribe((competition: Competition | CompetitionDraft) => {
+    this.selectedCompetition$.pipe(filter(Boolean), first()).subscribe((competition: Competition | CompetitionDraft) => {
       this.competition = Util.containsWorkshopOrCompetitionDetails(competition) ? competition.competitiveEventDetails : competition;
     });
   }

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
@@ -4,8 +4,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { MatDialog } from '@angular/material/dialog';
 import { Select, Store } from '@ngxs/store';
-import { first, Observable } from 'rxjs';
-import { filter, takeUntil } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { filter, takeUntil, first } from 'rxjs/operators';
 
 import { NavBarName, PersonalCabinetTitle } from 'shared/enum/enumUA/navigation-bar';
 import { Role } from 'shared/enum/role';

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition.component.ts
@@ -141,7 +141,6 @@ export class CreateCompetitionComponent extends CreateFormComponent implements O
     }
     this.selectedCompetition$.pipe(filter(Boolean), takeUntil(this.destroy$)).subscribe((competition: Competition | CompetitionDraft) => {
       this.competition = Util.containsWorkshopOrCompetitionDetails(competition) ? competition.competitiveEventDetails : competition;
-      console.log(this.competition)
     });
   }
 

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="RequiredFormGroup" class="step flex flex-col justify-center items-between">
   <app-image-form-control
     *ngIf="isImagesFeature"
-    [imgMaxAmount]="10"
+    [imgMaxAmount]="1"
     [cropperConfig]="cropperConfig"
     [label]="'Фонове зображення'"
     formControlName="coverImage"

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatGridListModule } from '@angular/material/grid-list';
@@ -16,13 +17,12 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgxsModule } from '@ngxs/store';
 import { NgxMaterialTimepickerModule } from 'ngx-material-timepicker';
-import { Provider } from 'shared/models/provider.model';
 
+import { Provider } from 'shared/models/provider.model';
 import { ImageFormControlComponent } from 'shared/components/image-form-control/image-form-control.component';
 import { MinMaxDirective } from 'shared/directives/min-max.directive';
 import { InfoMenuType } from 'shared/enum/info-menu-type';
 import { CreateRequiredFormComponent } from './create-required-form.component';
-import { ActivatedRoute } from '@angular/router';
 
 describe('CreateRequiredFormComponent', () => {
   let component: CreateRequiredFormComponent;

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.spec.ts
@@ -22,6 +22,7 @@ import { ImageFormControlComponent } from 'shared/components/image-form-control/
 import { MinMaxDirective } from 'shared/directives/min-max.directive';
 import { InfoMenuType } from 'shared/enum/info-menu-type';
 import { CreateRequiredFormComponent } from './create-required-form.component';
+import { ActivatedRoute } from '@angular/router';
 
 describe('CreateRequiredFormComponent', () => {
   let component: CreateRequiredFormComponent;
@@ -55,6 +56,18 @@ describe('CreateRequiredFormComponent', () => {
         MinMaxDirective,
         MockInfoMenuComponent,
         MockInstitutionHierarchyComponent
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: (key: string) => null
+              }
+            }
+          }
+        }
       ]
     }).compileComponents();
   });

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
@@ -256,17 +256,19 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
   }
 
   private listenToChanges(): void {
-    merge(
-      ...['coverImage', 'title', 'shortTitle'].map(
-        (controlName) =>
-          this.RequiredFormGroup.get(controlName)?.valueChanges.pipe(
-            throttleTime(5000, undefined, {
-              leading: true,
-              trailing: false
-            })
-          ) ?? of()
-      )
-    )
+    const fieldsToListen = ['coverImage', 'title', 'shortTitle'];
+
+    const mappedFields = fieldsToListen.map(
+      (controlName) =>
+        this.RequiredFormGroup.get(controlName)?.valueChanges.pipe(
+          throttleTime(5000, undefined, {
+            leading: true,
+            trailing: false
+          })
+        ) ?? of()
+    );
+
+    merge(...mappedFields)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.store.dispatch(

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
@@ -3,8 +3,8 @@ import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms'
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngxs/store';
 import { TranslateService } from '@ngx-translate/core';
-import { takeUntil } from 'rxjs/operators';
-import { merge, of, Subject, throttleTime } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
+import { first, merge, of, Subject, throttleTime } from 'rxjs';
 
 import { Constants } from 'shared/constants/constants';
 import { MUST_CONTAIN_LETTERS } from 'shared/constants/regex-constants';
@@ -17,7 +17,6 @@ import { Competition } from 'shared/models/competition.model';
 import { Provider } from 'shared/models/provider.model';
 import { CopperConfig } from 'shared/configs/copper.config';
 import { AgeRangeValidator } from 'shared/validators/age-range-validator';
-import { maxArrayLength, minArrayLength } from 'shared/validators/array-length/array-length-validator';
 import { ShowMessageBar } from 'shared/store/app.actions';
 
 @Component({
@@ -123,6 +122,17 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
    */
   public activateEditMode(): void {
     this.RequiredFormGroup.patchValue(this.competition, { emitEvent: false });
+
+    if (this.competition.coverImageId) {
+      this.RequiredFormGroup.get('coverImage').removeValidators(Validators.required);
+      this.RequiredFormGroup.get('coverImageId')
+        .valueChanges.pipe(
+          filter((value) => !value),
+          first()
+        )
+        .subscribe(() => this.RequiredFormGroup.get('coverImage').addValidators(Validators.required));
+    }
+
     if (this.competition.scheduledStartTime) {
       this.minDate = new Date(
         new Date(this.competition.scheduledStartTime).setMonth(new Date(this.competition.scheduledStartTime).getMonth() - 1)
@@ -167,7 +177,7 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
     this.RequiredFormGroup = this.formBuilder.group(
       {
         image: new FormControl(''),
-        coverImage: new FormControl('', [Validators.required, minArrayLength(1), maxArrayLength(1)]),
+        coverImage: new FormControl('', Validators.required),
         coverImageId: new FormControl(''),
         title: new FormControl('', [
           Validators.required,

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
@@ -3,8 +3,8 @@ import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms'
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngxs/store';
 import { TranslateService } from '@ngx-translate/core';
-import { filter, takeUntil } from 'rxjs/operators';
-import { first, merge, of, Subject, throttleTime } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { merge, of, Subject, throttleTime } from 'rxjs';
 
 import { Constants } from 'shared/constants/constants';
 import { MUST_CONTAIN_LETTERS } from 'shared/constants/regex-constants';
@@ -47,7 +47,6 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
   protected minDate: Date = new Date(new Date().setMonth(new Date().getMonth() - 12));
   protected maxDate: Date = new Date(new Date().setFullYear(new Date().getFullYear() + 1));
   protected readonly validationConstants = ValidationConstants;
-  protected readonly TypeOfCompetition = TypeOfCompetition;
   protected readonly InfoMenuType = InfoMenuType;
   protected readonly ownershipType = OwnershipTypes;
 
@@ -118,16 +117,6 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
    */
   public activateEditMode(): void {
     this.RequiredFormGroup.patchValue(this.competition, { emitEvent: false });
-
-    if (this.competition.coverImageId) {
-      this.RequiredFormGroup.get('coverImage').removeValidators(Validators.required);
-      this.RequiredFormGroup.get('coverImageId')
-        .valueChanges.pipe(
-          filter((value) => !value),
-          first()
-        )
-        .subscribe(() => this.RequiredFormGroup.get('coverImage').addValidators(Validators.required));
-    }
 
     if (this.competition.scheduledStartTime) {
       this.minDate = new Date(

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
@@ -157,7 +157,7 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
       this.availableSeatsRadioBtnControl.setValue(false);
     }
 
-    if (!this.route.snapshot.paramMap.get('entity')) {
+    if (!this.route.snapshot.paramMap.has('entity')) {
       this.listenToChanges();
     }
   }

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
@@ -1,7 +1,10 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { Store } from '@ngxs/store';
+import { TranslateService } from '@ngx-translate/core';
 import { takeUntil } from 'rxjs/operators';
-import { Subject } from 'rxjs';
+import { merge, of, Subject, throttleTime } from 'rxjs';
 
 import { Constants } from 'shared/constants/constants';
 import { MUST_CONTAIN_LETTERS } from 'shared/constants/regex-constants';
@@ -15,6 +18,7 @@ import { Provider } from 'shared/models/provider.model';
 import { CopperConfig } from 'shared/configs/copper.config';
 import { AgeRangeValidator } from 'shared/validators/age-range-validator';
 import { maxArrayLength, minArrayLength } from 'shared/validators/array-length/array-length-validator';
+import { ShowMessageBar } from 'shared/store/app.actions';
 
 @Component({
   selector: 'app-create-required-form',
@@ -51,7 +55,12 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
   private readonly destroy$: Subject<boolean> = new Subject<boolean>();
   private readonly minimumSeats: number = 1;
 
-  constructor(private readonly formBuilder: FormBuilder) {}
+  constructor(
+    private readonly formBuilder: FormBuilder,
+    private store: Store,
+    private route: ActivatedRoute,
+    private translateService: TranslateService
+  ) {}
 
   public get availableSeatsControl(): FormControl {
     return this.RequiredFormGroup.get('numberOfSeats') as FormControl;
@@ -89,6 +98,10 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
     }
 
     this.initListeners();
+
+    if (this.route.snapshot.paramMap.get('entity') === 'competition') {
+      this.listenToChanges();
+    }
   }
 
   public ngOnDestroy(): void {
@@ -241,5 +254,28 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
     this.filteredTypeOfCompetition = Object.entries(TypeOfCompetition)
       .filter(([key, value]) => !isNaN(Number(key)) && (stage || value !== 'CompetitionStage'))
       .map(([key, value]) => ({ key, value: value as string }));
+  }
+
+  private listenToChanges(): void {
+    merge(
+      ...['coverImage', 'title', 'shortTitle'].map(
+        (controlName) =>
+          this.RequiredFormGroup.get(controlName)?.valueChanges.pipe(
+            throttleTime(5000, undefined, {
+              leading: true,
+              trailing: false
+            })
+          ) ?? of()
+      )
+    )
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.store.dispatch(
+          new ShowMessageBar({
+            message: this.translateService.instant('SERVICE_MESSAGES.SNACK_BAR_TEXT.CHANGE_REQUIRES_MODERATION'),
+            type: 'warningYellow'
+          })
+        );
+      });
   }
 }

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
@@ -97,10 +97,6 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
     }
 
     this.initListeners();
-
-    if (this.route.snapshot.paramMap.get('entity') === 'competition') {
-      this.listenToChanges();
-    }
   }
 
   public ngOnDestroy(): void {
@@ -170,6 +166,10 @@ export class CreateRequiredFormComponent implements OnInit, OnDestroy {
     } else {
       this.setAvailableSeatsControlValue(this.availableSeats, 'enable', false);
       this.availableSeatsRadioBtnControl.setValue(false);
+    }
+
+    if (!this.route.snapshot.paramMap.get('entity')) {
+      this.listenToChanges();
     }
   }
 

--- a/src/app/shell/personal-cabinet/provider/create-provider/create-provider.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-provider/create-provider.component.ts
@@ -1,6 +1,6 @@
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { Form, FormArray, FormControl, FormGroup } from '@angular/forms';
+import { FormArray, FormControl, FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatStepper } from '@angular/material/stepper';
 import { ActivatedRoute, Params, Router } from '@angular/router';
@@ -15,7 +15,6 @@ import { NavBarName, PersonalCabinetTitle } from 'shared/enum/enumUA/navigation-
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { CreateProviderSteps } from 'shared/enum/provider';
 import { Role } from 'shared/enum/role';
-import { Address } from 'shared/models/address.model';
 import { FeaturesList } from 'shared/models/features-list.model';
 import { Provider } from 'shared/models/provider.model';
 import { User } from 'shared/models/user.model';

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
@@ -345,17 +345,18 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
   }
 
   private listenToChanges(): void {
-    merge(
-      ...['coverImage', 'title', 'shortTitle'].map(
-        (controlName) =>
-          this.AboutFormGroup.get(controlName)?.valueChanges.pipe(
-            throttleTime(5000, undefined, {
-              leading: true,
-              trailing: false
-            })
-          ) ?? of()
-      )
-    )
+    const fieldsToListen = ['coverImage', 'title', 'shortTitle'];
+    const mappedFields = fieldsToListen.map(
+      (controlName) =>
+        this.AboutFormGroup.get(controlName)?.valueChanges.pipe(
+          throttleTime(5000, undefined, {
+            leading: true,
+            trailing: false
+          })
+        ) ?? of()
+    );
+
+    merge(...mappedFields)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.store.dispatch(

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
@@ -174,7 +174,7 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
       this.availableSeatsRadioBtnControl.setValue(false);
     }
 
-    if (this.route.snapshot.paramMap.get('entity') === 'workshop') {
+    if (!this.route.snapshot.paramMap.get('entity')) {
       this.listenToChanges();
     }
 

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
@@ -174,7 +174,7 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
       this.availableSeatsRadioBtnControl.setValue(false);
     }
 
-    if (!this.route.snapshot.paramMap.get('entity')) {
+    if (!this.route.snapshot.paramMap.has('entity')) {
       this.listenToChanges();
     }
 

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-additional-about-form/create-additional-about-form.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-additional-about-form/create-additional-about-form.component.spec.ts
@@ -1,14 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { Workshop } from 'shared/models/workshop.model';
-import { AgeComposition, EducationalShift, GroupType, PayRateType, SpecialNeedsType } from 'shared/enum/workshop';
 import { TranslateModule } from '@ngx-translate/core';
-import { MaterialModule } from 'shared/modules/material.module';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgxsModule, Store } from '@ngxs/store';
+import { of } from 'rxjs';
+
+import { AgeComposition, EducationalShift, GroupType, PayRateType, SpecialNeedsType } from 'shared/enum/workshop';
+import { MaterialModule } from 'shared/modules/material.module';
 import { GetAllInstitutions } from 'shared/store/meta-data.actions';
 import { Constants } from 'shared/constants/constants';
-import { of } from 'rxjs';
 import { CreateAdditionalAboutFormComponent } from './create-additional-about-form.component';
 
 describe('CreateAdditionalAboutFormComponent', () => {
@@ -27,7 +29,19 @@ describe('CreateAdditionalAboutFormComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [CreateAdditionalAboutFormComponent],
       imports: [ReactiveFormsModule, MaterialModule, BrowserAnimationsModule, TranslateModule.forRoot(), NgxsModule.forRoot([])],
-      providers: [FormBuilder]
+      providers: [
+        FormBuilder,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: (key: string) => null
+              }
+            }
+          }
+        }
+      ]
     }).compileComponents();
 
     store = TestBed.inject(Store);

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-additional-about-form/create-additional-about-form.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-additional-about-form/create-additional-about-form.component.spec.ts
@@ -36,7 +36,7 @@ describe('CreateAdditionalAboutFormComponent', () => {
           useValue: {
             snapshot: {
               paramMap: {
-                get: (key: string) => null
+                has: () => false
               }
             }
           }

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-additional-about-form/create-additional-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-additional-about-form/create-additional-about-form.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngxs/store';
 import { TranslateService } from '@ngx-translate/core';
 import { Subject, throttleTime } from 'rxjs';
@@ -53,7 +54,8 @@ export class CreateAdditionalAboutFormComponent implements OnInit, OnDestroy {
   constructor(
     private readonly formBuilder: FormBuilder,
     private readonly store: Store,
-    private readonly translateService: TranslateService
+    private readonly translateService: TranslateService,
+    private readonly route: ActivatedRoute
   ) {
     this.initializeForm();
   }
@@ -91,7 +93,6 @@ export class CreateAdditionalAboutFormComponent implements OnInit, OnDestroy {
 
     this.priceControlListener();
     this.priceValueListener();
-    this.listenToChanges();
     this.listenToBenefitsChanges();
     this.passAdditionalAboutGroup.emit(this.AdditionalAboutGroup);
   }
@@ -122,6 +123,9 @@ export class CreateAdditionalAboutFormComponent implements OnInit, OnDestroy {
     );
     this.checkIfMinSport();
     this.handlePriceChange();
+    if (!this.route.snapshot.paramMap.get('entity')) {
+      this.listenToChanges();
+    }
   }
 
   private initializeForm(): void {

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-additional-about-form/create-additional-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-additional-about-form/create-additional-about-form.component.ts
@@ -123,7 +123,7 @@ export class CreateAdditionalAboutFormComponent implements OnInit, OnDestroy {
     );
     this.checkIfMinSport();
     this.handlePriceChange();
-    if (!this.route.snapshot.paramMap.get('entity')) {
+    if (!this.route.snapshot.paramMap.has('entity')) {
       this.listenToChanges();
     }
   }

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
@@ -248,7 +248,7 @@ export class CreateDescriptionFormComponent implements OnInit, OnDestroy, AfterV
       this.DescriptionFormGroup.get('competitiveSelectionDescription')?.enable();
     }
 
-    if (!this.route.snapshot.paramMap.get('entity')) {
+    if (!this.route.snapshot.paramMap.has('entity')) {
       this.listenToChanges();
     }
 

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
@@ -384,17 +384,25 @@ export class CreateDescriptionFormComponent implements OnInit, OnDestroy, AfterV
   }
 
   private listenToChanges(): void {
-    merge(
-      ...['imageFiles', 'workshopDescriptionItems', 'competitiveSelectionDescription', 'keyWords', 'enrollmentProcedureDescription'].map(
-        (controlName) =>
-          this.DescriptionFormGroup.get(controlName)?.valueChanges.pipe(
-            throttleTime(5000, undefined, {
-              leading: true,
-              trailing: false
-            })
-          ) ?? of()
-      )
-    )
+    const fieldsToListen = [
+      'imageFiles',
+      'workshopDescriptionItems',
+      'competitiveSelectionDescription',
+      'keyWords',
+      'enrollmentProcedureDescription'
+    ];
+
+    const mappedFields = fieldsToListen.map(
+      (controlName) =>
+        this.DescriptionFormGroup.get(controlName)?.valueChanges.pipe(
+          throttleTime(5000, undefined, {
+            leading: true,
+            trailing: false
+          })
+        ) ?? of()
+    );
+
+    merge(...mappedFields)
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.store.dispatch(

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
@@ -248,7 +248,7 @@ export class CreateDescriptionFormComponent implements OnInit, OnDestroy, AfterV
       this.DescriptionFormGroup.get('competitiveSelectionDescription')?.enable();
     }
 
-    if (this.route.snapshot.paramMap.get('entity') === 'workshop') {
+    if (!this.route.snapshot.paramMap.get('entity')) {
       this.listenToChanges();
     }
 

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
@@ -210,7 +210,7 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
       }
 
       this.selectedWorkshop$.pipe(takeUntil(this.destroy$), filter(Boolean)).subscribe((workshop: Workshop | WorkshopDraft) => {
-        this.workshop = Util.containsWorkshopDetails(workshop) ? workshop.workshopDetails : workshop;
+        this.workshop = Util.containsWorkshopOrCompetitionDetails(workshop) ? workshop.workshopDetails : workshop;
       });
     }
   }

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
@@ -29,8 +29,8 @@ import {
   GetUnfinishedWorkshop,
   OnDeleteUnfinishedWorkshop,
   OnSaveWorkshopStep,
-  UpdateDraft,
-  UpdateWorkshop
+  UpdateWorkshop,
+  UpdateWorkshopDraft
 } from 'shared/store/provider.actions';
 import { RegistrationState } from 'shared/store/registration.state';
 import { GetWorkshopById, GetWorkshopDraftById, ResetProvider, ResetWorkshop } from 'shared/store/shared-user.actions';
@@ -271,7 +271,7 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
 
     if (this.editMode) {
       workshop = new Workshop(aboutInfo, descInfo, contacts, additionalAboutInfo, teachers, provider, this.workshop?.id);
-      if (this.route.snapshot.paramMap.get('entity') === WorkshopType.Workshop) {
+      if (this.entity === WorkshopType.Workshop) {
         if (this.shouldBeDraft(workshop)) {
           this.dialog
             .open(ConfirmationModalWindowComponent, {
@@ -281,7 +281,7 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
               }
             })
             .afterClosed()
-            .pipe(take(1), filter(Boolean))
+            .pipe(filter(Boolean))
             .subscribe(() => {
               this.store.dispatch(new UpdateWorkshop(workshop));
             });
@@ -290,7 +290,7 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
         }
       } else {
         const draftId = this.getRouteParam();
-        this.store.dispatch(new UpdateDraft(draftId, workshop));
+        this.store.dispatch(new UpdateWorkshopDraft(draftId, workshop));
       }
     } else {
       workshop = new Workshop(aboutInfo, descInfo, contacts, additionalAboutInfo, teachers, provider);

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-workshop.component.ts
@@ -79,7 +79,6 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
   public AboutFormGroup: FormGroup;
   public DescriptionFormGroup: FormGroup;
   public AdditionalAboutGroup: FormGroup;
-  public AddressFormGroup: FormGroup;
   public TeacherFormArray: FormArray;
   public WorkshopContactsFormArray: FormArray;
 
@@ -297,15 +296,6 @@ export class CreateWorkshopComponent extends CreateFormComponent implements OnIn
       this.store.dispatch(new CreateWorkshopDraft(workshop));
     }
     this.store.dispatch(new OnDeleteUnfinishedWorkshop());
-  }
-
-  /**
-   * This method receives a form from create-address child component and assigns to the Address FormGroup
-   * @param form
-   */
-  public onReceiveAddressFormGroup(form: FormGroup): void {
-    this.AddressFormGroup = form;
-    this.subscribeOnDirtyForm(form);
   }
 
   /**

--- a/src/app/shell/personal-cabinet/provider/provider-competition/provider-competition.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-competition/provider-competition.component.html
@@ -1,6 +1,6 @@
 <div class="add-wrapper">
   <p class="text">{{ 'BANNERS.ADD_COMPETITION' | translate }}</p>
-  <a [routerLink]="['/create-competition', ModeConstants.NEW]">
+  <a [routerLink]="['/create/competition', ModeConstants.NEW]">
     <button class="btn" mat-raised-button>{{ 'BUTTONS.ADD_COMPETITION' | translate }}</button>
   </a>
 </div>

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.html
@@ -1,6 +1,6 @@
 <div class="add-wrapper">
   <p class="text">{{ 'BANNERS.ADD_COMPETITION' | translate }}</p>
-  <a [routerLink]="['/create', ModeConstants.NEW]">
+  <a [routerLink]="['/create/competition', ModeConstants.NEW]">
     <button class="btn" mat-raised-button>{{ 'BUTTONS.ADD_COMPETITION' | translate }}</button>
   </a>
 </div>

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.html
@@ -9,6 +9,7 @@
     <app-competition-card
       class="card"
       *ngFor="let competitionDraft of competitionDrafts.entities; trackBy: trackByDraft"
+      [isCabinet]="true"
       [competition]="competitionDraft"
       (deleteCompetition)="onDelete($event)">
     </app-competition-card>

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.html
@@ -4,7 +4,7 @@
     <button class="btn" mat-raised-button>{{ 'BUTTONS.ADD_COMPETITION' | translate }}</button>
   </a>
 </div>
-<ng-container *ngIf="!isLoading && !!competitionDrafts">
+<ng-container *ngIf="!(isLoading$ | async) && !!competitionDrafts">
   <div class="card-wrapper" *ngIf="competitionDrafts?.totalAmount">
     <app-competition-card
       class="card"

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.html
@@ -1,0 +1,26 @@
+<div class="add-wrapper">
+  <p class="text">{{ 'BANNERS.ADD_COMPETITION' | translate }}</p>
+  <a [routerLink]="['/create', ModeConstants.NEW]">
+    <button class="btn" mat-raised-button>{{ 'BUTTONS.ADD_COMPETITION' | translate }}</button>
+  </a>
+</div>
+<ng-container *ngIf="!isLoading && !!competitionDrafts">
+  <div class="card-wrapper" *ngIf="competitionDrafts?.totalAmount">
+    <app-competition-card
+      class="card"
+      *ngFor="let competitionDraft of competitionDrafts.entities; trackBy: trackByDraft"
+      [competition]="competitionDraft"
+      (deleteCompetition)="onDelete($event)">
+    </app-competition-card>
+  </div>
+  <ng-container *ngIf="competitionDrafts.totalAmount">
+    <app-paginator
+      [totalEntities]="competitionDrafts.totalAmount"
+      [currentPage]="currentPage"
+      [itemsPerPage]="competitionCardParameters.size"
+      (pageChange)="onPageChange($event)"
+      (itemsPerPageChange)="onItemsPerPageChange($event)">
+    </app-paginator>
+  </ng-container>
+</ng-container>
+

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.scss
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.scss
@@ -1,0 +1,3 @@
+@use 'list-wrappers';
+@use 'card-wrapper';
+@use 'buttons';

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CompetitionDraftsComponent } from './competition-drafts.component';
+
+describe('CompetitionDraftsComponent', () => {
+  let component: CompetitionDraftsComponent;
+  let fixture: ComponentFixture<CompetitionDraftsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CompetitionDraftsComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(CompetitionDraftsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.spec.ts
@@ -1,18 +1,64 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { Actions, NgxsModule, Store } from '@ngxs/store';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
 
+import { OnDraftSendForModerationSuccess } from 'shared/store/provider.actions';
+import { SearchResponse } from 'shared/models/search.model';
+import { ProviderState } from 'shared/store/provider.state';
+import { Provider } from 'shared/models/provider.model';
+import { Role } from 'shared/enum/role';
+import { CompetitionDraftCard } from 'shared/models/competition.model';
 import { CompetitionDraftsComponent } from './competition-drafts.component';
 
 describe('CompetitionDraftsComponent', () => {
   let component: CompetitionDraftsComponent;
   let fixture: ComponentFixture<CompetitionDraftsComponent>;
+  let actions$: Actions;
+  let matDialog: MatDialog;
+  let store: Store;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CompetitionDraftsComponent]
+      imports: [RouterTestingModule, NgxsModule.forRoot([]), MatDialogModule, TranslateModule.forRoot()],
+      declarations: [CompetitionDraftsComponent],
+      providers: [
+        {
+          provide: Actions,
+          useValue: {
+            pipe: jest.fn().mockReturnValue(of(new OnDraftSendForModerationSuccess()))
+          }
+        },
+        {
+          provide: MatDialog,
+          useValue: {
+            open: jest.fn()
+          }
+        }
+      ]
     }).compileComponents();
+    const initialState = {
+      totalAmount: 2,
+      entities: [{} as CompetitionDraftCard, {} as CompetitionDraftCard]
+    } as SearchResponse<CompetitionDraftCard[]>;
+
+    store = TestBed.inject(Store);
+    actions$ = TestBed.inject(Actions);
+    matDialog = TestBed.inject(MatDialog);
+
+    jest.spyOn(store, 'select').mockImplementation((selector) => {
+      // @ts-ignore
+      if (selector === ProviderState.providerCompetitionDrafts) {
+        return of(initialState);
+      }
+    });
 
     fixture = TestBed.createComponent(CompetitionDraftsComponent);
     component = fixture.componentInstance;
+    component.provider = { id: '123' } as Provider;
+    component.role = Role.provider;
     fixture.detectChanges();
   });
 

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.spec.ts
@@ -1,16 +1,23 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { Actions, NgxsModule, Store } from '@ngxs/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
-import { OnDraftSendForModerationSuccess } from 'shared/store/provider.actions';
+import {
+  DeleteCompetitionDraftById,
+  GetProviderViewCompetitionDrafts,
+  OnDraftSendForModerationSuccess
+} from 'shared/store/provider.actions';
 import { SearchResponse } from 'shared/models/search.model';
 import { ProviderState } from 'shared/store/provider.state';
 import { Provider } from 'shared/models/provider.model';
 import { Role } from 'shared/enum/role';
 import { CompetitionDraftCard } from 'shared/models/competition.model';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { PaginationConstants } from 'shared/constants/constants';
 import { CompetitionDraftsComponent } from './competition-drafts.component';
 
 describe('CompetitionDraftsComponent', () => {
@@ -64,5 +71,100 @@ describe('CompetitionDraftsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should set drafts', fakeAsync(() => {
+    component.ngOnInit();
+
+    expect(component.competitionDrafts).toBeTruthy();
+  }));
+
+  it('should get drafts if OnDraftSendForModerationSuccess', () => {
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+    component.ngOnInit();
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+    expect(dispatchSpy).toHaveBeenCalledWith(new GetProviderViewCompetitionDrafts(component.competitionCardParameters));
+  });
+
+  it('trackBy fn', () => {
+    const mockCompetition = { competitiveEventDraftId: '123' } as CompetitionDraftCard;
+
+    expect(component.trackByDraft(0, mockCompetition)).toBe('123');
+  });
+
+  describe('MatDialog', () => {
+    const mockCompetition = { competitiveEventDraftId: '123', title: 'test' } as CompetitionDraftCard;
+
+    it('should open dialog', () => {
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(of(true))
+      };
+
+      jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+      component.onDelete(mockCompetition);
+
+      expect(matDialog.open).toHaveBeenCalledWith(
+        ConfirmationModalWindowComponent,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: ModalConfirmationType.delete,
+            property: mockCompetition.title
+          })
+        })
+      );
+    });
+
+    it('should dispatch DeleteWorkshopDraftById', () => {
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(of(true))
+      };
+
+      jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+      component.onDelete(mockCompetition);
+
+      expect(dispatchSpy).toHaveBeenCalledWith(new DeleteCompetitionDraftById(mockCompetition, component.competitionCardParameters));
+    });
+
+    it('should not dispatch DeleteWorkshopDraftById', () => {
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(of(false))
+      };
+
+      jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+      component.onDelete(mockCompetition);
+
+      expect(dispatchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onPageChange', () => {
+    it('should update currentPage', () => {
+      const mockPage = { element: 1, isActive: true };
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+      component.onPageChange(mockPage);
+
+      expect(dispatchSpy).toHaveBeenCalled();
+    });
+
+    it('should update item per page', () => {
+      const mockSize = 8;
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+      component.onItemsPerPageChange(8);
+
+      expect(component.competitionCardParameters.size).toEqual(mockSize);
+      expect(component.currentPage).toEqual(PaginationConstants.firstPage);
+      expect(dispatchSpy).toHaveBeenCalledWith(new GetProviderViewCompetitionDrafts(component.competitionCardParameters));
+    });
   });
 });

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.spec.ts
@@ -9,9 +9,8 @@ describe('CompetitionDraftsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CompetitionDraftsComponent]
-    })
-    .compileComponents();
-    
+    }).compileComponents();
+
     fixture = TestBed.createComponent(CompetitionDraftsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { Constants, ModeConstants, PaginationConstants } from 'shared/constants/constants';
 import { Actions, ofAction, Select, Store } from '@ngxs/store';
 import { ProviderState } from 'shared/store/provider.state';
@@ -24,9 +24,9 @@ import { takeUntil } from 'rxjs/operators';
 @Component({
   selector: 'app-competition-drafts',
   templateUrl: './competition-drafts.component.html',
-  styleUrl: './competition-drafts.component.scss'
+  styleUrls: ['./competition-drafts.component.scss']
 })
-export class CompetitionDraftsComponent implements OnInit {
+export class CompetitionDraftsComponent implements OnInit, OnDestroy {
   @Input() public role: Role;
   @Input() public isLoading$: Observable<boolean>;
   @Input() public provider: Provider;
@@ -59,6 +59,11 @@ export class CompetitionDraftsComponent implements OnInit {
       this.competitionDrafts = competitionDrafts;
     });
     this.actions$.pipe(ofAction(OnDraftSendForModerationSuccess), takeUntil(this.destroy$)).subscribe(() => this.getProviderDrafts());
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.unsubscribe();
   }
 
   /**

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.ts
@@ -1,28 +1,35 @@
-import { Component, Inject, Input } from '@angular/core';
+import { Component, Inject, Input, OnInit } from '@angular/core';
 import { Constants, ModeConstants, PaginationConstants } from 'shared/constants/constants';
-import { Actions, Select, Store } from '@ngxs/store';
+import { Actions, ofAction, Select, Store } from '@ngxs/store';
 import { ProviderState } from 'shared/store/provider.state';
-import { filter, Observable } from 'rxjs';
+import { filter, Observable, Subject } from 'rxjs';
 import { SearchResponse } from 'shared/models/search.model';
 import { PaginationElement } from 'shared/models/pagination-element.model';
 import { MatDialog } from '@angular/material/dialog';
 import { WINDOW } from 'ngx-window-token';
-import { DeleteCompetitionDraftById, GetProviderViewCompetitionDrafts } from 'shared/store/provider.actions';
+import {
+  DeleteCompetitionDraftById,
+  GetProviderViewCompetitionDrafts,
+  OnDraftSendForModerationSuccess
+} from 'shared/store/provider.actions';
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Util } from 'shared/utils/utils';
 import { MatTabChangeEvent } from '@angular/material/tabs';
 import { Role } from 'shared/enum/role';
 import { CompetitionCardParameters, CompetitionDraftCard } from 'shared/models/competition.model';
+import { Provider } from 'shared/models/provider.model';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-competition-drafts',
   templateUrl: './competition-drafts.component.html',
   styleUrl: './competition-drafts.component.scss'
 })
-export class CompetitionDraftsComponent {
+export class CompetitionDraftsComponent implements OnInit {
   @Input() public role: Role;
-  @Input() public isLoading: boolean;
+  @Input() public isLoading$: Observable<boolean>;
+  @Input() public provider: Provider;
   @Select(ProviderState.providerCompetitionDrafts)
   public competitionDrafts$: Observable<SearchResponse<CompetitionDraftCard[]>>;
 
@@ -36,12 +43,23 @@ export class CompetitionDraftsComponent {
     size: PaginationConstants.WORKSHOPS_PER_PAGE
   };
 
+  private destroy$: Subject<boolean> = new Subject<boolean>();
+
   constructor(
     protected store: Store,
     protected matDialog: MatDialog,
     private actions$: Actions,
     @Inject(WINDOW) private window: Window
   ) {}
+
+  public ngOnInit(): void {
+    this.competitionCardParameters.providerId = this.provider.id;
+    this.getProviderDrafts();
+    this.competitionDrafts$.pipe(takeUntil(this.destroy$)).subscribe((competitionDrafts: SearchResponse<CompetitionDraftCard[]>) => {
+      this.competitionDrafts = competitionDrafts;
+    });
+    this.actions$.pipe(ofAction(OnDraftSendForModerationSuccess), takeUntil(this.destroy$)).subscribe(() => this.getProviderDrafts());
+  }
 
   /**
    * This method delete workshop By Workshop Id

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/competition-drafts/competition-drafts.component.ts
@@ -1,0 +1,92 @@
+import { Component, Inject, Input } from '@angular/core';
+import { Constants, ModeConstants, PaginationConstants } from 'shared/constants/constants';
+import { Actions, Select, Store } from '@ngxs/store';
+import { ProviderState } from 'shared/store/provider.state';
+import { filter, Observable } from 'rxjs';
+import { SearchResponse } from 'shared/models/search.model';
+import { PaginationElement } from 'shared/models/pagination-element.model';
+import { MatDialog } from '@angular/material/dialog';
+import { WINDOW } from 'ngx-window-token';
+import { DeleteCompetitionDraftById, GetProviderViewCompetitionDrafts } from 'shared/store/provider.actions';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { Util } from 'shared/utils/utils';
+import { MatTabChangeEvent } from '@angular/material/tabs';
+import { Role } from 'shared/enum/role';
+import { CompetitionCardParameters, CompetitionDraftCard } from 'shared/models/competition.model';
+
+@Component({
+  selector: 'app-competition-drafts',
+  templateUrl: './competition-drafts.component.html',
+  styleUrl: './competition-drafts.component.scss'
+})
+export class CompetitionDraftsComponent {
+  @Input() public role: Role;
+  @Input() public isLoading: boolean;
+  @Select(ProviderState.providerCompetitionDrafts)
+  public competitionDrafts$: Observable<SearchResponse<CompetitionDraftCard[]>>;
+
+  public readonly constants: typeof Constants = Constants;
+  public readonly ModeConstants = ModeConstants;
+
+  public competitionDrafts: SearchResponse<CompetitionDraftCard[]>;
+  public currentPage: PaginationElement = PaginationConstants.firstPage;
+  public competitionCardParameters: CompetitionCardParameters = {
+    providerId: '',
+    size: PaginationConstants.WORKSHOPS_PER_PAGE
+  };
+
+  constructor(
+    protected store: Store,
+    protected matDialog: MatDialog,
+    private actions$: Actions,
+    @Inject(WINDOW) private window: Window
+  ) {}
+
+  /**
+   * This method delete workshop By Workshop Id
+   * @param competition
+   */
+  public onDelete(competition: CompetitionDraftCard): void {
+    const dialogRef = this.matDialog.open(ConfirmationModalWindowComponent, {
+      width: Constants.MODAL_SMALL,
+      data: {
+        type: ModalConfirmationType.delete,
+        property: competition.title
+      }
+    });
+
+    dialogRef
+      .afterClosed()
+      .pipe(filter(Boolean))
+      .subscribe(() => {
+        this.store.dispatch(new DeleteCompetitionDraftById(competition, this.competitionCardParameters));
+      });
+  }
+
+  public onPageChange(page: PaginationElement): void {
+    this.currentPage = page;
+    this.getProviderDrafts();
+    Util.scrollToTop(this.window);
+  }
+
+  public onItemsPerPageChange(itemsPerPage: number): void {
+    this.competitionCardParameters.size = itemsPerPage;
+    this.onPageChange(PaginationConstants.firstPage);
+  }
+
+  public trackByDraft(index: number, item: CompetitionDraftCard): string {
+    return item.competitiveEventDraftId;
+  }
+
+  public onTabChange(event: MatTabChangeEvent): void {
+    return;
+  }
+
+  private getProviderDrafts(): void {
+    Util.setFromPaginationParam(this.competitionCardParameters, this.currentPage, this.competitionDrafts?.totalAmount);
+    if (this.role === Role.provider || this.role === Role.providerDeputy) {
+      this.store.dispatch(new GetProviderViewCompetitionDrafts(this.competitionCardParameters));
+    }
+  }
+}

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.html
@@ -1,8 +1,8 @@
 <mat-tab-group mat-align-tabs="start" [mat-stretch-tabs]="false" [selectedIndex]="selectedTab" (selectedTabChange)="onTabChange($event)">
-  <mat-tab label="'ENUM.NAV_BAR_NAME.WORKSHOPS">
+  <mat-tab [label]="'ENUM.NAV_BAR_NAME.WORKSHOPS' | translate">
     <app-workshop-drafts [role]="role" [provider]="provider" [isLoading$]="isLoading$"></app-workshop-drafts>
   </mat-tab>
-  <mat-tab label="Конкурси">
+  <mat-tab [label]="'ENUM.NAV_BAR_NAME.COMPETITIONS' | translate">
     <app-competition-drafts [role]="role" [provider]="provider" [isLoading$]="isLoading$"></app-competition-drafts>
   </mat-tab>
 </mat-tab-group>

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.html
@@ -1,36 +1,9 @@
-<div class="add-wrapper">
-  <p class="text">{{ 'BANNERS.ADD_WORKSHOP' | translate }}</p>
-  <button class="btn" mat-raised-button [disabled]="hasUnfinishedWorkshopData$ | async" [routerLink]="['/create', ModeConstants.NEW]">
-    {{ 'BUTTONS.ADD_WORKSHOP' | translate }}
-  </button>
-</div>
-<div class="flex flex-col gap-4">
-  <app-provider-status-banner
-    [provider]="provider"
-    [mode]="BannerMode.Unfinished"
-    *ngIf="(hasUnfinishedWorkshopData$ | async) && isLoaded"
-    class="unfinished-banner">
-  </app-provider-status-banner>
-  <div>
-    <ng-container *ngIf="!(isLoading$ | async) && !!workshopDrafts">
-      <div class="card-wrapper" *ngIf="workshopDrafts?.totalAmount">
-        <app-workshop-card
-          class="card"
-          *ngFor="let workshopDraft of workshopDrafts.entities; trackBy: trackByDraft"
-          [workshop]="workshopDraft"
-          [isCabinetView]="true"
-          (deleteWorkshop)="onDelete($event)">
-        </app-workshop-card>
-      </div>
-      <ng-container *ngIf="workshopDrafts.totalAmount">
-        <app-paginator
-          [totalEntities]="workshopDrafts.totalAmount"
-          [currentPage]="currentPage"
-          [itemsPerPage]="workshopCardParameters.size"
-          (pageChange)="onPageChange($event)"
-          (itemsPerPageChange)="onItemsPerPageChange($event)">
-        </app-paginator>
-      </ng-container>
-    </ng-container>
-  </div>
-</div>
+<mat-tab-group mat-align-tabs="start" [mat-stretch-tabs]="false" (selectedTabChange)="onTabChange($event)">
+  <mat-tab label="Гуртки">
+    <app-workshop-drafts [role]="role" [isLoading]="isLoading$ | async"></app-workshop-drafts>
+  </mat-tab>
+  <mat-tab label="Конкурси">
+    <app-competition-drafts [role]="role" [isLoading]="isLoading$ | async"></app-competition-drafts>
+  </mat-tab>
+</mat-tab-group>
+

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.html
@@ -1,4 +1,4 @@
-<mat-tab-group mat-align-tabs="start" [mat-stretch-tabs]="false" (selectedTabChange)="onTabChange($event)">
+<mat-tab-group mat-align-tabs="start" [mat-stretch-tabs]="false" [selectedIndex]="selectedTab" (selectedTabChange)="onTabChange($event)">
   <mat-tab label="Гуртки">
     <app-workshop-drafts [role]="role" [provider]="provider" [isLoading$]="isLoading$"></app-workshop-drafts>
   </mat-tab>

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.html
@@ -1,9 +1,9 @@
 <mat-tab-group mat-align-tabs="start" [mat-stretch-tabs]="false" (selectedTabChange)="onTabChange($event)">
   <mat-tab label="Гуртки">
-    <app-workshop-drafts [role]="role" [isLoading]="isLoading$ | async"></app-workshop-drafts>
+    <app-workshop-drafts [role]="role" [provider]="provider" [isLoading$]="isLoading$"></app-workshop-drafts>
   </mat-tab>
   <mat-tab label="Конкурси">
-    <app-competition-drafts [role]="role" [isLoading]="isLoading$ | async"></app-competition-drafts>
+    <app-competition-drafts [role]="role" [provider]="provider" [isLoading$]="isLoading$"></app-competition-drafts>
   </mat-tab>
 </mat-tab-group>
 

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.html
@@ -1,9 +1,8 @@
 <mat-tab-group mat-align-tabs="start" [mat-stretch-tabs]="false" [selectedIndex]="selectedTab" (selectedTabChange)="onTabChange($event)">
-  <mat-tab label="Гуртки">
+  <mat-tab label="'ENUM.NAV_BAR_NAME.WORKSHOPS">
     <app-workshop-drafts [role]="role" [provider]="provider" [isLoading$]="isLoading$"></app-workshop-drafts>
   </mat-tab>
   <mat-tab label="Конкурси">
     <app-competition-drafts [role]="role" [provider]="provider" [isLoading$]="isLoading$"></app-competition-drafts>
   </mat-tab>
 </mat-tab-group>
-

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.scss
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.scss
@@ -1,3 +1,1 @@
-@use 'list-wrappers';
-@use 'card-wrapper';
-@use 'buttons';
+@use 'navigation-tabs';

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.spec.ts
@@ -1,17 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatTabChangeEvent } from '@angular/material/tabs';
 import { NgxsModule } from '@ngxs/store';
+import { BehaviorSubject, of } from 'rxjs';
+
 import { ProviderDraftsComponent } from './provider-drafts.component';
 
 describe('ProviderDraftsComponent', () => {
   let component: ProviderDraftsComponent;
   let fixture: ComponentFixture<ProviderDraftsComponent>;
+  const activatedRouteMock = {
+    queryParams: of({})
+  } as ActivatedRoute;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NgxsModule.forRoot([])],
       declarations: [ProviderDraftsComponent],
-      providers: [{ provide: ActivatedRoute, useValue: {} }]
+      providers: [{ provide: ActivatedRoute, useValue: activatedRouteMock }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProviderDraftsComponent);
@@ -20,5 +26,73 @@ describe('ProviderDraftsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('tab params', () => {
+    let router: Router;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      router = TestBed.inject(Router);
+      jest.spyOn(router, 'navigate');
+    });
+
+    it('should set initial params if undefined', () => {
+      const t = { t: 'workshops' };
+      activatedRouteMock.queryParams = of({ t: undefined });
+      component.ngOnInit();
+      expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
+    });
+
+    it('should set initial params', () => {
+      const t = { t: 'workshops' };
+      activatedRouteMock.queryParams = of(t);
+      component.ngOnInit();
+      expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
+    });
+
+    it('should set initial params if they are incorrect', () => {
+      const t = { t: 'workshops' };
+      activatedRouteMock.queryParams = of({ t: 'wrong param' });
+      component.ngOnInit();
+      expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
+    });
+
+    it('should set initial params if key is incorrect', () => {
+      const t = { t: 'workshops' };
+      activatedRouteMock.queryParams = of({ w: 'wrong param' });
+      component.ngOnInit();
+      expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
+    });
+
+    it('should set params on direct change', () => {
+      let t = { t: 'workshops' };
+      const queryParams$ = new BehaviorSubject(t);
+      activatedRouteMock.queryParams = queryParams$.asObservable();
+      component.ngOnInit();
+      expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
+      t = { t: 'competitions' };
+      queryParams$.next(t);
+      expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
+      expect(router.navigate).toHaveBeenCalledTimes(2);
+    });
+
+    it('should set params correctly if params are incorrect', () => {
+      const t = { t: 'workshops' };
+      const queryParams$ = new BehaviorSubject(t);
+      activatedRouteMock.queryParams = queryParams$.asObservable();
+      component.ngOnInit();
+      expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
+      queryParams$.next({ t: 'wrong param' });
+      expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
+      expect(router.navigate).toHaveBeenCalledTimes(2);
+    });
+
+    it('should set params on tab change', () => {
+      const t = { t: 'competitions' };
+      component.ngOnInit();
+      component.onTabChange({ index: 1 } as MatTabChangeEvent);
+      expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
+    });
   });
 });

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.spec.ts
@@ -1,194 +1,24 @@
-import { Component, Input } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatTabsModule } from '@angular/material/tabs';
-import { RouterTestingModule } from '@angular/router/testing';
-import { TranslateModule } from '@ngx-translate/core';
-import { Actions, NgxsModule, Store } from '@ngxs/store';
-import { of } from 'rxjs';
-
-import { NoResultCardComponent } from 'shared/components/no-result-card/no-result-card.component';
-import { Workshop, WorkshopDraftCard } from 'shared/models/workshop.model';
-import { ApplicationChildFilterPipe } from 'shared/pipes/application-child-filter.pipe';
-import { ApplicationFilterPipe } from 'shared/pipes/application-filter.pipe';
-import { SearchResponse } from 'shared/models/search.model';
-import { ProviderState } from 'shared/store/provider.state';
-import { Provider } from 'shared/models/provider.model';
-import { Role } from 'shared/enum/role';
-import { DeleteWorkshopDraftById, GetProviderViewWorkshopDrafts, OnDraftSendForModerationSuccess } from 'shared/store/provider.actions';
-import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
-import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
-import { RegistrationState } from 'shared/store/registration.state';
-import { PaginationConstants } from 'shared/constants/constants';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { NgxsModule } from '@ngxs/store';
 import { ProviderDraftsComponent } from './provider-drafts.component';
 
-describe('ProviderWorkshopsComponent', () => {
+describe('ProviderDraftsComponent', () => {
   let component: ProviderDraftsComponent;
   let fixture: ComponentFixture<ProviderDraftsComponent>;
-  let actions$: Actions;
-  let matDialog: MatDialog;
-  let store: Store;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule, NgxsModule.forRoot([]), MatDialogModule, MatTabsModule, TranslateModule.forRoot()],
-      declarations: [
-        ProviderDraftsComponent,
-        MockWorkshopCardComponent,
-        ApplicationFilterPipe,
-        ApplicationChildFilterPipe,
-        NoResultCardComponent
-      ],
-      providers: [
-        {
-          provide: Actions,
-          useValue: {
-            pipe: jest.fn().mockReturnValue(of(new OnDraftSendForModerationSuccess()))
-          }
-        },
-        {
-          provide: MatDialog,
-          useValue: {
-            open: jest.fn()
-          }
-        }
-      ]
+      imports: [NgxsModule.forRoot([])],
+      declarations: [ProviderDraftsComponent],
+      providers: [{ provide: ActivatedRoute, useValue: {} }]
     }).compileComponents();
-    const initialState = {
-      totalAmount: 2,
-      entities: [{} as WorkshopDraftCard, {} as WorkshopDraftCard]
-    } as SearchResponse<WorkshopDraftCard[]>;
-
-    store = TestBed.inject(Store);
-    actions$ = TestBed.inject(Actions);
-    matDialog = TestBed.inject(MatDialog);
-
-    jest.spyOn(store, 'select').mockImplementation((selector) => {
-      // @ts-ignore
-      if (selector === ProviderState.providerDrafts) {
-        return of(initialState);
-      }
-      // @ts-ignore
-      if (selector === RegistrationState.role) {
-        return of(Role.provider);
-      }
-      // @ts-ignore
-      if (selector === ProviderState.getTimeToLiveUnfinishedWorkshop) {
-        return of('');
-      }
-    });
 
     fixture = TestBed.createComponent(ProviderDraftsComponent);
     component = fixture.componentInstance;
-    component.provider = { id: '123' } as Provider;
-    component.ngOnInit(); // to set role
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-
-  it('should set drafts', fakeAsync(() => {
-    component.initProviderData();
-
-    expect(component.workshopDrafts).toBeTruthy();
-  }));
-
-  it('should get drafts if OnDraftSendForModerationSuccess', () => {
-    const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-    component.initProviderData();
-
-    expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenCalledWith(new GetProviderViewWorkshopDrafts(component.workshopCardParameters));
-  });
-
-  it('trackBy fn', () => {
-    const mockWorkshop = { workshopDraftId: '123' } as WorkshopDraftCard;
-
-    expect(component.trackByDraft(0, mockWorkshop)).toBe('123');
-  });
-
-  describe('MatDialog', () => {
-    const mockWorkshop = { workshopDraftId: '123', title: 'test' } as WorkshopDraftCard;
-
-    it('should open dialog', () => {
-      const dialogRef = {
-        afterClosed: jest.fn().mockReturnValue(of(true))
-      };
-
-      jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
-
-      component.onDelete(mockWorkshop);
-
-      expect(matDialog.open).toHaveBeenCalledWith(
-        ConfirmationModalWindowComponent,
-        expect.objectContaining({
-          data: expect.objectContaining({
-            type: ModalConfirmationType.delete,
-            property: mockWorkshop.title
-          })
-        })
-      );
-    });
-
-    it('should dispatch DeleteWorkshopDraftById', () => {
-      const dialogRef = {
-        afterClosed: jest.fn().mockReturnValue(of(true))
-      };
-
-      jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
-
-      const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-      component.onDelete(mockWorkshop);
-
-      expect(dispatchSpy).toHaveBeenCalledWith(new DeleteWorkshopDraftById(mockWorkshop, component.workshopCardParameters));
-    });
-
-    it('should not dispatch DeleteWorkshopDraftById', () => {
-      const dialogRef = {
-        afterClosed: jest.fn().mockReturnValue(of(false))
-      };
-
-      jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
-
-      const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-      component.onDelete(mockWorkshop);
-
-      expect(dispatchSpy).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('onPageChange', () => {
-    it('should update currentPage', () => {
-      const mockPage = { element: 1, isActive: true };
-      const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-      component.onPageChange(mockPage);
-
-      expect(dispatchSpy).toHaveBeenCalled();
-    });
-
-    it('should update item per page', () => {
-      const mockSize = 8;
-      const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-      component.onItemsPerPageChange(8);
-
-      expect(component.workshopCardParameters.size).toEqual(mockSize);
-      expect(component.currentPage).toEqual(PaginationConstants.firstPage);
-      expect(dispatchSpy).toHaveBeenCalledWith(new GetProviderViewWorkshopDrafts(component.workshopCardParameters));
-    });
-  });
 });
-
-@Component({
-  selector: 'app-workshop-card',
-  template: ''
-})
-class MockWorkshopCardComponent {
-  @Input() workshop: Workshop;
-  @Input() isCabinetView: boolean;
-}

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatTabChangeEvent } from '@angular/material/tabs';
 import { NgxsModule } from '@ngxs/store';
+import { TranslateModule } from '@ngx-translate/core';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { ProviderDraftsComponent } from './provider-drafts.component';
@@ -15,7 +16,7 @@ describe('ProviderDraftsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([])],
+      imports: [NgxsModule.forRoot([]), TranslateModule.forRoot()],
       declarations: [ProviderDraftsComponent],
       providers: [{ provide: ActivatedRoute, useValue: activatedRouteMock }]
     }).compileComponents();
@@ -38,58 +39,58 @@ describe('ProviderDraftsComponent', () => {
     });
 
     it('should set initial params if undefined', () => {
-      const t = { t: 'workshops' };
-      activatedRouteMock.queryParams = of({ t: undefined });
+      const t = { tab: 'workshops' };
+      activatedRouteMock.queryParams = of({ tab: undefined });
       component.ngOnInit();
       expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
     });
 
     it('should set initial params', () => {
-      const t = { t: 'workshops' };
+      const t = { tab: 'workshops' };
       activatedRouteMock.queryParams = of(t);
       component.ngOnInit();
       expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
     });
 
     it('should set initial params if they are incorrect', () => {
-      const t = { t: 'workshops' };
-      activatedRouteMock.queryParams = of({ t: 'wrong param' });
+      const t = { tab: 'workshops' };
+      activatedRouteMock.queryParams = of({ tab: 'wrong param' });
       component.ngOnInit();
       expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
     });
 
     it('should set initial params if key is incorrect', () => {
-      const t = { t: 'workshops' };
+      const t = { tab: 'workshops' };
       activatedRouteMock.queryParams = of({ w: 'wrong param' });
       component.ngOnInit();
       expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
     });
 
     it('should set params on direct change', () => {
-      let t = { t: 'workshops' };
+      let t = { tab: 'workshops' };
       const queryParams$ = new BehaviorSubject(t);
       activatedRouteMock.queryParams = queryParams$.asObservable();
       component.ngOnInit();
       expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
-      t = { t: 'competitions' };
+      t = { tab: 'competitions' };
       queryParams$.next(t);
       expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
       expect(router.navigate).toHaveBeenCalledTimes(2);
     });
 
     it('should set params correctly if params are incorrect', () => {
-      const t = { t: 'workshops' };
+      const t = { tab: 'workshops' };
       const queryParams$ = new BehaviorSubject(t);
       activatedRouteMock.queryParams = queryParams$.asObservable();
       component.ngOnInit();
       expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
-      queryParams$.next({ t: 'wrong param' });
+      queryParams$.next({ tab: 'wrong param' });
       expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });
       expect(router.navigate).toHaveBeenCalledTimes(2);
     });
 
     it('should set params on tab change', () => {
-      const t = { t: 'competitions' };
+      const t = { tab: 'competitions' };
       component.ngOnInit();
       component.onTabChange({ index: 1 } as MatTabChangeEvent);
       expect(router.navigate).toHaveBeenCalledWith([], { relativeTo: activatedRouteMock, queryParams: t });

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
@@ -1,8 +1,10 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Store } from '@ngxs/store';
-import { MatDialog } from '@angular/material/dialog';
 import { MatTabChangeEvent } from '@angular/material/tabs';
+import { MatDialog } from '@angular/material/dialog';
+import { Store } from '@ngxs/store';
+import { map, takeUntil } from 'rxjs/operators';
+
 import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
 import { PushNavPath } from 'shared/store/navigation.actions';
 import {
@@ -22,6 +24,9 @@ import { ProviderComponent } from '../provider.component';
   styleUrls: ['./provider-drafts.component.scss']
 })
 export class ProviderDraftsComponent extends ProviderComponent implements OnInit, OnDestroy {
+  public selectedTab: number;
+  private readonly tabs: string[] = ['workshops', 'competitions'];
+
   constructor(
     protected store: Store,
     protected matDialog: MatDialog,
@@ -29,6 +34,18 @@ export class ProviderDraftsComponent extends ProviderComponent implements OnInit
     private route: ActivatedRoute
   ) {
     super(store, matDialog);
+  }
+
+  public ngOnInit(): void {
+    super.ngOnInit();
+    this.route.queryParams
+      .pipe(
+        map((params) => params.t),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((t: string | undefined) => {
+        this.updateTab(t);
+      });
   }
 
   /**
@@ -48,8 +65,17 @@ export class ProviderDraftsComponent extends ProviderComponent implements OnInit
     return;
   }
 
+  public updateTab(param: string): void {
+    const t = this.tabs.includes(param) ? param : this.tabs[0];
+    this.selectedTab = this.tabs.indexOf(t);
+    this.updateQueryParams(t);
+  }
+
   public onTabChange(event: MatTabChangeEvent): void {
-    const t = event.index === 0 ? 'workshops' : 'competitions';
+    this.updateQueryParams(this.tabs[event.index]);
+  }
+
+  private updateQueryParams(t: string): void {
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { t }

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
@@ -1,15 +1,9 @@
-import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Store } from '@ngxs/store';
 import { MatDialog } from '@angular/material/dialog';
-import { Actions, ofAction, Select, Store } from '@ngxs/store';
-import { WINDOW } from 'ngx-window-token';
-import { filter, Observable } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
-
-import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { MatTabChangeEvent } from '@angular/material/tabs';
 import { Constants, ModeConstants, PaginationConstants } from 'shared/constants/constants';
 import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
-import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
-import { Role } from 'shared/enum/role';
 import { PaginationElement } from 'shared/models/pagination-element.model';
 import { SearchResponse } from 'shared/models/search.model';
 import { WorkshopCardParameters, WorkshopDraftCard } from 'shared/models/workshop.model';
@@ -31,14 +25,6 @@ import { ProviderComponent } from '../provider.component';
   styleUrls: ['./provider-drafts.component.scss']
 })
 export class ProviderDraftsComponent extends ProviderComponent implements OnInit, OnDestroy {
-  @Select(ProviderState.providerDrafts)
-  public workshopDrafts$: Observable<SearchResponse<WorkshopDraftCard[]>>;
-  @Select(ProviderState.hasUnfinishedWorkshopData)
-  public hasUnfinishedWorkshopData$: Observable<boolean>;
-  @Select(ProviderState.getTimeToLiveUnfinishedWorkshop)
-  public draftLiveTime$: Observable<string>;
-  public isLoaded: boolean = false;
-  public readonly BannerMode = BannerMode;
   public readonly constants: typeof Constants = Constants;
   public readonly ModeConstants = ModeConstants;
 
@@ -51,23 +37,13 @@ export class ProviderDraftsComponent extends ProviderComponent implements OnInit
 
   constructor(
     protected store: Store,
-    protected matDialog: MatDialog,
-    private actions$: Actions,
-    @Inject(WINDOW) private window: Window
+    protected matDialog: MatDialog
   ) {
     super(store, matDialog);
   }
 
-  public ngOnInit(): void {
-    super.ngOnInit();
-    this.store.dispatch(new GetUnfinishedWorkshop());
-    this.draftLiveTime$.pipe(takeUntil(this.destroy$)).subscribe(() => {
-      this.isLoaded = true;
-    });
-  }
-
   /**
-   * This method set navigation path
+   * This method sets navigation path
    */
   public addNavPath(): void {
     this.store.dispatch(
@@ -79,62 +55,11 @@ export class ProviderDraftsComponent extends ProviderComponent implements OnInit
     );
   }
 
-  /**
-   * This method get provider workshop according to the role
-   */
   public initProviderData(): void {
-    this.workshopCardParameters.providerId = this.provider.id;
-    this.getProviderDrafts();
-
-    this.workshopDrafts$.pipe(takeUntil(this.destroy$)).subscribe((workshopDrafts: SearchResponse<WorkshopDraftCard[]>) => {
-      this.workshopDrafts = workshopDrafts;
-    });
-    this.actions$
-      .pipe(ofAction(OnDraftSendForModerationSuccess))
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(() => this.getProviderDrafts());
+    return;
   }
 
-  /**
-   * This method delete workshop By Workshop Id
-   * @param workshop
-   */
-  public onDelete(workshop: WorkshopDraftCard): void {
-    const dialogRef = this.matDialog.open(ConfirmationModalWindowComponent, {
-      width: Constants.MODAL_SMALL,
-      data: {
-        type: ModalConfirmationType.delete,
-        property: workshop.title
-      }
-    });
-
-    dialogRef
-      .afterClosed()
-      .pipe(filter(Boolean))
-      .subscribe(() => {
-        this.store.dispatch(new DeleteWorkshopDraftById(workshop, this.workshopCardParameters));
-      });
-  }
-
-  public onPageChange(page: PaginationElement): void {
-    this.currentPage = page;
-    this.getProviderDrafts();
-    Util.scrollToTop(this.window);
-  }
-
-  public onItemsPerPageChange(itemsPerPage: number): void {
-    this.workshopCardParameters.size = itemsPerPage;
-    this.onPageChange(PaginationConstants.firstPage);
-  }
-
-  public trackByDraft(index: number, item: WorkshopDraftCard): string {
-    return item.workshopDraftId;
-  }
-
-  private getProviderDrafts(): void {
-    Util.setFromPaginationParam(this.workshopCardParameters, this.currentPage, this.workshopDrafts?.totalAmount);
-    if (this.role === Role.provider || this.role === Role.providerDeputy) {
-      this.store.dispatch(new GetProviderViewWorkshopDrafts(this.workshopCardParameters));
-    }
+  public onTabChange(event: MatTabChangeEvent): void {
+    return;
   }
 }

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
@@ -65,7 +65,7 @@ export class ProviderDraftsComponent extends ProviderComponent implements OnInit
     return;
   }
 
-  public updateTab(param: string): void {
+  public updateTab(param: string | undefined): void {
     const t = this.tabs.includes(param) ? param : this.tabs[0];
     this.selectedTab = this.tabs.indexOf(t);
     this.updateQueryParams(t);

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
@@ -31,7 +31,7 @@ export class ProviderDraftsComponent extends ProviderComponent implements OnInit
     super.ngOnInit();
     this.route.queryParams
       .pipe(
-        map((params) => params.t),
+        map((params) => params.tab),
         takeUntil(this.destroy$)
       )
       .subscribe((tab: string | undefined) => {

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
@@ -7,15 +7,6 @@ import { map, takeUntil } from 'rxjs/operators';
 
 import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
 import { PushNavPath } from 'shared/store/navigation.actions';
-import {
-  DeleteWorkshopDraftById,
-  GetProviderViewWorkshopDrafts,
-  GetUnfinishedWorkshop,
-  OnDraftSendForModerationSuccess
-} from 'shared/store/provider.actions';
-import { ProviderState } from 'shared/store/provider.state';
-import { Util } from 'shared/utils/utils';
-import { BannerMode } from 'shared/enum/bannerMode';
 import { ProviderComponent } from '../provider.component';
 
 @Component({

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
@@ -3,11 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngxs/store';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTabChangeEvent } from '@angular/material/tabs';
-import { Constants, ModeConstants, PaginationConstants } from 'shared/constants/constants';
 import { NavBarName } from 'shared/enum/enumUA/navigation-bar';
-import { PaginationElement } from 'shared/models/pagination-element.model';
-import { SearchResponse } from 'shared/models/search.model';
-import { WorkshopCardParameters, WorkshopDraftCard } from 'shared/models/workshop.model';
 import { PushNavPath } from 'shared/store/navigation.actions';
 import {
   DeleteWorkshopDraftById,
@@ -26,16 +22,6 @@ import { ProviderComponent } from '../provider.component';
   styleUrls: ['./provider-drafts.component.scss']
 })
 export class ProviderDraftsComponent extends ProviderComponent implements OnInit, OnDestroy {
-  public readonly constants: typeof Constants = Constants;
-  public readonly ModeConstants = ModeConstants;
-
-  public workshopDrafts: SearchResponse<WorkshopDraftCard[]>;
-  public currentPage: PaginationElement = PaginationConstants.firstPage;
-  public workshopCardParameters: WorkshopCardParameters = {
-    providerId: '',
-    size: PaginationConstants.WORKSHOPS_PER_PAGE
-  };
-
   constructor(
     protected store: Store,
     protected matDialog: MatDialog,

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngxs/store';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTabChangeEvent } from '@angular/material/tabs';
@@ -37,7 +38,9 @@ export class ProviderDraftsComponent extends ProviderComponent implements OnInit
 
   constructor(
     protected store: Store,
-    protected matDialog: MatDialog
+    protected matDialog: MatDialog,
+    private router: Router,
+    private route: ActivatedRoute
   ) {
     super(store, matDialog);
   }
@@ -60,6 +63,10 @@ export class ProviderDraftsComponent extends ProviderComponent implements OnInit
   }
 
   public onTabChange(event: MatTabChangeEvent): void {
-    return;
+    const t = event.index === 0 ? 'workshops' : 'competitions';
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { t }
+    });
   }
 }

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/provider-drafts.component.ts
@@ -34,8 +34,8 @@ export class ProviderDraftsComponent extends ProviderComponent implements OnInit
         map((params) => params.t),
         takeUntil(this.destroy$)
       )
-      .subscribe((t: string | undefined) => {
-        this.updateTab(t);
+      .subscribe((tab: string | undefined) => {
+        this.updateTab(tab);
       });
   }
 
@@ -57,19 +57,19 @@ export class ProviderDraftsComponent extends ProviderComponent implements OnInit
   }
 
   public updateTab(param: string | undefined): void {
-    const t = this.tabs.includes(param) ? param : this.tabs[0];
-    this.selectedTab = this.tabs.indexOf(t);
-    this.updateQueryParams(t);
+    const tab = this.tabs.includes(param) ? param : this.tabs[0];
+    this.selectedTab = this.tabs.indexOf(tab);
+    this.updateQueryParams(tab);
   }
 
   public onTabChange(event: MatTabChangeEvent): void {
     this.updateQueryParams(this.tabs[event.index]);
   }
 
-  private updateQueryParams(t: string): void {
+  private updateQueryParams(tab: string): void {
     this.router.navigate([], {
       relativeTo: this.route,
-      queryParams: { t }
+      queryParams: { tab }
     });
   }
 }

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.html
@@ -1,0 +1,26 @@
+<div class="add-wrapper">
+  <p class="text">{{ 'BANNERS.ADD_WORKSHOP' | translate }}</p>
+  <a [routerLink]="['/create', ModeConstants.NEW]">
+    <button class="btn" mat-raised-button>{{ 'BUTTONS.ADD_WORKSHOP' | translate }}</button>
+  </a>
+</div>
+<ng-container *ngIf="!isLoading && !!workshopDrafts">
+  <div class="card-wrapper" *ngIf="workshopDrafts?.totalAmount">
+    <app-workshop-card
+      class="card"
+      *ngFor="let workshopDraft of workshopDrafts.entities; trackBy: trackByDraft"
+      [workshop]="workshopDraft"
+      [isCabinetView]="true"
+      (deleteWorkshop)="onDelete($event)">
+    </app-workshop-card>
+  </div>
+  <ng-container *ngIf="workshopDrafts.totalAmount">
+    <app-paginator
+      [totalEntities]="workshopDrafts.totalAmount"
+      [currentPage]="currentPage"
+      [itemsPerPage]="workshopCardParameters.size"
+      (pageChange)="onPageChange($event)"
+      (itemsPerPageChange)="onItemsPerPageChange($event)">
+    </app-paginator>
+  </ng-container>
+</ng-container>

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.html
@@ -1,26 +1,36 @@
 <div class="add-wrapper">
   <p class="text">{{ 'BANNERS.ADD_WORKSHOP' | translate }}</p>
-  <a [routerLink]="['/create/workshop', ModeConstants.NEW]">
-    <button class="btn" mat-raised-button>{{ 'BUTTONS.ADD_WORKSHOP' | translate }}</button>
-  </a>
+  <button class="btn" mat-raised-button [disabled]="hasUnfinishedWorkshopData$ | async" [routerLink]="['/create', ModeConstants.NEW]">
+    {{ 'BUTTONS.ADD_WORKSHOP' | translate }}
+  </button>
 </div>
-<ng-container *ngIf="!(isLoading$ | async) && !!workshopDrafts">
-  <div class="card-wrapper" *ngIf="workshopDrafts?.totalAmount">
-    <app-workshop-card
-      class="card"
-      *ngFor="let workshopDraft of workshopDrafts.entities; trackBy: trackByDraft"
-      [workshop]="workshopDraft"
-      [isCabinetView]="true"
-      (deleteWorkshop)="onDelete($event)">
-    </app-workshop-card>
+<div class="flex flex-col gap-4">
+  <app-provider-status-banner
+    [provider]="provider"
+    [mode]="BannerMode.Unfinished"
+    *ngIf="(hasUnfinishedWorkshopData$ | async) && isLoaded"
+    class="unfinished-banner">
+  </app-provider-status-banner>
+  <div>
+    <ng-container *ngIf="!(isLoading$ | async) && !!workshopDrafts">
+      <div class="card-wrapper" *ngIf="workshopDrafts?.totalAmount">
+        <app-workshop-card
+          class="card"
+          *ngFor="let workshopDraft of workshopDrafts.entities; trackBy: trackByDraft"
+          [workshop]="workshopDraft"
+          [isCabinetView]="true"
+          (deleteWorkshop)="onDelete($event)">
+        </app-workshop-card>
+      </div>
+      <ng-container *ngIf="workshopDrafts.totalAmount">
+        <app-paginator
+          [totalEntities]="workshopDrafts.totalAmount"
+          [currentPage]="currentPage"
+          [itemsPerPage]="workshopCardParameters.size"
+          (pageChange)="onPageChange($event)"
+          (itemsPerPageChange)="onItemsPerPageChange($event)">
+        </app-paginator>
+      </ng-container>
+    </ng-container>
   </div>
-  <ng-container *ngIf="workshopDrafts.totalAmount">
-    <app-paginator
-      [totalEntities]="workshopDrafts.totalAmount"
-      [currentPage]="currentPage"
-      [itemsPerPage]="workshopCardParameters.size"
-      (pageChange)="onPageChange($event)"
-      (itemsPerPageChange)="onItemsPerPageChange($event)">
-    </app-paginator>
-  </ng-container>
-</ng-container>
+</div>

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.html
@@ -1,6 +1,6 @@
 <div class="add-wrapper">
   <p class="text">{{ 'BANNERS.ADD_WORKSHOP' | translate }}</p>
-  <a [routerLink]="['/create', ModeConstants.NEW]">
+  <a [routerLink]="['/create/workshop', ModeConstants.NEW]">
     <button class="btn" mat-raised-button>{{ 'BUTTONS.ADD_WORKSHOP' | translate }}</button>
   </a>
 </div>

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.html
@@ -4,7 +4,7 @@
     <button class="btn" mat-raised-button>{{ 'BUTTONS.ADD_WORKSHOP' | translate }}</button>
   </a>
 </div>
-<ng-container *ngIf="!isLoading && !!workshopDrafts">
+<ng-container *ngIf="!(isLoading$ | async) && !!workshopDrafts">
   <div class="card-wrapper" *ngIf="workshopDrafts?.totalAmount">
     <app-workshop-card
       class="card"

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.scss
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.scss
@@ -1,0 +1,3 @@
+@use 'list-wrappers';
+@use 'card-wrapper';
+@use 'buttons';

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WorkshopDraftsComponent } from './workshop-drafts.component';
+
+describe('WorkshopDraftsComponent', () => {
+  let component: WorkshopDraftsComponent;
+  let fixture: ComponentFixture<WorkshopDraftsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WorkshopDraftsComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(WorkshopDraftsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.spec.ts
@@ -9,9 +9,8 @@ describe('WorkshopDraftsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [WorkshopDraftsComponent]
-    })
-    .compileComponents();
-    
+    }).compileComponents();
+
     fixture = TestBed.createComponent(WorkshopDraftsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.spec.ts
@@ -1,22 +1,166 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { Actions, NgxsModule, Store } from '@ngxs/store';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
 
+import { DeleteWorkshopDraftById, GetProviderViewWorkshopDrafts, OnDraftSendForModerationSuccess } from 'shared/store/provider.actions';
+import { WorkshopDraftCard } from 'shared/models/workshop.model';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { PaginationConstants } from 'shared/constants/constants';
+import { SearchResponse } from 'shared/models/search.model';
+import { ProviderState } from 'shared/store/provider.state';
+import { Provider } from 'shared/models/provider.model';
+import { Role } from 'shared/enum/role';
 import { WorkshopDraftsComponent } from './workshop-drafts.component';
 
 describe('WorkshopDraftsComponent', () => {
   let component: WorkshopDraftsComponent;
   let fixture: ComponentFixture<WorkshopDraftsComponent>;
+  let actions$: Actions;
+  let matDialog: MatDialog;
+  let store: Store;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WorkshopDraftsComponent]
+      imports: [RouterTestingModule, NgxsModule.forRoot([]), MatDialogModule, TranslateModule.forRoot()],
+      declarations: [WorkshopDraftsComponent],
+      providers: [
+        {
+          provide: Actions,
+          useValue: {
+            pipe: jest.fn().mockReturnValue(of(new OnDraftSendForModerationSuccess()))
+          }
+        },
+        {
+          provide: MatDialog,
+          useValue: {
+            open: jest.fn()
+          }
+        }
+      ]
     }).compileComponents();
+    const initialState = {
+      totalAmount: 2,
+      entities: [{} as WorkshopDraftCard, {} as WorkshopDraftCard]
+    } as SearchResponse<WorkshopDraftCard[]>;
+
+    store = TestBed.inject(Store);
+    actions$ = TestBed.inject(Actions);
+    matDialog = TestBed.inject(MatDialog);
+
+    jest.spyOn(store, 'select').mockImplementation((selector) => {
+      // @ts-ignore
+      if (selector === ProviderState.providerWorkshopDrafts) {
+        return of(initialState);
+      }
+    });
 
     fixture = TestBed.createComponent(WorkshopDraftsComponent);
     component = fixture.componentInstance;
+    component.provider = { id: '123' } as Provider;
+    component.role = Role.provider;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should set drafts', fakeAsync(() => {
+    component.ngOnInit();
+
+    expect(component.workshopDrafts).toBeTruthy();
+  }));
+
+  it('should get drafts if OnDraftSendForModerationSuccess', () => {
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+    component.ngOnInit();
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+    expect(dispatchSpy).toHaveBeenCalledWith(new GetProviderViewWorkshopDrafts(component.workshopCardParameters));
+  });
+
+  it('trackBy fn', () => {
+    const mockWorkshop = { workshopDraftId: '123' } as WorkshopDraftCard;
+
+    expect(component.trackByDraft(0, mockWorkshop)).toBe('123');
+  });
+
+  describe('MatDialog', () => {
+    const mockWorkshop = { workshopDraftId: '123', title: 'test' } as WorkshopDraftCard;
+
+    it('should open dialog', () => {
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(of(true))
+      };
+
+      jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+      component.onDelete(mockWorkshop);
+
+      expect(matDialog.open).toHaveBeenCalledWith(
+        ConfirmationModalWindowComponent,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: ModalConfirmationType.delete,
+            property: mockWorkshop.title
+          })
+        })
+      );
+    });
+
+    it('should dispatch DeleteWorkshopDraftById', () => {
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(of(true))
+      };
+
+      jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+      component.onDelete(mockWorkshop);
+
+      expect(dispatchSpy).toHaveBeenCalledWith(new DeleteWorkshopDraftById(mockWorkshop, component.workshopCardParameters));
+    });
+
+    it('should not dispatch DeleteWorkshopDraftById', () => {
+      const dialogRef = {
+        afterClosed: jest.fn().mockReturnValue(of(false))
+      };
+
+      jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
+
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+      component.onDelete(mockWorkshop);
+
+      expect(dispatchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onPageChange', () => {
+    it('should update currentPage', () => {
+      const mockPage = { element: 1, isActive: true };
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+      component.onPageChange(mockPage);
+
+      expect(dispatchSpy).toHaveBeenCalled();
+    });
+
+    it('should update item per page', () => {
+      const mockSize = 8;
+      const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+      component.onItemsPerPageChange(8);
+
+      expect(component.workshopCardParameters.size).toEqual(mockSize);
+      expect(component.currentPage).toEqual(PaginationConstants.firstPage);
+      expect(dispatchSpy).toHaveBeenCalledWith(new GetProviderViewWorkshopDrafts(component.workshopCardParameters));
+    });
   });
 });

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.spec.ts
@@ -1,19 +1,24 @@
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { Actions, NgxsModule, Store } from '@ngxs/store';
+import { MatTabsModule } from '@angular/material/tabs';
+import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
+import { Actions, NgxsModule, Store } from '@ngxs/store';
 import { of } from 'rxjs';
 
-import { DeleteWorkshopDraftById, GetProviderViewWorkshopDrafts, OnDraftSendForModerationSuccess } from 'shared/store/provider.actions';
+import { NoResultCardComponent } from 'shared/components/no-result-card/no-result-card.component';
 import { WorkshopDraftCard } from 'shared/models/workshop.model';
-import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
-import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
-import { PaginationConstants } from 'shared/constants/constants';
+import { ApplicationChildFilterPipe } from 'shared/pipes/application-child-filter.pipe';
+import { ApplicationFilterPipe } from 'shared/pipes/application-filter.pipe';
 import { SearchResponse } from 'shared/models/search.model';
 import { ProviderState } from 'shared/store/provider.state';
 import { Provider } from 'shared/models/provider.model';
 import { Role } from 'shared/enum/role';
+import { DeleteWorkshopDraftById, GetProviderViewWorkshopDrafts, OnDraftSendForModerationSuccess } from 'shared/store/provider.actions';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { RegistrationState } from 'shared/store/registration.state';
+import { PaginationConstants } from 'shared/constants/constants';
 import { WorkshopDraftsComponent } from './workshop-drafts.component';
 
 describe('WorkshopDraftsComponent', () => {
@@ -25,8 +30,8 @@ describe('WorkshopDraftsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule, NgxsModule.forRoot([]), MatDialogModule, TranslateModule.forRoot()],
-      declarations: [WorkshopDraftsComponent],
+      imports: [RouterTestingModule, NgxsModule.forRoot([]), MatDialogModule, MatTabsModule, TranslateModule.forRoot()],
+      declarations: [WorkshopDraftsComponent, ApplicationFilterPipe, ApplicationChildFilterPipe, NoResultCardComponent],
       providers: [
         {
           provide: Actions,
@@ -56,13 +61,21 @@ describe('WorkshopDraftsComponent', () => {
       if (selector === ProviderState.providerWorkshopDrafts) {
         return of(initialState);
       }
+      // @ts-ignore
+      if (selector === RegistrationState.role) {
+        return of(Role.provider);
+      }
+      // @ts-ignore
+      if (selector === ProviderState.getTimeToLiveUnfinishedWorkshop) {
+        return of('');
+      }
     });
 
     fixture = TestBed.createComponent(WorkshopDraftsComponent);
     component = fixture.componentInstance;
     component.provider = { id: '123' } as Provider;
     component.role = Role.provider;
-    fixture.detectChanges();
+    component.ngOnInit(); // to set role
   });
 
   it('should create', () => {
@@ -70,24 +83,22 @@ describe('WorkshopDraftsComponent', () => {
   });
 
   it('should set drafts', fakeAsync(() => {
-    component.ngOnInit();
-
-    expect(component.workshopDrafts).toBeTruthy();
+    expect((component as any).workshopDrafts).toBeTruthy();
   }));
 
-  it('should get drafts if OnDraftSendForModerationSuccess', () => {
+  it('should get drafts once OnDraftSendForModerationSuccess', () => {
     const dispatchSpy = jest.spyOn(store, 'dispatch');
 
     component.ngOnInit();
 
-    expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenCalledWith(new GetProviderViewWorkshopDrafts(component.workshopCardParameters));
+    expect(dispatchSpy).toHaveBeenCalledTimes(3);
+    expect(dispatchSpy).toHaveBeenCalledWith(new GetProviderViewWorkshopDrafts((component as any).workshopCardParameters));
   });
 
   it('trackBy fn', () => {
     const mockWorkshop = { workshopDraftId: '123' } as WorkshopDraftCard;
 
-    expect(component.trackByDraft(0, mockWorkshop)).toBe('123');
+    expect((component as any).trackByDraft(0, mockWorkshop)).toBe('123');
   });
 
   describe('MatDialog', () => {
@@ -100,7 +111,7 @@ describe('WorkshopDraftsComponent', () => {
 
       jest.spyOn(matDialog, 'open').mockReturnValue(dialogRef as any);
 
-      component.onDelete(mockWorkshop);
+      (component as any).onDelete(mockWorkshop);
 
       expect(matDialog.open).toHaveBeenCalledWith(
         ConfirmationModalWindowComponent,
@@ -122,9 +133,9 @@ describe('WorkshopDraftsComponent', () => {
 
       const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-      component.onDelete(mockWorkshop);
+      (component as any).onDelete(mockWorkshop);
 
-      expect(dispatchSpy).toHaveBeenCalledWith(new DeleteWorkshopDraftById(mockWorkshop, component.workshopCardParameters));
+      expect(dispatchSpy).toHaveBeenCalledWith(new DeleteWorkshopDraftById(mockWorkshop, (component as any).workshopCardParameters));
     });
 
     it('should not dispatch DeleteWorkshopDraftById', () => {
@@ -136,7 +147,7 @@ describe('WorkshopDraftsComponent', () => {
 
       const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-      component.onDelete(mockWorkshop);
+      (component as any).onDelete(mockWorkshop);
 
       expect(dispatchSpy).not.toHaveBeenCalled();
     });
@@ -147,7 +158,7 @@ describe('WorkshopDraftsComponent', () => {
       const mockPage = { element: 1, isActive: true };
       const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-      component.onPageChange(mockPage);
+      (component as any).onPageChange(mockPage);
 
       expect(dispatchSpy).toHaveBeenCalled();
     });
@@ -156,11 +167,11 @@ describe('WorkshopDraftsComponent', () => {
       const mockSize = 8;
       const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-      component.onItemsPerPageChange(8);
+      (component as any).onItemsPerPageChange(8);
 
-      expect(component.workshopCardParameters.size).toEqual(mockSize);
-      expect(component.currentPage).toEqual(PaginationConstants.firstPage);
-      expect(dispatchSpy).toHaveBeenCalledWith(new GetProviderViewWorkshopDrafts(component.workshopCardParameters));
+      expect((component as any).workshopCardParameters.size).toEqual(mockSize);
+      expect((component as any).currentPage).toEqual(PaginationConstants.firstPage);
+      expect(dispatchSpy).toHaveBeenCalledWith(new GetProviderViewWorkshopDrafts((component as any).workshopCardParameters));
     });
   });
 });

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
@@ -8,11 +8,7 @@ import { WorkshopCardParameters, WorkshopDraftCard } from 'shared/models/worksho
 import { PaginationElement } from 'shared/models/pagination-element.model';
 import { MatDialog } from '@angular/material/dialog';
 import { WINDOW } from 'ngx-window-token';
-import {
-  DeleteWorkshopDraftById,
-  GetProviderViewWorkshopDrafts,
-  OnDraftSendForModerationSuccess
-} from 'shared/store/provider.actions';
+import { DeleteWorkshopDraftById, GetProviderViewWorkshopDrafts, OnDraftSendForModerationSuccess } from 'shared/store/provider.actions';
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Util } from 'shared/utils/utils';

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
@@ -1,28 +1,35 @@
-import { Component, Inject, Input } from '@angular/core';
+import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { Constants, ModeConstants, PaginationConstants } from 'shared/constants/constants';
-import { Actions, Select, Store } from '@ngxs/store';
+import { Actions, ofAction, Select, Store } from '@ngxs/store';
 import { ProviderState } from 'shared/store/provider.state';
-import { filter, Observable } from 'rxjs';
+import { filter, Observable, Subject } from 'rxjs';
 import { SearchResponse } from 'shared/models/search.model';
 import { WorkshopCardParameters, WorkshopDraftCard } from 'shared/models/workshop.model';
 import { PaginationElement } from 'shared/models/pagination-element.model';
 import { MatDialog } from '@angular/material/dialog';
 import { WINDOW } from 'ngx-window-token';
-import { DeleteWorkshopDraftById, GetProviderViewWorkshopDrafts } from 'shared/store/provider.actions';
+import {
+  DeleteWorkshopDraftById,
+  GetProviderViewWorkshopDrafts,
+  OnDraftSendForModerationSuccess
+} from 'shared/store/provider.actions';
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Util } from 'shared/utils/utils';
 import { MatTabChangeEvent } from '@angular/material/tabs';
 import { Role } from 'shared/enum/role';
+import { Provider } from 'shared/models/provider.model';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-workshop-drafts',
   templateUrl: './workshop-drafts.component.html',
   styleUrl: './workshop-drafts.component.scss'
 })
-export class WorkshopDraftsComponent {
+export class WorkshopDraftsComponent implements OnInit, OnDestroy {
   @Input() public role: Role;
-  @Input() public isLoading: boolean;
+  @Input() public isLoading$: Observable<boolean>;
+  @Input() public provider: Provider;
   @Select(ProviderState.providerWorkshopDrafts)
   public workshopDrafts$: Observable<SearchResponse<WorkshopDraftCard[]>>;
 
@@ -36,12 +43,28 @@ export class WorkshopDraftsComponent {
     size: PaginationConstants.WORKSHOPS_PER_PAGE
   };
 
+  private destroy$: Subject<boolean> = new Subject<boolean>();
+
   constructor(
     protected store: Store,
     protected matDialog: MatDialog,
     private actions$: Actions,
     @Inject(WINDOW) private window: Window
   ) {}
+
+  public ngOnInit(): void {
+    this.workshopCardParameters.providerId = this.provider.id;
+    this.getProviderDrafts();
+    this.workshopDrafts$.pipe(takeUntil(this.destroy$)).subscribe((workshopDrafts: SearchResponse<WorkshopDraftCard[]>) => {
+      this.workshopDrafts = workshopDrafts;
+    });
+    this.actions$.pipe(ofAction(OnDraftSendForModerationSuccess), takeUntil(this.destroy$)).subscribe(() => this.getProviderDrafts());
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.unsubscribe();
+  }
 
   /**
    * This method delete workshop By Workshop Id

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
@@ -98,10 +98,6 @@ export class WorkshopDraftsComponent implements OnInit, OnDestroy {
     return item.workshopDraftId;
   }
 
-  public onTabChange(event: MatTabChangeEvent): void {
-    return;
-  }
-
   private getProviderDrafts(): void {
     Util.setFromPaginationParam(this.workshopCardParameters, this.currentPage, this.workshopDrafts?.totalAmount);
     if (this.role === Role.provider || this.role === Role.providerDeputy) {

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
@@ -8,13 +8,19 @@ import { WorkshopCardParameters, WorkshopDraftCard } from 'shared/models/worksho
 import { PaginationElement } from 'shared/models/pagination-element.model';
 import { MatDialog } from '@angular/material/dialog';
 import { WINDOW } from 'ngx-window-token';
-import { DeleteWorkshopDraftById, GetProviderViewWorkshopDrafts, OnDraftSendForModerationSuccess } from 'shared/store/provider.actions';
+import {
+  DeleteWorkshopDraftById,
+  GetProviderViewWorkshopDrafts,
+  GetUnfinishedWorkshop,
+  OnDraftSendForModerationSuccess
+} from 'shared/store/provider.actions';
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Util } from 'shared/utils/utils';
 import { Role } from 'shared/enum/role';
 import { Provider } from 'shared/models/provider.model';
 import { takeUntil } from 'rxjs/operators';
+import { BannerMode } from 'shared/enum/bannerMode';
 
 @Component({
   selector: 'app-workshop-drafts',
@@ -27,7 +33,13 @@ export class WorkshopDraftsComponent implements OnInit, OnDestroy {
   @Input() public provider: Provider;
   @Select(ProviderState.providerWorkshopDrafts)
   public workshopDrafts$: Observable<SearchResponse<WorkshopDraftCard[]>>;
+  @Select(ProviderState.hasUnfinishedWorkshopData)
+  public hasUnfinishedWorkshopData$: Observable<boolean>;
+  @Select(ProviderState.getTimeToLiveUnfinishedWorkshop)
+  public draftLiveTime$: Observable<string>;
+  public isLoaded: boolean = false;
 
+  public readonly BannerMode = BannerMode;
   public readonly constants: typeof Constants = Constants;
   public readonly ModeConstants = ModeConstants;
 
@@ -54,6 +66,10 @@ export class WorkshopDraftsComponent implements OnInit, OnDestroy {
       this.workshopDrafts = workshopDrafts;
     });
     this.actions$.pipe(ofAction(OnDraftSendForModerationSuccess), takeUntil(this.destroy$)).subscribe(() => this.getProviderDrafts());
+    this.store.dispatch(new GetUnfinishedWorkshop());
+    this.draftLiveTime$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.isLoaded = true;
+    });
   }
 
   public ngOnDestroy(): void {

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
@@ -12,7 +12,6 @@ import { DeleteWorkshopDraftById, GetProviderViewWorkshopDrafts, OnDraftSendForM
 import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
 import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
 import { Util } from 'shared/utils/utils';
-import { MatTabChangeEvent } from '@angular/material/tabs';
 import { Role } from 'shared/enum/role';
 import { Provider } from 'shared/models/provider.model';
 import { takeUntil } from 'rxjs/operators';
@@ -20,7 +19,7 @@ import { takeUntil } from 'rxjs/operators';
 @Component({
   selector: 'app-workshop-drafts',
   templateUrl: './workshop-drafts.component.html',
-  styleUrl: './workshop-drafts.component.scss'
+  styleUrls: ['./workshop-drafts.component.scss']
 })
 export class WorkshopDraftsComponent implements OnInit, OnDestroy {
   @Input() public role: Role;

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.ts
@@ -1,0 +1,92 @@
+import { Component, Inject, Input } from '@angular/core';
+import { Constants, ModeConstants, PaginationConstants } from 'shared/constants/constants';
+import { Actions, Select, Store } from '@ngxs/store';
+import { ProviderState } from 'shared/store/provider.state';
+import { filter, Observable } from 'rxjs';
+import { SearchResponse } from 'shared/models/search.model';
+import { WorkshopCardParameters, WorkshopDraftCard } from 'shared/models/workshop.model';
+import { PaginationElement } from 'shared/models/pagination-element.model';
+import { MatDialog } from '@angular/material/dialog';
+import { WINDOW } from 'ngx-window-token';
+import { DeleteWorkshopDraftById, GetProviderViewWorkshopDrafts } from 'shared/store/provider.actions';
+import { ConfirmationModalWindowComponent } from 'shared/components/confirmation-modal-window/confirmation-modal-window.component';
+import { ModalConfirmationType } from 'shared/enum/modal-confirmation';
+import { Util } from 'shared/utils/utils';
+import { MatTabChangeEvent } from '@angular/material/tabs';
+import { Role } from 'shared/enum/role';
+
+@Component({
+  selector: 'app-workshop-drafts',
+  templateUrl: './workshop-drafts.component.html',
+  styleUrl: './workshop-drafts.component.scss'
+})
+export class WorkshopDraftsComponent {
+  @Input() public role: Role;
+  @Input() public isLoading: boolean;
+  @Select(ProviderState.providerWorkshopDrafts)
+  public workshopDrafts$: Observable<SearchResponse<WorkshopDraftCard[]>>;
+
+  public readonly constants: typeof Constants = Constants;
+  public readonly ModeConstants = ModeConstants;
+
+  public workshopDrafts: SearchResponse<WorkshopDraftCard[]>;
+  public currentPage: PaginationElement = PaginationConstants.firstPage;
+  public workshopCardParameters: WorkshopCardParameters = {
+    providerId: '',
+    size: PaginationConstants.WORKSHOPS_PER_PAGE
+  };
+
+  constructor(
+    protected store: Store,
+    protected matDialog: MatDialog,
+    private actions$: Actions,
+    @Inject(WINDOW) private window: Window
+  ) {}
+
+  /**
+   * This method delete workshop By Workshop Id
+   * @param workshop
+   */
+  public onDelete(workshop: WorkshopDraftCard): void {
+    const dialogRef = this.matDialog.open(ConfirmationModalWindowComponent, {
+      width: Constants.MODAL_SMALL,
+      data: {
+        type: ModalConfirmationType.delete,
+        property: workshop.title
+      }
+    });
+
+    dialogRef
+      .afterClosed()
+      .pipe(filter(Boolean))
+      .subscribe(() => {
+        this.store.dispatch(new DeleteWorkshopDraftById(workshop, this.workshopCardParameters));
+      });
+  }
+
+  public onPageChange(page: PaginationElement): void {
+    this.currentPage = page;
+    this.getProviderDrafts();
+    Util.scrollToTop(this.window);
+  }
+
+  public onItemsPerPageChange(itemsPerPage: number): void {
+    this.workshopCardParameters.size = itemsPerPage;
+    this.onPageChange(PaginationConstants.firstPage);
+  }
+
+  public trackByDraft(index: number, item: WorkshopDraftCard): string {
+    return item.workshopDraftId;
+  }
+
+  public onTabChange(event: MatTabChangeEvent): void {
+    return;
+  }
+
+  private getProviderDrafts(): void {
+    Util.setFromPaginationParam(this.workshopCardParameters, this.currentPage, this.workshopDrafts?.totalAmount);
+    if (this.role === Role.provider || this.role === Role.providerDeputy) {
+      this.store.dispatch(new GetProviderViewWorkshopDrafts(this.workshopCardParameters));
+    }
+  }
+}

--- a/src/app/shell/personal-cabinet/provider/provider-workshops/provider-workshops.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-workshops/provider-workshops.component.html
@@ -1,6 +1,6 @@
 <div class="add-wrapper">
   <p class="text">{{ 'BANNERS.ADD_WORKSHOP' | translate }}</p>
-  <button class="btn" mat-raised-button [disabled]="hasUnfinishedWorkshopData$ | async" [routerLink]="['/create', ModeConstants.NEW]">
+  <button class="btn" mat-raised-button [disabled]="hasUnfinishedWorkshopData$ | async" [routerLink]="['/create/workshop', ModeConstants.NEW]">
     {{ 'BUTTONS.ADD_WORKSHOP' | translate }}
   </button>
 </div>

--- a/src/app/shell/personal-cabinet/provider/provider.module.ts
+++ b/src/app/shell/personal-cabinet/provider/provider.module.ts
@@ -39,6 +39,7 @@ import { CreatePositionFormComponent } from './create-position/position-form/cre
 import { ProviderEmployeesComponent } from './provider-employees/provider-employees.component';
 import { CreateCompetitionComponent } from './create-competition/create-competition.component';
 import { CreateRequiredFormComponent } from './create-competition/create-required-form/create-required-form.component';
+// eslint-disable-next-line max-len
 import { CreateCompetitionDescriptionFormComponent } from './create-competition/create-competition-description-form/create-competition-description-form.component';
 import { CreateJudgeComponent } from './create-competition/create-judge/create-judge.component';
 import { JudgeFormComponent } from './create-competition/create-judge/judge-form/judge-form.component';
@@ -64,8 +65,8 @@ import { CompetitionDraftsComponent } from './provider-drafts/competition-drafts
     EmployeesComponent,
     ProviderApplicationsComponent,
     ProviderWorkshopsComponent,
-    ProviderDraftsComponent,
     WorkshopDraftsComponent,
+    ProviderDraftsComponent,
     CompetitionDraftsComponent,
     WorkingHoursFormWrapperComponent,
     ProviderEmployeesUploadComponent,

--- a/src/app/shell/personal-cabinet/provider/provider.module.ts
+++ b/src/app/shell/personal-cabinet/provider/provider.module.ts
@@ -44,6 +44,8 @@ import { CreateJudgeComponent } from './create-competition/create-judge/create-j
 import { JudgeFormComponent } from './create-competition/create-judge/judge-form/judge-form.component';
 import { ProviderCompetitionComponent } from './provider-competition/provider-competition.component';
 import { ProviderDraftsComponent } from './provider-drafts/provider-drafts.component';
+import { WorkshopDraftsComponent } from './provider-drafts/workshop-drafts/workshop-drafts.component';
+import { CompetitionDraftsComponent } from './provider-drafts/competition-drafts/competition-drafts.component';
 
 @NgModule({
   declarations: [
@@ -63,6 +65,8 @@ import { ProviderDraftsComponent } from './provider-drafts/provider-drafts.compo
     ProviderApplicationsComponent,
     ProviderWorkshopsComponent,
     ProviderDraftsComponent,
+    WorkshopDraftsComponent,
+    CompetitionDraftsComponent,
     WorkingHoursFormWrapperComponent,
     ProviderEmployeesUploadComponent,
     ProviderStudySubjectsComponent,

--- a/src/app/shell/shell-routing.module.ts
+++ b/src/app/shell/shell-routing.module.ts
@@ -93,14 +93,14 @@ const routes: Routes = [
     loadChildren: () => import('./details/details.module').then((m) => m.DetailsModule)
   },
   {
-    path: 'create/:param',
+    path: 'create/workshop/:param',
     component: CreateWorkshopComponent,
     loadChildren: () => import('./personal-cabinet/provider/provider.module').then((m) => m.ProviderModule),
     canLoad: [ProviderGuard],
     canDeactivate: [CreateGuard]
   },
   {
-    path: 'create/:entity/:param',
+    path: 'create/workshop/:entity/:param',
     component: CreateWorkshopComponent,
     loadChildren: () => import('./personal-cabinet/provider/provider.module').then((m) => m.ProviderModule),
     canLoad: [ProviderGuard],
@@ -205,14 +205,21 @@ const routes: Routes = [
   },
   { path: 'server-error', component: ServerErrorPageComponent },
   {
-    path: 'create-competition/:entity/:param',
+    path: 'create/competition/:param',
     component: CreateCompetitionComponent,
     loadChildren: () => import('./personal-cabinet/provider/provider.module').then((m) => m.ProviderModule),
     canLoad: [ProviderGuard],
     canDeactivate: [CreateGuard]
   },
   {
-    path: 'create-competition/:entity/:id/:param',
+    path: 'create/competition/:entity/:param',
+    component: CreateCompetitionComponent,
+    loadChildren: () => import('./personal-cabinet/provider/provider.module').then((m) => m.ProviderModule),
+    canLoad: [ProviderGuard],
+    canDeactivate: [CreateGuard]
+  },
+  {
+    path: 'create/competition/:entity/:id/:param',
     component: CreateCompetitionComponent,
     loadChildren: () => import('./personal-cabinet/provider/provider.module').then((m) => m.ProviderModule),
     canLoad: [ProviderGuard],

--- a/src/app/shell/shell-routing.module.ts
+++ b/src/app/shell/shell-routing.module.ts
@@ -205,14 +205,14 @@ const routes: Routes = [
   },
   { path: 'server-error', component: ServerErrorPageComponent },
   {
-    path: 'create-competition/:param',
+    path: 'create-competition/:entity/:param',
     component: CreateCompetitionComponent,
     loadChildren: () => import('./personal-cabinet/provider/provider.module').then((m) => m.ProviderModule),
     canLoad: [ProviderGuard],
     canDeactivate: [CreateGuard]
   },
   {
-    path: 'create-competition/:id/:param',
+    path: 'create-competition/:entity/:id/:param',
     component: CreateCompetitionComponent,
     loadChildren: () => import('./personal-cabinet/provider/provider.module').then((m) => m.ProviderModule),
     canLoad: [ProviderGuard],

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -141,6 +141,7 @@
       "PORTAL": "Портал",
       "PROVIDERS": "Заклади",
       "WORKSHOPS": "Гуртки",
+      "COMPETITIONS": "Конкурси",
       "SEARCH_RESULT": "Результати пошуку",
       "SUPPORT": "Підтримка",
       "USERS": "Користувачі",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider cabinet: separate Workshop and Competition draft views with lists, pagination and draft actions (publish/send for moderation, delete).
  * Competition/workshop cards and details: show draft status, moderator messages, provider stats and publish/stop actions.

* **Enhancements**
  * Creation routes updated to /create/workshop and /create/competition; details for drafts use /details/workshop-draft and /details/competition-draft.
  * Competition creation now supports images and limits background image upload to 1.
  * Edit screens show moderation-warning banners when relevant.

* **Accessibility**
  * Keyboard support for card edit/delete actions.

* **Style**
  * New draft and rejection styles and consistent tab heights.

* **Bug Fixes**
  * Validators handle empty values gracefully; improved image handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->