### PR TITLE
Smyk / 3119 System allows special characters, negative values while entering a keywords into a "Ключові слова" field

### DIFF
--- a/src/app/shared/constants/regex-constants.ts
+++ b/src/app/shared/constants/regex-constants.ts
@@ -59,3 +59,6 @@ export const WORD_SPLIT_REGEX: RegExp = /[ ,/]+/;
 
 // Regex for social network link
 export const SOCIAL_NETWORK_LINK_REGEX: RegExp = /^https?:\/\/[\w\d\.-]+\.[a-z]{2,}(?:\/.*)?$/;
+
+//  Regex for keywords
+export const KEYWORDS_REGEX: RegExp = /^[A-Za-z0-9 ]+$/;

--- a/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-workshop/create-description-form/create-description-form.component.ts
@@ -15,7 +15,7 @@ import { filter, map, take, takeUntil } from 'rxjs/operators';
 import { ENTER } from '@angular/cdk/keycodes';
 import { CropperConfigurationConstants, ModeConstants } from 'shared/constants/constants';
 import { Tag } from 'shared/models/tag.model';
-import { MUST_CONTAIN_LETTERS } from 'shared/constants/regex-constants';
+import { KEYWORDS_REGEX, MUST_CONTAIN_LETTERS } from 'shared/constants/regex-constants';
 import { ValidationConstants } from 'shared/constants/validation';
 import { Provider } from 'shared/models/provider.model';
 import { Workshop, WorkshopDescriptionItem } from 'shared/models/workshop.model';
@@ -170,7 +170,7 @@ export class CreateDescriptionFormComponent extends FieldsListenerComponent impl
   public onKeyWordsInput(isEditMode: boolean = true): void {
     this.DescriptionFormGroup.get('keyWords').markAsTouched();
     const inputKeyWord = this.keyWordsCtrl.value?.trim().toLowerCase();
-    if (inputKeyWord && !this.keyWords.includes(inputKeyWord)) {
+    if (inputKeyWord && !this.keyWords.includes(inputKeyWord) && KEYWORDS_REGEX.test(inputKeyWord)) {
       if (this.keyWords.length < this.validationConstants.MAX_KEYWORDS_LENGTH) {
         this.keyWords = [...this.keyWords, inputKeyWord];
         this.updateKeywordsInputState();


### PR DESCRIPTION
#3119 
Created Regex for keywords input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workshop creation: Keywords now accept only letters, numbers, and spaces, preventing invalid entries.
  * Duplicate and empty keywords are still blocked, improving data quality in the description form.

* **Chores**
  * Added a reusable keyword validation pattern to ensure consistent keyword rules across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->