### PR TITLE
Oliinyk / Planned schedule appears after pressing Enter in about form

### DIFF
--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/working-hours-form-wrapper/working-hours-form-wrapper.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/working-hours-form-wrapper/working-hours-form-wrapper.component.html
@@ -8,7 +8,7 @@
   </app-working-hours-form>
 </ng-container>
 <div class="add-hour flex flex-row justify-start items-center">
-  <button class="btn-add" mat-button (click)="addWorkingHours()" [disabled]="workingHoursFormArray.invalid">
+  <button class="btn-add" type="button" mat-button (click)="addWorkingHours()" [disabled]="workingHoursFormArray.invalid">
     <mat-icon class="mat-icon-add">add</mat-icon>{{ 'BUTTONS.ADD_MORE_LESSONS_SCHEDULE' | translate }}
   </button>
 </div>


### PR DESCRIPTION
#3085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents accidental form submission when clicking Add in the Working Hours section of the Create Workshop > About form within Personal Cabinet. The Add button now behaves correctly without submitting the entire form, allowing users to add entries without losing progress, reducing interruptions during setup, and improving overall form reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->