### PR TITLE
Spelina/[create-workshop] added custom calendar header without years for study subject selection and literal parsing

### DIFF
--- a/src/app/shared/components/calendar-month-header/month-only-header.component.html
+++ b/src/app/shared/components/calendar-month-header/month-only-header.component.html
@@ -1,5 +1,5 @@
 <div class="calendar-header">
-  <button mat-icon-button class="flex items-center justify-center prev" (click)="previousClicked('month')"></button>
+  <button mat-icon-button class="flex items-center justify-center prev" (click)="previousClicked()"></button>
   <span class="calendar-header-label">{{ periodLabel }}</span>
-  <button mat-icon-button class="flex items-center justify-center next" (click)="nextClicked('month')"></button>
+  <button mat-icon-button class="flex items-center justify-center next" (click)="nextClicked()"></button>
 </div>

--- a/src/app/shared/components/calendar-month-header/month-only-header.component.html
+++ b/src/app/shared/components/calendar-month-header/month-only-header.component.html
@@ -1,0 +1,5 @@
+<div class="calendar-header">
+  <button mat-icon-button class="flex items-center justify-center prev" (click)="previousClicked('month')"></button>
+  <span class="calendar-header-label">{{ periodLabel }}</span>
+  <button mat-icon-button class="flex items-center justify-center next" (click)="nextClicked('month')"></button>
+</div>

--- a/src/app/shared/components/calendar-month-header/month-only-header.component.scss
+++ b/src/app/shared/components/calendar-month-header/month-only-header.component.scss
@@ -1,0 +1,44 @@
+.calendar-header {
+  display: flex;
+  align-items: center;
+  height: 40px;
+  padding: 8px 8px 0 8px;
+}
+
+.calendar-header-label {
+  flex: 1;
+  font-weight: 500;
+  text-align: center;
+}
+
+button.mat-mdc-icon-button.mat-mdc-button-base {
+  height: 40px;
+  width: 40px;
+  padding: 8px;
+
+  color: var(--mat-datepicker-calendar-navigation-button-icon-color);
+}
+
+// copy of mat calendar buttons below
+.prev::after {
+  border-left-width: 2px !important;
+  transform: translateX(2px) rotate(-45deg);
+}
+
+.next::after {
+  border-right-width: 2px !important;
+  transform: translateX(-1px) rotate(45deg);
+}
+
+.prev::after,
+.next::after {
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  position: absolute;
+  content: '';
+  margin: 15.5px;
+  border: 0 solid currentColor;
+  border-top-width: 2px;
+}

--- a/src/app/shared/components/calendar-month-header/month-only-header.component.spec.ts
+++ b/src/app/shared/components/calendar-month-header/month-only-header.component.spec.ts
@@ -1,0 +1,80 @@
+import { ChangeDetectorRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MatCalendar } from '@angular/material/datepicker';
+import { DateAdapter, MAT_DATE_FORMATS, MatDateFormats } from '@angular/material/core';
+import { Subject } from 'rxjs';
+
+import { MonthOnlyHeaderComponent } from './month-only-header.component';
+
+describe('MonthOnlyHeaderComponent', () => {
+  let component: MonthOnlyHeaderComponent<Date>;
+  let mockCalendar: Partial<MatCalendar<Date>>;
+  let mockAdapter: Partial<DateAdapter<Date>>;
+  let mockFormats: MatDateFormats;
+  let mockCdr: Partial<ChangeDetectorRef>;
+
+  beforeEach(() => {
+    mockCalendar = {
+      activeDate: new Date(2025, 8, 1),
+      stateChanges: new Subject<void>()
+    };
+
+    mockAdapter = {
+      format: jest.fn((date: Date) => date.toDateString()),
+      addCalendarMonths: jest.fn((date: Date, months: number) => {
+        const newDate = new Date(date);
+        newDate.setMonth(newDate.getMonth() + months);
+        return newDate;
+      })
+    };
+
+    mockFormats = {
+      parse: { dateInput: 'LL' },
+      display: { monthYearLabel: 'MMM yyyy', dateInput: 'LL', monthYearA11yLabel: 'MMMM yyyy', dateA11yLabel: 'LL' }
+    };
+
+    mockCdr = { markForCheck: jest.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: MatCalendar, useValue: mockCalendar },
+        { provide: DateAdapter, useValue: mockAdapter },
+        { provide: MAT_DATE_FORMATS, useValue: mockFormats },
+        { provide: ChangeDetectorRef, useValue: mockCdr }
+      ]
+    });
+
+    component = new MonthOnlyHeaderComponent(
+      mockCalendar as MatCalendar<Date>,
+      mockAdapter as DateAdapter<Date>,
+      mockFormats,
+      mockCdr as ChangeDetectorRef
+    );
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('periodLabel should return upper case', () => {
+    (mockAdapter.format as jest.Mock).mockReturnValue('Sep 2025');
+    expect(component.periodLabel).toBe('SEP 2025');
+  });
+
+  it('previousClicked should reduce month by 1', () => {
+    const currentDate = mockCalendar.activeDate;
+    component.previousClicked();
+    expect(mockAdapter.addCalendarMonths).toHaveBeenCalledWith(currentDate, -1);
+  });
+
+  it('nextClicked should increase month by 1', () => {
+    const currentDate = mockCalendar.activeDate;
+    component.nextClicked();
+    expect(mockAdapter.addCalendarMonths).toHaveBeenCalledWith(currentDate, 1);
+  });
+
+  it('should call markForCheck if stateChanges fired', () => {
+    (mockCalendar.stateChanges as Subject<void>).next();
+    expect(mockCdr.markForCheck).toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/components/calendar-month-header/month-only-header.component.ts
+++ b/src/app/shared/components/calendar-month-header/month-only-header.component.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnDestroy } from '@angular/core';
+import { Subject } from 'rxjs';
+import { MatCalendar } from '@angular/material/datepicker';
+import { DateAdapter, MAT_DATE_FORMATS, MatDateFormats } from '@angular/material/core';
+import { takeUntil } from 'rxjs/operators';
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'calendar-header',
+  templateUrl: './month-only-header.component.html',
+  styleUrls: ['./month-only-header.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MonthOnlyHeaderComponent<D> implements OnDestroy {
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private _calendar: MatCalendar<D>,
+    private _dateAdapter: DateAdapter<D>,
+    @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
+    cdr: ChangeDetectorRef
+  ) {
+    _calendar.stateChanges.pipe(takeUntil(this.destroy$)).subscribe(() => cdr.markForCheck());
+  }
+
+  public get periodLabel(): string {
+    return this._dateAdapter.format(this._calendar.activeDate, this._dateFormats.display.monthYearLabel).toLocaleUpperCase();
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  public previousClicked(mode: string): void {
+    this._calendar.activeDate = this._dateAdapter.addCalendarMonths(this._calendar.activeDate, -1);
+  }
+
+  public nextClicked(mode: string): void {
+    this._calendar.activeDate = this._dateAdapter.addCalendarMonths(this._calendar.activeDate, 1);
+  }
+}

--- a/src/app/shared/components/calendar-month-header/month-only-header.component.ts
+++ b/src/app/shared/components/calendar-month-header/month-only-header.component.ts
@@ -15,16 +15,16 @@ export class MonthOnlyHeaderComponent<D> implements OnDestroy {
   private destroy$ = new Subject<void>();
 
   constructor(
-    private _calendar: MatCalendar<D>,
-    private _dateAdapter: DateAdapter<D>,
-    @Inject(MAT_DATE_FORMATS) private _dateFormats: MatDateFormats,
-    cdr: ChangeDetectorRef
+    private readonly calendar: MatCalendar<D>,
+    private readonly dateAdapter: DateAdapter<D>,
+    @Inject(MAT_DATE_FORMATS) private readonly dateFormats: MatDateFormats,
+    private cdr: ChangeDetectorRef
   ) {
-    _calendar.stateChanges.pipe(takeUntil(this.destroy$)).subscribe(() => cdr.markForCheck());
+    calendar.stateChanges.pipe(takeUntil(this.destroy$)).subscribe(() => this.cdr.markForCheck());
   }
 
   public get periodLabel(): string {
-    return this._dateAdapter.format(this._calendar.activeDate, this._dateFormats.display.monthYearLabel).toLocaleUpperCase();
+    return this.dateAdapter.format(this.calendar.activeDate, this.dateFormats.display.monthYearLabel).toLocaleUpperCase();
   }
 
   public ngOnDestroy(): void {
@@ -33,10 +33,10 @@ export class MonthOnlyHeaderComponent<D> implements OnDestroy {
   }
 
   public previousClicked(mode: string): void {
-    this._calendar.activeDate = this._dateAdapter.addCalendarMonths(this._calendar.activeDate, -1);
+    this.calendar.activeDate = this.dateAdapter.addCalendarMonths(this.calendar.activeDate, -1);
   }
 
   public nextClicked(mode: string): void {
-    this._calendar.activeDate = this._dateAdapter.addCalendarMonths(this._calendar.activeDate, 1);
+    this.calendar.activeDate = this.dateAdapter.addCalendarMonths(this.calendar.activeDate, 1);
   }
 }

--- a/src/app/shared/components/calendar-month-header/month-only-header.component.ts
+++ b/src/app/shared/components/calendar-month-header/month-only-header.component.ts
@@ -32,11 +32,11 @@ export class MonthOnlyHeaderComponent<D> implements OnDestroy {
     this.destroy$.complete();
   }
 
-  public previousClicked(mode: string): void {
+  public previousClicked(): void {
     this.calendar.activeDate = this.dateAdapter.addCalendarMonths(this.calendar.activeDate, -1);
   }
 
-  public nextClicked(mode: string): void {
+  public nextClicked(): void {
     this.calendar.activeDate = this.dateAdapter.addCalendarMonths(this.calendar.activeDate, 1);
   }
 }

--- a/src/app/shared/components/calendar-month-header/month-only-header.component.ts
+++ b/src/app/shared/components/calendar-month-header/month-only-header.component.ts
@@ -5,8 +5,6 @@ import { DateAdapter, MAT_DATE_FORMATS, MatDateFormats } from '@angular/material
 import { takeUntil } from 'rxjs/operators';
 
 @Component({
-  // eslint-disable-next-line @angular-eslint/component-selector
-  selector: 'calendar-header',
   templateUrl: './month-only-header.component.html',
   styleUrls: ['./month-only-header.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/shared/components/calendar-month-header/month-only-header.component.ts
+++ b/src/app/shared/components/calendar-month-header/month-only-header.component.ts
@@ -18,7 +18,7 @@ export class MonthOnlyHeaderComponent<D> implements OnDestroy {
     private readonly calendar: MatCalendar<D>,
     private readonly dateAdapter: DateAdapter<D>,
     @Inject(MAT_DATE_FORMATS) private readonly dateFormats: MatDateFormats,
-    private cdr: ChangeDetectorRef
+    private readonly cdr: ChangeDetectorRef
   ) {
     calendar.stateChanges.pipe(takeUntil(this.destroy$)).subscribe(() => this.cdr.markForCheck());
   }

--- a/src/app/shared/configs/study-period-dates.config.ts
+++ b/src/app/shared/configs/study-period-dates.config.ts
@@ -2,11 +2,11 @@ import { MatDateFormats } from '@angular/material/core';
 
 export const LOCAL_STUDY_PERIOD_DATE_FORMATS: MatDateFormats = {
   parse: {
-    dateInput: 'DD/MM/YYYY'
+    dateInput: ['DD/MMM', 'DD/MM']
   },
   display: {
-    dateInput: 'DD/MM',
-    monthYearLabel: 'MMM yyyy',
+    dateInput: 'DD/MMM',
+    monthYearLabel: 'MMM',
     dateA11yLabel: 'LL',
     monthYearA11yLabel: 'MMMM yyyy'
   }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -15,6 +15,7 @@ import { StepperDirective } from 'shared/directives/stepper/stepper.directive';
 import { DecimalNumberPipe } from 'shared/pipes/decimal-number.pipe';
 import { NumberArrowsDirective } from 'shared/directives/number-arrows/number-arrows.directive';
 import { SharedSearchbarComponent } from 'shared/components/filters-list/shared-searchbar/shared-searchbar.component';
+import { MonthOnlyHeaderComponent } from 'shared/components/calendar-month-header/month-only-header.component';
 import { AchievementCardComponent } from '../shell/details/details-tabs/achievements/achievement-card/achievement-card.component';
 import { RateComponent } from '../shell/details/details-tabs/reviews/rate/rate.component';
 import { StarsComponent } from '../shell/details/details-tabs/reviews/stars/stars.component';
@@ -187,7 +188,8 @@ import { DirectionTreeComponent } from './components/filters-list/direction-tree
     DecimalNumberPipe,
     ContactsCardComponent,
     NumberArrowsDirective,
-    DraftFiltersComponent
+    DraftFiltersComponent,
+    MonthOnlyHeaderComponent
   ],
 
   imports: [
@@ -285,7 +287,8 @@ import { DirectionTreeComponent } from './components/filters-list/direction-tree
     DecimalNumberPipe,
     ContactsCardComponent,
     NumberArrowsDirective,
-    DraftFiltersComponent
+    DraftFiltersComponent,
+    MonthOnlyHeaderComponent
   ]
 })
 export class SharedModule {}

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
@@ -121,7 +121,7 @@
               placeholder="{{ 'FORMS.PLACEHOLDERS.STUDY_PERIOD_DATE_FORMAT' | translate }}"
               class="text-center" />
             <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
-            <mat-datepicker #startPicker></mat-datepicker>
+            <mat-datepicker [calendarHeaderComponent]="MonthOnlyHeaderComponent" #startPicker></mat-datepicker>
           </mat-form-field>
         </div>
         <app-validation-hint [validationFormControl]="studyPeriodDates.get('startDate')" [errorMessagesMap]="errorMap">
@@ -141,7 +141,7 @@
               placeholder="{{ 'FORMS.PLACEHOLDERS.STUDY_PERIOD_DATE_FORMAT' | translate }}"
               class="text-center" />
             <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
-            <mat-datepicker #endPicker></mat-datepicker>
+            <mat-datepicker [calendarHeaderComponent]="MonthOnlyHeaderComponent" #endPicker></mat-datepicker>
           </mat-form-field>
         </div>
         <app-validation-hint [validationFormControl]="studyPeriodDates.get('endDate')" [errorMessagesMap]="errorMap"></app-validation-hint>

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
@@ -27,6 +27,7 @@ import { GetLanguageList } from 'shared/store/meta-data.actions';
 import { maxArrayLength, minArrayLength } from 'shared/validators/array-length/array-length-validator';
 import { ImageControlValidator } from 'shared/validators/image-control-validator';
 import { base64ToFile } from 'ngx-image-cropper';
+import { MonthOnlyHeaderComponent } from 'shared/components/calendar-month-header/month-only-header.component';
 import { FieldsListenerComponent } from '../../../shared-cabinet/create-form/fields-listener.component';
 
 @Component({
@@ -44,6 +45,7 @@ export class CreateAboutFormComponent extends FieldsListenerComponent implements
   @Input() public isImagesFeature: boolean;
   @Output() public PassAboutFormGroup = new EventEmitter();
 
+  public readonly MonthOnlyHeaderComponent = MonthOnlyHeaderComponent;
   public readonly validationConstants = ValidationConstants;
   public readonly MIN_SEATS = Constants.MIN_SEATS;
   public readonly UNLIMITED_SEATS = Constants.UNLIMITED_SEATS;

--- a/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.html
+++ b/src/app/shell/personal-cabinet/provider/provider-drafts/workshop-drafts/workshop-drafts.component.html
@@ -1,6 +1,10 @@
 <div class="add-wrapper">
   <p class="text">{{ 'BANNERS.ADD_WORKSHOP' | translate }}</p>
-  <button class="btn" mat-raised-button [disabled]="hasUnfinishedWorkshopData$ | async" [routerLink]="['/create', ModeConstants.NEW]">
+  <button
+    class="btn"
+    mat-raised-button
+    [disabled]="hasUnfinishedWorkshopData$ | async"
+    [routerLink]="['/create/workshop', ModeConstants.NEW]">
     {{ 'BUTTONS.ADD_WORKSHOP' | translate }}
   </button>
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a month-only calendar header for date pickers with previous/next navigation and an uppercase month label; exported via SharedModule and used in the Create Workshop form.
  * Updated date input/display formats to accept DD/MMM and DD/MM and to show short month (MMM).

* **Behavior**
  * “Add Workshop” button now navigates directly to the Create Workshop page.

* **Tests**
  * Added unit tests for header label, navigation, and change-detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->