### PR TITLE
Spelina/#3056 fixed wrong translate key for competition details

### DIFF
--- a/src/app/shell/details/details-tabs/competition-about/competition-about.component.html
+++ b/src/app/shell/details/details-tabs/competition-about/competition-about.component.html
@@ -1,6 +1,6 @@
 <div class="wrapper">
   <ng-container *ngIf="competition.competitiveEventDescriptionItems?.length">
-    <h5 class="title">{{ 'TITLES.ABOUT_THE_WORKSHOP' | translate }}</h5>
+    <h5 class="title">{{ 'TITLES.ABOUT_THE_COMPETITION' | translate }}</h5>
     <div *ngFor="let item of competition.competitiveEventDescriptionItems" class="config-wrapper">
       <h5 class="section-title">{{ item.sectionName }}</h5>
       <p class="line-break">{{ item.description }}</p>


### PR DESCRIPTION
#3056 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated a heading to display "About the Competition" instead of "About the Workshop" in the competition details section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->