### PR TITLE
Zhylka/ fix competition imageIds format

### DIFF
--- a/src/app/shared/services/competitions/user-competition.service.ts
+++ b/src/app/shared/services/competitions/user-competition.service.ts
@@ -159,7 +159,7 @@ export class UserCompetitionService {
   private createFormData(competition: Competition, draftId?: string): FormData {
     const preKey = draftId ? 'CompetitiveEventV2Dto.' : '';
     const formData = new FormData();
-    const formNames = ['contacts', 'competitiveEventDescriptionItems', 'judges', 'subDirectionIds'];
+    const formNames = ['contacts', 'competitiveEventDescriptionItems', 'judges', 'subDirectionIds', 'imageIds'];
     const imageFiles = ['imageFiles', 'coverImage'];
 
     Object.keys(competition).forEach((key: string) => {

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
@@ -249,8 +249,8 @@ export class CreateCompetitionDescriptionFormComponent extends FieldsListenerCom
 
   private initForm(): void {
     this.DescriptionFormGroup = this.formBuilder.group({
-      imageFiles: new FormControl('', [Validators.required, minArrayLength(1), maxArrayLength(10)]),
-      imageIds: new FormControl(''),
+      imageFiles: new FormControl([], [Validators.required, minArrayLength(1), maxArrayLength(10)]),
+      imageIds: new FormControl([]),
       directionId: new FormControl(null, Validators.required),
       subDirectionIds: new FormControl(null, Validators.required),
       coverageId: new FormControl(null, Validators.required),

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
@@ -119,6 +119,10 @@ export class CreateRequiredFormComponent extends FieldsListenerComponent impleme
   public activateEditMode(): void {
     this.RequiredFormGroup.patchValue(this.competition, { emitEvent: false });
 
+    if (this.competition.coverImageId) {
+      this.RequiredFormGroup.get('coverImageId').setValue([this.competition.coverImageId], { emitEvent: false });
+    }
+
     if (this.competition.scheduledStartTime) {
       this.minDate = new Date(
         new Date(this.competition.scheduledStartTime).setMonth(new Date(this.competition.scheduledStartTime).getMonth() - 1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Competition form submissions now include image IDs so selected images are preserved when sending data.
  * Image-related form controls are initialized as arrays to match validators and avoid validation or submission errors.
  * Edit mode now preselects the existing cover image so the previously chosen cover remains visible and editable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->