### PR TITLE
update title length to 120

### DIFF
--- a/src/app/shared/constants/validation.ts
+++ b/src/app/shared/constants/validation.ts
@@ -30,6 +30,7 @@ export class ValidationConstants {
   static readonly INPUT_LENGTH_30 = 30;
   static readonly INPUT_LENGTH_60 = 60;
   static readonly INPUT_LENGTH_100 = 100;
+  static readonly INPUT_LENGTH_120 = 120;
   static readonly INPUT_LENGTH_254 = 254;
   static readonly INPUT_LENGTH_256 = 256;
   static readonly INPUT_LENGTH_500 = 500;

--- a/src/app/shell/admin-tools/data/admin-competition-list/moderator-draft-competition-form/moderator-draft-competition-form.component.ts
+++ b/src/app/shell/admin-tools/data/admin-competition-list/moderator-draft-competition-form/moderator-draft-competition-form.component.ts
@@ -234,7 +234,7 @@ export class ModeratorDraftCompetitionFormComponent extends CreateFormComponent 
       title: new FormControl('', [
         Validators.required,
         Validators.minLength(ValidationConstants.INPUT_LENGTH_1),
-        Validators.maxLength(ValidationConstants.INPUT_LENGTH_60),
+        Validators.maxLength(ValidationConstants.INPUT_LENGTH_120),
         Validators.pattern(MUST_CONTAIN_LETTERS)
       ]),
       shortTitle: new FormControl('', [

--- a/src/app/shell/admin-tools/data/admin-workshop-list/moderator-draft-edit-form/moderator-draft-edit-form.component.html
+++ b/src/app/shell/admin-tools/data/admin-workshop-list/moderator-draft-edit-form/moderator-draft-edit-form.component.html
@@ -35,7 +35,7 @@
           <app-validation-hint
             [validationFormControl]="form.get('title')"
             [minCharacters]="validationConstants.INPUT_LENGTH_1"
-            [maxCharacters]="validationConstants.INPUT_LENGTH_60">
+            [maxCharacters]="validationConstants.INPUT_LENGTH_120">
           </app-validation-hint>
 
           <div class="flex flex-row justify-between items-center">

--- a/src/app/shell/admin-tools/data/admin-workshop-list/moderator-draft-edit-form/moderator-draft-edit-form.component.ts
+++ b/src/app/shell/admin-tools/data/admin-workshop-list/moderator-draft-edit-form/moderator-draft-edit-form.component.ts
@@ -232,7 +232,7 @@ export class ModeratorDraftEditFormComponent extends CreateFormComponent impleme
       title: new FormControl('', [
         Validators.required,
         Validators.minLength(ValidationConstants.INPUT_LENGTH_1),
-        Validators.maxLength(ValidationConstants.INPUT_LENGTH_60),
+        Validators.maxLength(ValidationConstants.INPUT_LENGTH_120),
         Validators.pattern(MUST_CONTAIN_LETTERS)
       ]),
       shortTitle: new FormControl('', [

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.html
@@ -18,7 +18,7 @@
   <app-validation-hint
     [validationFormControl]="RequiredFormGroup.get('title')"
     [minCharacters]="ValidationConstants.INPUT_LENGTH_1"
-    [maxCharacters]="ValidationConstants.INPUT_LENGTH_60">
+    [maxCharacters]="ValidationConstants.INPUT_LENGTH_120">
   </app-validation-hint>
 
   <label class="step-label">{{ 'FORMS.LABELS.SHORT_TITLE' | translate }}<span class="step-required">*</span></label>

--- a/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-required-form/create-required-form.component.ts
@@ -186,7 +186,7 @@ export class CreateRequiredFormComponent extends FieldsListenerComponent impleme
         title: new FormControl('', [
           Validators.required,
           Validators.minLength(ValidationConstants.INPUT_LENGTH_1),
-          Validators.maxLength(ValidationConstants.INPUT_LENGTH_60),
+          Validators.maxLength(ValidationConstants.INPUT_LENGTH_120),
           Validators.pattern(MUST_CONTAIN_LETTERS)
         ]),
         shortTitle: new FormControl('', [

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.html
@@ -23,7 +23,7 @@
   <app-validation-hint
     [validationFormControl]="AboutFormGroup.get('title')"
     [minCharacters]="validationConstants.INPUT_LENGTH_1"
-    [maxCharacters]="validationConstants.INPUT_LENGTH_60">
+    [maxCharacters]="validationConstants.INPUT_LENGTH_120">
   </app-validation-hint>
 
   <div class="flex flex-row justify-between items-center">

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-about-form/create-about-form.component.ts
@@ -193,7 +193,7 @@ export class CreateAboutFormComponent extends FieldsListenerComponent implements
         title: new FormControl('', [
           Validators.required,
           Validators.minLength(ValidationConstants.INPUT_LENGTH_1),
-          Validators.maxLength(ValidationConstants.INPUT_LENGTH_60),
+          Validators.maxLength(ValidationConstants.INPUT_LENGTH_120),
           Validators.pattern(MUST_CONTAIN_LETTERS)
         ]),
         shortTitle: new FormControl('', [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Increased maximum title length from 60 to 120 characters across competition and workshop creation/edit forms for admins and providers.
  * Updated validation messages and character count hints to reflect the new 120-character limit.

* Chores
  * Added a reusable validation constant for a 120-character input length to standardize limits across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->