### PR TITLE
Smyk / 3108 The 'providerTitle' key and its value are sent for creating a workshop draft

### DIFF
--- a/src/app/shared/services/workshops/user-workshop/user-workshop.service.ts
+++ b/src/app/shared/services/workshops/user-workshop/user-workshop.service.ts
@@ -250,6 +250,7 @@ export class UserWorkshopService {
     ];
     const imageFiles = ['imageFiles', 'coverImage'];
     const skipNullKeys = ['maxAge', 'minAge'];
+    const skipKeys = ['providerTitle'];
 
     if (workshop.price) {
       workshop.price = workshop.price.toString().replace('.', ',');
@@ -261,7 +262,9 @@ export class UserWorkshopService {
           workshop[key].forEach((file: File) => formData.append(`${preKey}${key}`, file));
         } else if (formNames.includes(key)) {
           formData.append(`${preKey}${key}`, JSON.stringify(workshop[key]));
-        } else {
+        } else if (skipKeys.includes(key)) {
+          /* empty */
+        } else if (!(skipNullKeys.includes(key) && workshop[key] === null)) {
           formData.append(`${preKey}${key}`, workshop[key]);
         }
       }


### PR DESCRIPTION
#3108 
Skipped providerTitle key while creating workshop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevents an unintended field from being included in workshop submission data, reducing validation errors and failed submissions.
  - Improves reliability and consistency of workshop form uploads by excluding the unwanted field from FormData assembly.
  - No visible UI changes; existing workflows behave the same with fewer edge-case errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->