### PR TITLE
Spelina/fix and refactor of date-input directive

### DIFF
--- a/src/app/shared/directives/date-input/date-input.directive.spec.ts
+++ b/src/app/shared/directives/date-input/date-input.directive.spec.ts
@@ -75,24 +75,24 @@ describe('DateInputDirective', () => {
 
   describe('validateOnInput()', () => {
     it('should add "/" at correct positions when needed', () => {
-      expect(directive.formatDate('12')).toBe('12/');
-      expect(directive.formatDate('12/12')).toBe('12/12/');
+      expect((directive as any).formatDate('12')).toBe('12/');
+      expect((directive as any).formatDate('12/12')).toBe('12/12/');
     });
 
     it('should not add "/" if it is already at the correct positions', () => {
-      expect(directive.formatDate('12/')).toBe('12/');
-      expect(directive.formatDate('12/12/')).toBe('12/12/');
+      expect((directive as any).formatDate('12/')).toBe('12/');
+      expect((directive as any).formatDate('12/12/')).toBe('12/12/');
     });
   });
 
   describe('validateOnPaste()', () => {
     it('should insert "/" at correct positions for pasted value', () => {
-      const result = directive.formatDate('12122004');
+      const result = (directive as any).formatDate('12122004');
       expect(result).toBe('12/12/2004');
     });
 
     it('should handle empty pasted value', () => {
-      const result = directive.formatDate('');
+      const result = (directive as any).formatDate('');
       expect(result).toBe('');
     });
   });

--- a/src/app/shared/directives/date-input/date-input.directive.ts
+++ b/src/app/shared/directives/date-input/date-input.directive.ts
@@ -33,23 +33,25 @@ export class DateInputDirective implements OnInit {
   }
 
   private formatDate(value: string): string {
-    if (value.length === 1 && value === '/') {
-      return '';
-    }
+    let formattedValue = this.digitsOnly(value);
+    formattedValue = this.insertSlashes(formattedValue);
+    return formattedValue.slice(0, 10);
+  }
 
-    let formattedDate = this.indexesToInsert.reduce((acc, index) => {
-      if (value.length >= index && acc.at(index) !== '/' && acc.at(index - 1) !== '/' && acc.at(index + 1) !== '/') {
-        return acc.slice(0, index) + '/' + acc.slice(index);
+  private insertSlashes(str: string): string {
+    const arr = str.split('');
+    this.indexesToInsert.forEach((i, idx) => {
+      if (str.length < i - idx) {
+        return arr.join('');
       }
-      return acc;
-    }, value);
+      if (arr[i] !== '/') {
+        arr.splice(i, 0, '/');
+      }
+    });
+    return arr.join('');
+  }
 
-    formattedDate = formattedDate.replace(/\/{2,}/g, '/');
-
-    if (formattedDate.split('/').length > 3) {
-      return formattedDate.split('/')[0] + '/' + formattedDate.split('/')[1] + '/' + formattedDate.split('/').slice(2).join('');
-    }
-
-    return formattedDate;
+  private digitsOnly(str: string): string {
+    return str.replace(/\//g, '');
   }
 }

--- a/src/app/shell/details/competition-details/competition-details.component.html
+++ b/src/app/shell/details/competition-details/competition-details.component.html
@@ -10,7 +10,7 @@
   <div
     class="flex flex-row flex-wrap box-border !justify-between items-center action-buttons-wrapper"
     *ngIf="providerParameters?.providerId === currentProvider?.id">
-    <button (click)="onActionButtonClick(ModalType.archiveCompetition)" class="btn btn-cancel" mat-button>
+    <button (click)="onActionButtonClick(ModalConfirmationType.archiveCompetition)" class="btn btn-cancel" mat-button>
       {{ 'BUTTONS.ARCHIVE' | translate }}
     </button>
     <div class="flex">

--- a/src/app/shell/details/competition-details/competition-details.component.ts
+++ b/src/app/shell/details/competition-details/competition-details.component.ts
@@ -52,7 +52,7 @@ export class CompetitionDetailsComponent extends TabParamsComponent implements O
 
   @Select(MetaDataState.subDirections) public subDirections$: Observable<Subdirection[]>;
 
-  public readonly ModalType = ModalConfirmationType;
+  public readonly ModalConfirmationType = ModalConfirmationType;
   public readonly CompetitionStatus = CompetitionStatus;
   public readonly RecruitmentStatusEnum = RecruitmentStatusEnum;
   public readonly FormOfLearningEnum = FormOfLearningEnum;


### PR DESCRIPTION
fixed handling of value's length over 10 on paste
refactoring
[competition-details] fixed wrong name of enum in template for publish btn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified and streamlined date-input formatting for maintainability; no user-facing changes.
* **Bug Fixes**
  * Archive action now opens the correct confirmation modal when archiving competitions.
* **Tests**
  * Updated unit tests to accommodate the internal formatting refactor; behavior and expectations unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->