### PR TITLE
Smyk / Fix workshop editing with images

### DIFF
--- a/src/app/shared/components/image-form-control/image-form-control.component.ts
+++ b/src/app/shared/components/image-form-control/image-form-control.component.ts
@@ -191,7 +191,6 @@ export class ImageFormControlComponent implements OnInit, ControlValueAccessor, 
 
   private removeImage(img: DecodedImage): void {
     const imageIndex = this.decodedImages.indexOf(img);
-
     if (this.moderatorDeleteFlow) {
       const indexOfDivider = this.decodedImages[imageIndex].image.split('/').indexOf('outofschool');
       const imageToDelete = this.decodedImages[imageIndex].image
@@ -213,6 +212,7 @@ export class ImageFormControlComponent implements OnInit, ControlValueAccessor, 
 
       this.onChange(this.selectedImages);
       this.updateImageIdsFormControl(imageIdToRemove);
+      this.deleteImage.emit();
       this.markAsTouched();
     }
   }

--- a/src/app/shared/components/validation-hint/validation-hint.component.ts
+++ b/src/app/shared/components/validation-hint/validation-hint.component.ts
@@ -55,6 +55,7 @@ export class ValidationHintComponent implements OnInit, OnDestroy, OnChanges {
   @Input() public isNumberValue: boolean;
   @Input() public minValue: number;
   @Input() public maxValue: number;
+  @Input() public isAge: boolean;
 
   // For price validation
   @Input() public isPrice: boolean;
@@ -326,7 +327,7 @@ export class ValidationHintComponent implements OnInit, OnDestroy, OnChanges {
   private checkFormLevelValidationErrors(errors: ValidationErrors): void {
     const errorConditions = [
       {
-        condition: (): boolean => errors?.invalidAgeRange,
+        condition: (): boolean => this.isAge && errors?.invalidAgeRange,
         message: ValidationMessages.INVALID_AGE_RANGE
       },
       {
@@ -336,6 +337,14 @@ export class ValidationHintComponent implements OnInit, OnDestroy, OnChanges {
       {
         condition: (): boolean => errors?.invalidDateRange,
         message: ValidationMessages.INVALID_START_END_DATE
+      },
+      {
+        condition: (): boolean => this.isImage && errors?.imageControlError && this.minImages === this.maxImages,
+        message: ValidationMessages.IMAGE_AMOUNT_SHOULD_BE
+      },
+      {
+        condition: (): boolean => this.isImage && errors?.imageControlError && this.minImages < this.maxImages,
+        message: ValidationMessages.IMAGE_AMOUNT_SHOULD_BE_FROM_TO
       }
     ];
 

--- a/src/app/shared/models/workshop.model.ts
+++ b/src/app/shared/models/workshop.model.ts
@@ -19,7 +19,7 @@ export abstract class WorkshopBase {
   studyPeriodDates: StudyPeriodDates;
   dateTimeRanges: DateTimeRanges[];
   isPaid: boolean;
-  price: number;
+  price: number | string;
   payRate: PayRateType;
   formOfLearning: FormOfLearning;
   availableSeats: number;

--- a/src/app/shared/services/workshops/user-workshop/user-workshop.service.ts
+++ b/src/app/shared/services/workshops/user-workshop/user-workshop.service.ts
@@ -250,6 +250,10 @@ export class UserWorkshopService {
     const imageFiles = ['imageFiles', 'coverImage'];
     const skipNullKeys = ['maxAge', 'minAge'];
 
+    if (workshop.price) {
+      workshop.price = workshop.price.toString().replace('.', ',');
+    }
+
     Object.keys(workshop).forEach((key: string) => {
       if (workshop[key]) {
         if (imageFiles.includes(key)) {

--- a/src/app/shared/validators/image-control-validator.spec.ts
+++ b/src/app/shared/validators/image-control-validator.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FormControl, FormGroup } from '@angular/forms';
+import { ImageControlValidator } from './image-control-validator';
+
+describe('ImageControlValidator', () => {
+  const validator = ImageControlValidator('coverImage', 'imageUrl');
+
+  let formGroup: FormGroup;
+
+  beforeEach(() => {
+    formGroup = new FormGroup({
+      coverImage: new FormControl([]),
+      imageUrl: new FormControl('')
+    });
+
+    // Attach validator to the group
+    formGroup.setValidators(validator);
+  });
+
+  it('should be created', () => {
+    expect(validator).toBeTruthy();
+  });
+
+  it('should return error when both fields are empty and coverImage is touched', () => {
+    formGroup.get('coverImage')?.markAsTouched();
+    formGroup.get('coverImage')?.setValue([]);
+    formGroup.get('imageUrl')?.setValue('');
+
+    expect(validator(formGroup)).toEqual({ imageControlError: true });
+  });
+
+  it('should be valid if coverImage is filled', () => {
+    formGroup.get('coverImage')?.markAsTouched();
+    formGroup.get('coverImage')?.setValue(['image.png']);
+    formGroup.get('imageUrl')?.setValue('');
+
+    expect(validator(formGroup)).toBeNull();
+  });
+
+  it('should be valid if imageUrl is filled', () => {
+    formGroup.get('coverImage')?.markAsTouched();
+    formGroup.get('coverImage')?.setValue([]);
+    formGroup.get('imageUrl')?.setValue('http://example.com/image.jpg');
+
+    expect(validator(formGroup)).toBeNull();
+  });
+
+  it('should be valid if both fields are filled', () => {
+    formGroup.get('coverImage')?.markAsTouched();
+    formGroup.get('coverImage')?.setValue(['image.png']);
+    formGroup.get('imageUrl')?.setValue('http://example.com/image.jpg');
+
+    expect(validator(formGroup)).toBeNull();
+  });
+
+  it('should be valid if both are empty but coverImage is not touched', () => {
+    formGroup.get('coverImage')?.markAsUntouched();
+    formGroup.get('coverImage')?.setValue([]);
+    formGroup.get('imageUrl')?.setValue('');
+
+    expect(validator(formGroup)).toBeNull();
+  });
+});

--- a/src/app/shared/validators/image-control-validator.ts
+++ b/src/app/shared/validators/image-control-validator.ts
@@ -1,0 +1,17 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export function ImageControlValidator(field1: string, field2: string): ValidatorFn {
+  return (group: AbstractControl): ValidationErrors | null => {
+    const field1Value = group.get(field1)?.value;
+    const field2Value = group.get(field2)?.value;
+
+    const isField1Empty = !field1Value || (Array.isArray(field1Value) && field1Value.length === 0);
+    const isField2Empty = field2Value.length === 0;
+
+    if (isField1Empty && isField2Empty && group.get(field1)?.touched) {
+      return { imageControlError: true };
+    }
+
+    return null;
+  };
+}

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
@@ -5,9 +5,10 @@
     [cropperConfig]="cropperConfig"
     [label]="'FORMS.LABELS.COVER_IMAGE' | translate"
     formControlName="coverImage"
-    [imageIdsFormControl]="AboutFormGroup.get('coverImageId')">
+    [imageIdsFormControl]="AboutFormGroup.get('coverImageId')"
+    (deleteImage)="onDeleteImage()">
   </app-image-form-control>
-  <app-validation-hint [validationFormControl]="AboutFormGroup.get('coverImage')" [isImage]="true" minImages="1" maxImages="1">
+  <app-validation-hint [validationFormControl]="AboutFormGroup" [formLevelValidation]="true" [isImage]="true" minImages="1" maxImages="1">
   </app-validation-hint>
 
   <label class="step-label">{{ 'FORMS.LABELS.TITLE' | translate }}<span class="step-required">*</span></label>
@@ -66,7 +67,7 @@
             isNumberValue="true"
             [minValue]="validationConstants.AGE_MIN"
             [maxValue]="validationConstants.BIRTH_AGE_MAX"></app-validation-hint>
-          <app-validation-hint formLevelValidation="true" [validationFormControl]="AboutFormGroup"></app-validation-hint>
+          <app-validation-hint isAge="true" formLevelValidation="true" [validationFormControl]="AboutFormGroup"></app-validation-hint>
         </div>
         <app-validation-hint
           class="w-[300px] ml-4"

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
@@ -26,6 +26,7 @@ import { MetaDataState } from 'shared/store/meta-data.state';
 import { LanguageListItem } from 'shared/models/language-list.model';
 import { GetLanguageList } from 'shared/store/meta-data.actions';
 import { maxArrayLength, minArrayLength } from 'shared/validators/array-length/array-length-validator';
+import { ImageControlValidator } from 'shared/validators/image-control-validator';
 
 @Component({
   selector: 'app-create-about-form',
@@ -66,6 +67,7 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
 
   public AboutFormGroup: FormGroup;
   public dateTimeRangesArray: FormArray = new FormArray([], [Validators.required]);
+  public coverImageControl: FormControl = new FormControl('', [Validators.required, minArrayLength(1), maxArrayLength(1)]);
   public useProviderInfoCtrl: FormControl = new FormControl(false);
   public availableSeatsRadioBtnControl: FormControl = new FormControl(true);
   public isShowHintAboutWorkshopAutoClosing: boolean = false;
@@ -168,6 +170,16 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
     if (this.route.snapshot.paramMap.get('entity') === 'workshop') {
       this.listenToChanges();
     }
+
+    this.coverImageControl.clearValidators();
+  }
+
+  public onDeleteImage(): void {
+    if (this.workshop) {
+      this.coverImageControl.addValidators([Validators.required, minArrayLength(1), maxArrayLength(1)]);
+      this.coverImageControl.markAsTouched();
+      this.coverImageControl.updateValueAndValidity();
+    }
   }
 
   private initForm(): void {
@@ -208,7 +220,7 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
         dateTimeRanges: this.dateTimeRangesArray,
         languageOfEducationId: new FormControl(null, Validators.required),
         formOfLearning: new FormControl(FormOfLearning.Offline, [Validators.required]),
-        coverImage: new FormControl('', [Validators.required, minArrayLength(1), maxArrayLength(1)]),
+        coverImage: this.coverImageControl,
         coverImageId: new FormControl(''),
         availableSeats: new FormControl(
           {
@@ -219,7 +231,7 @@ export class CreateAboutFormComponent implements OnInit, OnDestroy {
         )
       },
       {
-        validators: [AgeRangeValidator('minAge', 'maxAge')]
+        validators: [AgeRangeValidator('minAge', 'maxAge'), ImageControlValidator('coverImage', 'coverImageId')]
       }
     );
   }

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-additional-about-form/create-additional-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-additional-about-form/create-additional-about-form.component.ts
@@ -74,7 +74,7 @@ export class CreateAdditionalAboutFormComponent implements OnInit, OnDestroy {
   }
 
   private get workshopPrice(): number {
-    return this.workshop?.price ? this.workshop.price : null;
+    return this.workshop?.price ? (this.workshop.price as number) : null;
   }
 
   public onInstitutionSubordinationChange(isMinSport: boolean): void {
@@ -194,7 +194,7 @@ export class CreateAdditionalAboutFormComponent implements OnInit, OnDestroy {
 
   private handlePriceChange(): void {
     if (this.workshop.price) {
-      this.setPriceControlValue(this.workshop.price, 'enable', false);
+      this.setPriceControlValue(this.workshop.price as number, 'enable', false);
       this.setPayRateControlValue(this.workshop.payRate, 'enable', false);
       this.priceRadioBtn.setValue(true);
     } else {

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.html
@@ -5,9 +5,15 @@
     [cropperConfig]="cropperConfig"
     [label]="'Фотографії'"
     formControlName="imageFiles"
-    [imageIdsFormControl]="DescriptionFormGroup.get('imageIds')">
+    [imageIdsFormControl]="DescriptionFormGroup.get('imageIds')"
+    (deleteImage)="onImageDelete()">
   </app-image-form-control>
-  <app-validation-hint [validationFormControl]="DescriptionFormGroup.get('imageFiles')" [isImage]="true" minImages="1" maxImages="10">
+  <app-validation-hint
+    formLevelValidation="true"
+    [validationFormControl]="DescriptionFormGroup"
+    [isImage]="true"
+    minImages="1"
+    maxImages="10">
   </app-validation-hint>
 
   <span class="font-semibold inline-block mt-2">

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
@@ -31,6 +31,7 @@ import { Store } from '@ngxs/store';
 import { TranslateService } from '@ngx-translate/core';
 import { ActivatedRoute } from '@angular/router';
 import { MetaDataState } from 'shared/store/meta-data.state';
+import { ImageControlValidator } from 'shared/validators/image-control-validator';
 
 @Component({
   selector: 'app-create-description-form',
@@ -70,6 +71,7 @@ export class CreateDescriptionFormComponent implements OnInit, OnDestroy, AfterV
   public EditFormGroup: FormGroup;
   public SectionItemsFormArray = new FormArray([]);
   public keyWordsCtrl: FormControl = new FormControl('');
+  public imageFilesControl: FormControl = new FormControl('', [Validators.required, minArrayLength(1), maxArrayLength(10)]);
 
   public isTagsFeatureEnabled: boolean = false;
   public keyWords: string[] = [];
@@ -89,23 +91,28 @@ export class CreateDescriptionFormComponent implements OnInit, OnDestroy, AfterV
     private readonly translateService: TranslateService,
     private readonly route: ActivatedRoute
   ) {
-    this.DescriptionFormGroup = this.formBuilder.group({
-      imageFiles: new FormControl('', [Validators.required, minArrayLength(1), maxArrayLength(10)]),
-      imageIds: new FormControl(''),
-      keyWords: new FormControl(null),
-      workshopDescriptionItems: this.SectionItemsFormArray,
-      competitiveSelection: new FormControl(false),
-      competitiveSelectionDescription: new FormControl({ value: '', disabled: true }, [
-        Validators.required,
-        Validators.pattern(MUST_CONTAIN_LETTERS)
-      ]),
-      enrollmentProcedureDescription: new FormControl('', [
-        Validators.minLength(ValidationConstants.INPUT_LENGTH_1),
-        Validators.maxLength(ValidationConstants.INPUT_LENGTH_2000),
-        Validators.pattern(MUST_CONTAIN_LETTERS)
-      ]),
-      coverage: new FormControl(this.Coverage.School)
-    });
+    this.DescriptionFormGroup = this.formBuilder.group(
+      {
+        imageFiles: this.imageFilesControl,
+        imageIds: new FormControl(''),
+        keyWords: new FormControl(null),
+        workshopDescriptionItems: this.SectionItemsFormArray,
+        competitiveSelection: new FormControl(false),
+        competitiveSelectionDescription: new FormControl({ value: '', disabled: true }, [
+          Validators.required,
+          Validators.pattern(MUST_CONTAIN_LETTERS)
+        ]),
+        enrollmentProcedureDescription: new FormControl('', [
+          Validators.minLength(ValidationConstants.INPUT_LENGTH_1),
+          Validators.maxLength(ValidationConstants.INPUT_LENGTH_2000),
+          Validators.pattern(MUST_CONTAIN_LETTERS)
+        ]),
+        coverage: new FormControl(this.Coverage.School)
+      },
+      {
+        validators: [ImageControlValidator('imageFiles', 'imageIds')]
+      }
+    );
   }
 
   public compareItems(item1: Direction, item2: Direction): boolean {
@@ -237,6 +244,18 @@ export class CreateDescriptionFormComponent implements OnInit, OnDestroy, AfterV
 
     if (this.route.snapshot.paramMap.get('entity') === 'workshop') {
       this.listenToChanges();
+    }
+
+    this.DescriptionFormGroup.updateValueAndValidity();
+
+    this.imageFilesControl.clearValidators();
+  }
+
+  public onImageDelete(): void {
+    if (this.workshop) {
+      this.imageFilesControl.addValidators([Validators.required, minArrayLength(1), maxArrayLength(10)]);
+      this.imageFilesControl.markAsTouched();
+      this.imageFilesControl.updateValueAndValidity();
     }
   }
 


### PR DESCRIPTION
Made at least 1 image required for about and description form groups. Created new validator to require one of '...image' and '...imageId' fields have at least 1 image. Added new conditions for validation hints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced advanced validation for image and age fields, including new form-level validation messages and custom validators for image controls.
  * Added event handling for image deletion in workshop creation forms.

* **Improvements**
  * Enhanced flexibility for workshop pricing by allowing the price field to accept both numbers and strings.
  * Improved form validation flow, enabling dynamic validator management when editing or deleting images.

* **Bug Fixes**
  * Adjusted validation hint logic to ensure error messages display only when relevant (e.g., age-related errors shown only for age fields).

* **Tests**
  * Added comprehensive unit tests for custom image control validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->