### PR TITLE
Spelina/fixed settlement selection and proper handling of keyboard input

### DIFF
--- a/src/app/shell/personal-cabinet/provider/create-address-form/create-address-form.component.spec.ts
+++ b/src/app/shell/personal-cabinet/provider/create-address-form/create-address-form.component.spec.ts
@@ -11,6 +11,7 @@ import { NgxsModule, Store } from '@ngxs/store';
 
 import { CodeficatorCategories } from 'shared/enum/codeficator-categories';
 import { ClearCodeficatorSearch } from 'shared/store/meta-data.actions';
+import { Address } from 'shared/models/address.model';
 import { CreateAddressFormComponent } from './create-address-form.component';
 
 describe('CreateAddressFormComponent', () => {
@@ -64,7 +65,7 @@ describe('CreateAddressFormComponent', () => {
         longitude: 0,
         fullName: ''
       }
-    };
+    } as Address;
     store = TestBed.inject(Store);
     fixture.detectChanges();
   });
@@ -81,17 +82,6 @@ describe('CreateAddressFormComponent', () => {
     expect(component.settlementSearchFormControl.value).toBeNull();
     expect(component.codeficatorIdFormControl.value).toBeNull();
     expect(component.settlementFormControl.value).toBeNull();
-  });
-
-  it('should not clear form controls on focus out when no value is selected if autocomplete is open', () => {
-    component.settlementSearchFormControl.setValue({ settlement: 'Test Settlement Search' }, { emitEvent: false });
-    component.settlementFormControl.setValue({ settlement: 'Test Settlement' }, { emitEvent: false });
-    component.autocomplete.options = { first: { value: null } } as any;
-    component.autocomplete._isOpen = true;
-
-    component.onFocusOut();
-
-    expect(component.settlementSearchFormControl.value).toEqual(component.settlementFormControl.value.settlement);
   });
 
   it('should update form controls on selecting a settlement', () => {

--- a/src/app/shell/personal-cabinet/provider/create-address-form/create-address-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-address-form/create-address-form.component.ts
@@ -3,7 +3,7 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { MatAutocomplete, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { Select, Store } from '@ngxs/store';
 import { Observable, Subject } from 'rxjs';
-import { debounceTime, delayWhen, distinctUntilChanged, filter, takeUntil, tap } from 'rxjs/operators';
+import { debounceTime, delayWhen, distinctUntilChanged, filter, takeUntil } from 'rxjs/operators';
 
 import { Constants } from 'shared/constants/constants';
 import { ValidationConstants } from 'shared/constants/validation';
@@ -11,6 +11,7 @@ import { Address } from 'shared/models/address.model';
 import { Codeficator } from 'shared/models/codeficator.model';
 import { ClearCodeficatorSearch, GetCodeficatorSearch } from 'shared/store/meta-data.actions';
 import { MetaDataState } from 'shared/store/meta-data.state';
+import { Util } from 'shared/utils/utils';
 
 @Component({
   selector: 'app-create-address-form',
@@ -62,7 +63,7 @@ export class CreateAddressFormComponent implements OnInit {
 
   /**
    * This method handle displayed value for mat-autocomplete dropdown
-   * @param codeficator: Codeficator | string
+   * @param codeficator
    */
   public displaySettlementNameFn(codeficator: Codeficator | string): string {
     return typeof codeficator === 'string' ? codeficator : codeficator?.settlement;
@@ -77,13 +78,23 @@ export class CreateAddressFormComponent implements OnInit {
     if (
       !this.settlementSearchFormControl.value ||
       codeficator?.settlement === Constants.NO_SETTLEMENT ||
-      this.settlementSearchFormControl.invalid
+      this.settlementSearchFormControl.invalid ||
+      this.settlementSearchFormControl.value.toLowerCase() !== codeficator.settlement.toLowerCase()
     ) {
       this.settlementSearchFormControl.setValue(null);
       this.codeficatorIdFormControl.setValue(null);
       this.settlementFormControl.setValue(null);
+      this.clearStreetAndBuildingNumber();
     } else if (!this.autocomplete.isOpen) {
       this.settlementSearchFormControl.setValue(this.settlementFormControl.value.settlement, { emitEvent: false });
+    } else if (this.settlementSearchFormControl.value.toLowerCase() === codeficator.settlement.toLowerCase()) {
+      this.settlementSearchFormControl.setValue(codeficator.settlement);
+      const { fullAddress, ...prev } = this.settlementFormControl.value || {};
+      this.settlementFormControl.patchValue(codeficator, { emitEvent: false });
+      if (!Util.deepEqual(prev, codeficator)) {
+        this.settlementFormControl.patchValue(codeficator, { emitEvent: false });
+        this.clearStreetAndBuildingNumber();
+      }
     }
   }
 
@@ -92,26 +103,36 @@ export class CreateAddressFormComponent implements OnInit {
    * @param event MatAutocompleteSelectedEvent
    */
   public onSelectSettlement(event: MatAutocompleteSelectedEvent): void {
-    this.settlementSearchFormControl.setValue(event.option.value.settlement, { emitEvent: false });
-    this.settlementFormControl.setValue(event.option.value, { emitEvent: false });
+    const selected = event.option.value;
+    const { fullAddress, ...prev } = this.settlementFormControl.value || {};
 
-    this.codeficatorIdFormControl.reset();
-    this.codeficatorIdFormControl.setValue(event.option.value.id);
+    if (!Util.deepEqual(prev, selected)) {
+      this.settlementFormControl.patchValue(selected, { emitEvent: false });
 
-    this.addressFormGroup.patchValue({
-      latitude: event.option.value.latitude,
-      longitude: event.option.value.longitude
-    });
+      this.codeficatorIdFormControl.reset();
+      this.codeficatorIdFormControl.setValue(selected.id);
 
-    if (!this.addressFormGroup.dirty) {
-      this.addressFormGroup.markAsDirty({ onlySelf: true });
+      this.clearStreetAndBuildingNumber();
+      this.addressFormGroup.patchValue({
+        latitude: selected.latitude,
+        longitude: selected.longitude
+      });
+
+      if (!this.addressFormGroup.dirty) {
+        this.addressFormGroup.markAsDirty({ onlySelf: true });
+      }
     }
+
+    this.settlementSearchFormControl.patchValue(selected.settlement, { emitEvent: false });
   }
 
   private activateEditMode(): void {
     if (this.address) {
       this.addressFormGroup.patchValue({ ...this.address }, { emitEvent: false, onlySelf: true });
-      this.settlementSearchFormControl.patchValue(this.address.codeficatorAddress?.settlement, { emitEvent: false, onlySelf: true });
+      this.settlementSearchFormControl.patchValue(this.address.codeficatorAddress?.settlement, {
+        emitEvent: false,
+        onlySelf: true
+      });
       this.settlementFormControl.patchValue(this.address.codeficatorAddress, { emitEvent: false, onlySelf: true });
       this.store.dispatch(new ClearCodeficatorSearch());
     }
@@ -126,13 +147,6 @@ export class CreateAddressFormComponent implements OnInit {
         debounceTime(500),
         distinctUntilChanged(),
         takeUntil(this.destroy$),
-        tap((value: string) => {
-          if (!value?.length || this.settlementSearchFormControl.invalid) {
-            this.store.dispatch(new ClearCodeficatorSearch());
-            this.streetFormControl.setValue('', { emitEvent: false });
-            this.buildingNumberFormControl.setValue('', { emitEvent: false });
-          }
-        }),
         filter((value: string) => value?.length > 2 && this.settlementSearchFormControl.valid),
         delayWhen((value: string) => this.store.dispatch(new GetCodeficatorSearch(value)))
       )
@@ -147,5 +161,12 @@ export class CreateAddressFormComponent implements OnInit {
           });
         }
       });
+  }
+
+  private clearStreetAndBuildingNumber(): void {
+    this.streetFormControl.setValue(null, { emitEvent: false });
+    this.streetFormControl.markAsUntouched();
+    this.buildingNumberFormControl.setValue(null, { emitEvent: false });
+    this.buildingNumberFormControl.markAsUntouched();
   }
 }

--- a/src/app/shell/personal-cabinet/provider/create-address-form/create-address-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-address-form/create-address-form.component.ts
@@ -1,9 +1,10 @@
 import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
+import { MatOption } from '@angular/material/core';
 import { MatAutocomplete, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { Select, Store } from '@ngxs/store';
 import { Observable, Subject } from 'rxjs';
-import { debounceTime, delayWhen, distinctUntilChanged, filter, takeUntil } from 'rxjs/operators';
+import { debounceTime, delayWhen, distinctUntilChanged, filter, takeUntil, tap } from 'rxjs/operators';
 
 import { Constants } from 'shared/constants/constants';
 import { ValidationConstants } from 'shared/constants/validation';
@@ -32,6 +33,7 @@ export class CreateAddressFormComponent implements OnInit {
   public readonly ValidationConstants = ValidationConstants;
   public readonly Constants = Constants;
 
+  private option: MatOption<Codeficator>;
   private destroy$: Subject<boolean> = new Subject<boolean>();
 
   constructor(private store: Store) {}
@@ -73,21 +75,20 @@ export class CreateAddressFormComponent implements OnInit {
    * This method listen input FocusOut event and update search and settlement controls value
    */
   public onFocusOut(): void {
-    const codeficator: Codeficator = this.autocomplete.options.first?.value;
+    const codeficator: Codeficator = this.autocomplete.options.first?.value || this.option;
+    const val = this.settlementSearchFormControl.value;
 
     if (
-      !this.settlementSearchFormControl.value ||
+      (!val && this.settlementSearchFormControl.invalid) ||
+      !codeficator ||
       codeficator?.settlement === Constants.NO_SETTLEMENT ||
-      this.settlementSearchFormControl.invalid ||
-      this.settlementSearchFormControl.value.toLowerCase() !== codeficator.settlement.toLowerCase()
+      val?.toLowerCase() !== codeficator.settlement.toLowerCase()
     ) {
       this.settlementSearchFormControl.setValue(null);
-      this.codeficatorIdFormControl.setValue(null);
       this.settlementFormControl.setValue(null);
+      this.codeficatorIdFormControl.setValue(null);
       this.clearStreetAndBuildingNumber();
-    } else if (!this.autocomplete.isOpen) {
-      this.settlementSearchFormControl.setValue(this.settlementFormControl.value.settlement, { emitEvent: false });
-    } else if (this.settlementSearchFormControl.value.toLowerCase() === codeficator.settlement.toLowerCase()) {
+    } else if (val?.toLowerCase() === codeficator?.settlement.toLowerCase()) {
       this.settlementSearchFormControl.setValue(codeficator.settlement);
       const { fullAddress, ...prev } = this.settlementFormControl.value || {};
       this.settlementFormControl.patchValue(codeficator, { emitEvent: false });
@@ -147,6 +148,11 @@ export class CreateAddressFormComponent implements OnInit {
         debounceTime(500),
         distinctUntilChanged(),
         takeUntil(this.destroy$),
+        tap((value: string) => {
+          if (!value?.length || this.settlementSearchFormControl.invalid) {
+            this.store.dispatch(new ClearCodeficatorSearch());
+          }
+        }),
         filter((value: string) => value?.length > 2 && this.settlementSearchFormControl.valid),
         delayWhen((value: string) => this.store.dispatch(new GetCodeficatorSearch(value)))
       )
@@ -159,6 +165,7 @@ export class CreateAddressFormComponent implements OnInit {
             latitude: settlement.value.latitude,
             longitude: settlement.value.longitude
           });
+          this.option = options[0].value;
         }
       });
   }


### PR DESCRIPTION
#3032 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Autocomplete falls back to the first available option when no explicit selection is present.

- Improvements
  - Case-insensitive settlement matching and deep-equality checks to avoid unnecessary form updates.
  - Coordinates auto-updated on settlement selection; form marked dirty only when data actually changes.
  - Introduced a helper to clear street/building fields and safer cached-option fallback.

- Bug Fixes
  - Clears settlement, street, and building only on invalid/mismatched input or on focus-out/selection (no clearing while typing).

- Tests
  - Specs adjusted: removed a focus-out preservation test and updated fixture typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->