### PR TITLE
Smyk / 3070 Vertical spacing between the workshop and price card is not static

### DIFF
--- a/src/app/shell/details/details.component.html
+++ b/src/app/shell/details/details.component.html
@@ -1,4 +1,4 @@
-<div class="details-container flex flex-col gap-0 justify-between items-stretch box-border">
+<div class="details-container flex flex-col gap-0 justify-start items-stretch box-border">
   <ng-container *ngIf="workshop; then WorkshopDetails; else CompetitionDetails"></ng-container>
   <app-side-menu
     *ngIf="provider && displayActionCard"

--- a/src/app/shell/details/details.component.scss
+++ b/src/app/shell/details/details.component.scss
@@ -19,5 +19,4 @@
 
 .workshop-page-wrap {
   overflow: hidden;
-  width: 100%;
 }


### PR DESCRIPTION
Changed justify to between and removed width: 100% for .workshop-page-wrap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted vertical alignment in the Details view from spaced-out to start-aligned, improving content grouping and readability.
  * Removed forced full-width from the Details page wrapper to allow natural sizing, enhancing responsive behavior across screen sizes.
  * Maintained overflow handling to prevent visual spillover while refining layout balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->