### PR TITLE
Zhylka/Fix benefits disappear when price is null 

### DIFF
--- a/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
+++ b/src/app/shell/personal-cabinet/provider/create-competition/create-competition-description-form/create-competition-description-form.component.ts
@@ -329,11 +329,9 @@ export class CreateCompetitionDescriptionFormComponent extends FieldsListenerCom
   }
 
   private priceControlListener(): void {
-    this.priceControl.valueChanges
+    this.priceRadioBtn.valueChanges
       .pipe(
-        map((val) => !!val),
-        distinctUntilChanged(),
-        filter(() => this.benefitsOptionRadioBtn.value),
+        filter((value) => !value),
         takeUntil(this.destroy$)
       )
       .subscribe(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted price selection logic in the Create Competition form so the benefits option is only auto-reset under the relevant price choice, preventing unexpected toggles.
  * Improved stability of the form by reducing unnecessary state changes when switching between price options, resulting in more predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->